### PR TITLE
Update Aztec barcode ZPL generation

### DIFF
--- a/src/registry/aztec.tsx
+++ b/src/registry/aztec.tsx
@@ -8,7 +8,7 @@ import { RotationSelect } from "../components/Properties/RotationSelect";
 export interface AztecProps {
   content: string;
   magnification: number; // 1–10, module size in dots
-  ecLevel: number; // 0 = auto, 1–99 error correction percentage, 201–232 for layers
+  ecLevel: number; // 0=default, 1-99=error correction %, 101-104=compact, 201-232=full, 300=rune
   rotation: ZplRotation;
 }
 

--- a/src/registry/aztec.tsx
+++ b/src/registry/aztec.tsx
@@ -26,11 +26,12 @@ export const aztec: ObjectTypeDefinition<AztecProps> = {
 
   toZPL: (obj) => {
     const p = obj.props;
-    // ^B0{orientation},{magnification},{ecic},{menuSymbol},{numberOfSymbols},{structuredID}
-    // Also ^BO (alternate) — we use ^B0 as canonical
+    // ^B0 a,b,c,d,e,f,g = orientation, magnification, ecic, errorControl,
+    // menuSymbol, numberOfSymbols, structuredID. ecLevel=0 is Zebra's
+    // documented default for errorControl, so emitting it as-is is valid.
     return [
       fieldPos(obj),
-      `^B0${p.rotation},${p.magnification},N,N,N,N`,
+      `^B0${p.rotation},${p.magnification},N,${p.ecLevel}`,
       fdField(p.content),
     ].join("");
   },

--- a/tests/fixtures/labelary_images/fixtures.json
+++ b/tests/fixtures/labelary_images/fixtures.json
@@ -123,7 +123,7 @@
     },
     {
       "id": "barcode_aztec_standard",
-      "zpl_input": "^XA^FO50,50^B0N,4,N,N,N,N^FDAztec123^FS^XZ",
+      "zpl_input": "^XA^FO50,50^B0N,4,N,0^FDAztec123^FS^XZ",
       "expected_bounds": {
         "x": 50,
         "y": 50,

--- a/tests/fixtures/testCases.ts
+++ b/tests/fixtures/testCases.ts
@@ -80,7 +80,7 @@ export const testCases: TestCase[] = [
   },
   {
     id: "barcode_aztec_standard",
-    zpl_input: "^XA^FO50,50^B0N,4,N,N,N,N^FDAztec123^FS^XZ",
+    zpl_input: "^XA^FO50,50^B0N,4,N,0^FDAztec123^FS^XZ",
     expected_bounds: { x: 50, y: 50, width: 100, height: 100 },
     image_ref: "barcode_aztec_standard.png",
   },


### PR DESCRIPTION
Modify the `toZPL` function for Aztec barcodes to correctly include the error correction level (`ecLevel`) in the ZPL command. Previously, a fixed `N` was used for this parameter, which is incorrect.

This change also updates the corresponding test fixtures to reflect the correct ZPL generation.