### PR TITLE
feat(image): inline upload-error feedback parity with FontManager

### DIFF
--- a/src/components/Fonts/FontManager.tsx
+++ b/src/components/Fonts/FontManager.tsx
@@ -90,6 +90,9 @@ function AddFontForm({ onDone }: AddFontFormProps) {
       await loadFontFile(file, printerName);
       onDone();
     } catch {
+      // Inline hint is the only signal (non-TTF/OTF, oversized, FileReader
+      // failure). Codebase has no production logging path; specific causes
+      // are debugged with a devtools breakpoint on this catch.
       setUploadFailed(true);
     } finally {
       setUploading(false);

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -256,6 +256,7 @@ const ar = {
       selectImage: 'اختر صورة…',
       upload: 'رفع صورة',
       uploading: 'جارٍ الرفع…',
+      uploadError: 'تعذر تحميل الصورة',
       preview: 'معاينة',
       widthDots: 'العرض (نقاط)',
       threshold: 'عتبة أحادية',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -256,6 +256,7 @@ const bg = {
       selectImage: 'Изберете изображение…',
       upload: 'Качване на изображение',
       uploading: 'Качване…',
+      uploadError: 'Изображението не може да бъде заредено',
       preview: 'Преглед',
       widthDots: 'Ширина (точки)',
       threshold: 'Моно праг',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -256,6 +256,7 @@ const cs = {
       selectImage: 'Vybrat obrázek…',
       upload: 'Nahrát obrázek',
       uploading: 'Nahrávání…',
+      uploadError: 'Obrázek nelze načíst',
       preview: 'Náhled',
       widthDots: 'Šířka (body)',
       threshold: 'Mono práh',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -256,6 +256,7 @@ const da = {
       selectImage: 'Vælg billede…',
       upload: 'Upload billede',
       uploading: 'Uploader…',
+      uploadError: 'Kunne ikke indlæse billede',
       preview: 'Forhåndsvisning',
       widthDots: 'Bredde (punkter)',
       threshold: 'Mono-tærskel',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -276,6 +276,7 @@ const de = {
       selectImage: 'Bild auswählen…',
       upload: 'Bild hochladen',
       uploading: 'Hochladen…',
+      uploadError: 'Bild konnte nicht geladen werden',
       preview: 'Vorschau',
       widthDots: 'Breite (Punkte)',
       threshold: 'Mono-Schwellenwert',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -256,6 +256,7 @@ const el = {
       selectImage: 'Επιλογή εικόνας…',
       upload: 'Μεταφόρτωση εικόνας',
       uploading: 'Μεταφόρτωση…',
+      uploadError: 'Αδυναμία φόρτωσης εικόνας',
       preview: 'Προεπισκόπηση',
       widthDots: 'Πλάτος (κουκκίδες)',
       threshold: 'Κατώφλι mono',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -276,6 +276,7 @@ const en = {
       selectImage: 'Select image…',
       upload: 'Upload image',
       uploading: 'Uploading…',
+      uploadError: 'Could not load image',
       preview: 'Preview',
       widthDots: 'Width (dots)',
       threshold: 'Mono threshold',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -256,6 +256,7 @@ const es = {
       selectImage: 'Seleccionar imagen…',
       upload: 'Subir imagen',
       uploading: 'Subiendo…',
+      uploadError: 'No se pudo cargar la imagen',
       preview: 'Vista previa',
       widthDots: 'Ancho (puntos)',
       threshold: 'Umbral mono',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -256,6 +256,7 @@ const et = {
       selectImage: 'Vali pilt…',
       upload: 'Laadi pilt üles',
       uploading: 'Üleslaadimine…',
+      uploadError: 'Pildi laadimine ebaõnnestus',
       preview: 'Eelvaade',
       widthDots: 'Laius (punktid)',
       threshold: 'Mono lävi',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -256,6 +256,7 @@ const fa = {
       selectImage: 'انتخاب تصویر…',
       upload: 'بارگذاری تصویر',
       uploading: 'در حال بارگذاری…',
+      uploadError: 'بارگذاری تصویر ممکن نشد',
       preview: 'پیش‌نمایش',
       widthDots: 'عرض (نقاط)',
       threshold: 'آستانه تک‌رنگ',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -256,6 +256,7 @@ const fi = {
       selectImage: 'Valitse kuva…',
       upload: 'Lataa kuva',
       uploading: 'Ladataan…',
+      uploadError: 'Kuvaa ei voitu ladata',
       preview: 'Esikatselu',
       widthDots: 'Leveys (pisteet)',
       threshold: 'Mono-kynnys',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -256,6 +256,7 @@ const fr = {
       selectImage: 'Sélectionner une image…',
       upload: 'Télécharger une image',
       uploading: 'Téléchargement…',
+      uploadError: 'Impossible de charger l\'image',
       preview: 'Aperçu',
       widthDots: 'Largeur (points)',
       threshold: 'Seuil mono',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -256,6 +256,7 @@ const he = {
       selectImage: 'בחר תמונה…',
       upload: 'העלאת תמונה',
       uploading: 'מעלה…',
+      uploadError: 'לא ניתן לטעון את התמונה',
       preview: 'תצוגה מקדימה',
       widthDots: 'רוחב (נקודות)',
       threshold: 'סף מונו',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -256,6 +256,7 @@ const hr = {
       selectImage: 'Odaberite sliku…',
       upload: 'Prenesi sliku',
       uploading: 'Prenošenje…',
+      uploadError: 'Sliku nije moguće učitati',
       preview: 'Pregled',
       widthDots: 'Širina (točke)',
       threshold: 'Mono prag',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -256,6 +256,7 @@ const hu = {
       selectImage: 'Kép kiválasztása…',
       upload: 'Kép feltöltése',
       uploading: 'Feltöltés…',
+      uploadError: 'A kép nem tölthető be',
       preview: 'Előnézet',
       widthDots: 'Szélesség (pont)',
       threshold: 'Mono küszöb',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -256,6 +256,7 @@ const it = {
       selectImage: 'Seleziona immagine…',
       upload: 'Carica immagine',
       uploading: 'Caricamento…',
+      uploadError: 'Impossibile caricare l\'immagine',
       preview: 'Anteprima',
       widthDots: 'Larghezza (punti)',
       threshold: 'Soglia mono',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -256,6 +256,7 @@ const ja = {
       selectImage: '画像を選択…',
       upload: '画像をアップロード',
       uploading: 'アップロード中…',
+      uploadError: '画像を読み込めませんでした',
       preview: 'プレビュー',
       widthDots: '幅（ドット）',
       threshold: 'モノクロしきい値',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -256,6 +256,7 @@ const ko = {
       selectImage: '이미지 선택…',
       upload: '이미지 업로드',
       uploading: '업로드 중…',
+      uploadError: '이미지를 불러올 수 없습니다',
       preview: '미리보기',
       widthDots: '너비 (도트)',
       threshold: '모노 임계값',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -256,6 +256,7 @@ const lt = {
       selectImage: 'Pasirinkite vaizdą…',
       upload: 'Įkelti vaizdą',
       uploading: 'Įkeliama…',
+      uploadError: 'Nepavyko įkelti vaizdo',
       preview: 'Peržiūra',
       widthDots: 'Plotis (taškai)',
       threshold: 'Mono slenkstis',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -256,6 +256,7 @@ const lv = {
       selectImage: 'Izvēlēties attēlu…',
       upload: 'Augšupielādēt attēlu',
       uploading: 'Augšupielāde…',
+      uploadError: 'Neizdevās ielādēt attēlu',
       preview: 'Priekšskatījums',
       widthDots: 'Platums (punkti)',
       threshold: 'Mono slieksnis',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -256,6 +256,7 @@ const nl = {
       selectImage: 'Afbeelding selecteren…',
       upload: 'Afbeelding uploaden',
       uploading: 'Uploaden…',
+      uploadError: 'Kon afbeelding niet laden',
       preview: 'Voorbeeld',
       widthDots: 'Breedte (punten)',
       threshold: 'Mono-drempelwaarde',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -256,6 +256,7 @@ const no = {
       selectImage: 'Velg bilde…',
       upload: 'Last opp bilde',
       uploading: 'Laster opp…',
+      uploadError: 'Kunne ikke laste bilde',
       preview: 'Forhåndsvisning',
       widthDots: 'Bredde (punkter)',
       threshold: 'Mono-terskel',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -256,6 +256,7 @@ const pl = {
       selectImage: 'Wybierz obraz…',
       upload: 'Prześlij obraz',
       uploading: 'Przesyłanie…',
+      uploadError: 'Nie można załadować obrazu',
       preview: 'Podgląd',
       widthDots: 'Szerokość (punkty)',
       threshold: 'Próg mono',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -256,6 +256,7 @@ const pt = {
       selectImage: 'Selecionar imagem…',
       upload: 'Carregar imagem',
       uploading: 'Carregando…',
+      uploadError: 'Não foi possível carregar a imagem',
       preview: 'Pré-visualização',
       widthDots: 'Largura (pontos)',
       threshold: 'Limiar mono',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -256,6 +256,7 @@ const ro = {
       selectImage: 'Selectați imaginea…',
       upload: 'Încărcați imaginea',
       uploading: 'Se încarcă…',
+      uploadError: 'Imaginea nu a putut fi încărcată',
       preview: 'Previzualizare',
       widthDots: 'Lățime (puncte)',
       threshold: 'Prag mono',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -256,6 +256,7 @@ const sk = {
       selectImage: 'Vybrať obrázok…',
       upload: 'Nahrať obrázok',
       uploading: 'Nahrávanie…',
+      uploadError: 'Obrázok sa nedá načítať',
       preview: 'Náhľad',
       widthDots: 'Šírka (body)',
       threshold: 'Mono prah',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -256,6 +256,7 @@ const sl = {
       selectImage: 'Izberite sliko…',
       upload: 'Naloži sliko',
       uploading: 'Nalaganje…',
+      uploadError: 'Slike ni bilo mogoče naložiti',
       preview: 'Predogled',
       widthDots: 'Širina (pike)',
       threshold: 'Mono prag',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -256,6 +256,7 @@ const sr = {
       selectImage: 'Изаберите слику…',
       upload: 'Отпремите слику',
       uploading: 'Отпремање…',
+      uploadError: 'Слика није могла да се учита',
       preview: 'Преглед',
       widthDots: 'Ширина (тачке)',
       threshold: 'Моно праг',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -256,6 +256,7 @@ const sv = {
       selectImage: 'Välj bild…',
       upload: 'Ladda upp bild',
       uploading: 'Laddar upp…',
+      uploadError: 'Kunde inte ladda bilden',
       preview: 'Förhandsvisning',
       widthDots: 'Bredd (punkter)',
       threshold: 'Mono-tröskel',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -256,6 +256,7 @@ const tr = {
       selectImage: 'Görsel seçin…',
       upload: 'Görsel yükle',
       uploading: 'Yükleniyor…',
+      uploadError: 'Görsel yüklenemedi',
       preview: 'Önizleme',
       widthDots: 'Genişlik (nokta)',
       threshold: 'Mono eşik',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -256,6 +256,7 @@ const zhHans = {
       selectImage: '选择图片…',
       upload: '上传图片',
       uploading: '上传中…',
+      uploadError: '无法加载图像',
       preview: '预览',
       widthDots: '宽度（点）',
       threshold: '单色阈值',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -256,6 +256,7 @@ const zhHant = {
       selectImage: '選擇圖片…',
       upload: '上傳圖片',
       uploading: '上傳中…',
+      uploadError: '無法載入圖片',
       preview: '預覽',
       widthDots: '寬度（點）',
       threshold: '單色閾值',

--- a/src/registry/image.tsx
+++ b/src/registry/image.tsx
@@ -87,17 +87,25 @@ export const image: ObjectTypeDefinition<ImageProps> = {
     const p = obj.props;
     const fileRef = useRef<HTMLInputElement>(null);
     const [uploading, setUploading] = useState(false);
+    const [uploadFailed, setUploadFailed] = useState(false);
 
     const cached = getImage(p.imageId);
     const allImages = getAllImages();
 
     const handleUpload = useCallback(async (file: File) => {
       setUploading(true);
+      setUploadFailed(false);
       try {
         const entry = await loadImageFile(file);
         // Pre-generate GFA cache
         const result = await imageToGFA(entry.dataUrl, p.widthDots, p.threshold);
         onChange({ imageId: entry.id, _gfaCache: result.zpl });
+      } catch {
+        // Surface the failure inline (non-image MIME, oversized file, decode
+        // error, GFA exception) and stop. The codebase has no production
+        // logging path; debugging specific causes (e.g. an obscure MIME) is
+        // done with a devtools breakpoint on this catch.
+        setUploadFailed(true);
       } finally {
         setUploading(false);
       }
@@ -160,6 +168,9 @@ export const image: ObjectTypeDefinition<ImageProps> = {
           >
             {uploading ? t.registry.image.uploading : t.registry.image.upload}
           </button>
+          {uploadFailed && (
+            <p className="text-[10px] font-mono text-red-400">{t.registry.image.uploadError}</p>
+          )}
         </div>
 
         {/* Preview thumbnail */}


### PR DESCRIPTION
The image upload handler had `try/finally` without `catch`, so failures (non-image MIME, oversize, decode error, GFA exception) propagated as unhandled rejections with no user signal. Add `uploadFailed` state and a small inline hint matching FontManager's pattern.