### PR TITLE
fix(serial): move ^SN before ^FD per ZPL spec

### DIFF
--- a/src/registry/serial.tsx
+++ b/src/registry/serial.tsx
@@ -37,7 +37,7 @@ export const serial: ObjectTypeDefinition<SerialProps> = {
       return `${field}^SF${p.increment},${p.content.length},Y^FD${p.content}^FS`;
     }
     // ^SN: start, increment, change-per-label
-    return `${field}^FD${p.content}^FS\n^SN${p.content},${p.increment},Y`;
+    return `${field}^SN${p.content},${p.increment},Y^FD${p.content}^FS`;
   },
 
   PropertiesPanel: ({ obj, onChange }) => {


### PR DESCRIPTION
^SN must precede ^FD within the same field definition, identical to ^SF. Previous output placed ^SN as a standalone command after ^FS, which caused Zebra printers to ignore serialization and print the same value on all copies.