### PR TITLE
feat: Add ZPL import append mode

### DIFF
--- a/src/components/Output/ZplImportModal.tsx
+++ b/src/components/Output/ZplImportModal.tsx
@@ -84,6 +84,12 @@ export function ZplImportModal({ onClose }: Props) {
 
     const { labelConfig, pages: importedPages, report } = importZplText(text, label.dpmm);
     const totalObjects = importedPages.reduce((s, p) => s + p.objects.length, 0);
+
+    if (totalObjects === 0 && Object.keys(labelConfig).length === 0) {
+      setError('No supported objects found in the ZPL code.');
+      return;
+    }
+
     applyImport(labelConfig, importedPages);
     setResult({ objectCount: totalObjects, report });
   };

--- a/src/components/Output/ZplImportModal.tsx
+++ b/src/components/Output/ZplImportModal.tsx
@@ -2,7 +2,8 @@ import { useRef, useState } from 'react';
 import { XMarkIcon, ClipboardDocumentIcon, CheckIcon, FolderOpenIcon } from '@heroicons/react/16/solid';
 import { importZplText } from '../../lib/zplImportService';
 import { readFileAsText } from '../../lib/readFile';
-import { useLabelStore } from '../../store/labelStore';
+import { useLabelStore, type Page } from '../../store/labelStore';
+import type { LabelConfig } from '../../types/ObjectType';
 import { formatReportAsText, type ImportResult } from '../../lib/importReport';
 import { ImportSummaryBody } from './ImportReportModal';
 import { useT } from '../../lib/useT';
@@ -18,9 +19,30 @@ export function ZplImportModal({ onClose }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ImportResult | null>(null);
   const [copied, setCopied] = useState(false);
+  const [appendMode, setAppendMode] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const loadDesign = useLabelStore((s) => s.loadDesign);
+  const appendPages = useLabelStore((s) => s.appendPages);
   const label = useLabelStore((s) => s.label);
+  const pages = useLabelStore((s) => s.pages);
+
+  // Append-mode only makes sense when there is something to append *to*.
+  // On a fresh designer (one empty page) we hide the toggle entirely
+  // because the resulting [empty, imported] state would just be clutter
+  // the user has to clean up manually.
+  const hasExistingContent =
+    pages.length > 1 || (pages[0]?.objects.length ?? 0) > 0;
+
+  const applyImport = (labelConfig: Partial<LabelConfig>, importedPages: Page[]) => {
+    if (appendMode && hasExistingContent) {
+      // Keep the current label config — the user opted to keep the
+      // existing design's dimensions, so any imported ^PW/^LL is
+      // intentionally discarded.
+      appendPages(importedPages);
+    } else {
+      loadDesign({ ...label, ...labelConfig }, importedPages);
+    }
+  };
 
   const handleImport = () => {
     setError(null);
@@ -29,15 +51,15 @@ export function ZplImportModal({ onClose }: Props) {
       return;
     }
 
-    const { labelConfig, pages, report } = importZplText(zpl, label.dpmm);
-    const totalObjects = pages.reduce((s, p) => s + p.objects.length, 0);
+    const { labelConfig, pages: importedPages, report } = importZplText(zpl, label.dpmm);
+    const totalObjects = importedPages.reduce((s, p) => s + p.objects.length, 0);
 
     if (totalObjects === 0 && Object.keys(labelConfig).length === 0) {
       setError('No supported objects found in the ZPL code.');
       return;
     }
 
-    loadDesign({ ...label, ...labelConfig }, pages);
+    applyImport(labelConfig, importedPages);
     setResult({ objectCount: totalObjects, report });
   };
 
@@ -60,9 +82,9 @@ export function ZplImportModal({ onClose }: Props) {
       return;
     }
 
-    const { labelConfig, pages, report } = importZplText(text, label.dpmm);
-    const totalObjects = pages.reduce((s, p) => s + p.objects.length, 0);
-    loadDesign({ ...label, ...labelConfig }, pages);
+    const { labelConfig, pages: importedPages, report } = importZplText(text, label.dpmm);
+    const totalObjects = importedPages.reduce((s, p) => s + p.objects.length, 0);
+    applyImport(labelConfig, importedPages);
     setResult({ objectCount: totalObjects, report });
   };
 
@@ -142,13 +164,26 @@ export function ZplImportModal({ onClose }: Props) {
           </div>
 
           <div className="flex items-center justify-between px-4 py-3 border-t border-border shrink-0">
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="flex items-center gap-1.5 font-mono text-[10px] text-muted hover:text-text transition-colors"
-            >
-              <FolderOpenIcon className="w-3.5 h-3.5" />
-              Choose file
-            </button>
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-1.5 font-mono text-[10px] text-muted hover:text-text transition-colors"
+              >
+                <FolderOpenIcon className="w-3.5 h-3.5" />
+                {t.app.chooseFile}
+              </button>
+              {hasExistingContent && (
+                <label className="flex items-center gap-1.5 cursor-pointer font-mono text-[10px] text-muted hover:text-text transition-colors">
+                  <input
+                    type="checkbox"
+                    className="accent-accent"
+                    checked={appendMode}
+                    onChange={(e) => setAppendMode(e.target.checked)}
+                  />
+                  {t.app.keepExistingPages}
+                </label>
+              )}
+            </div>
             <div className="flex gap-2">
               <button
                 onClick={onClose}

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -97,6 +97,8 @@ const ar = {
   app: {
     file: 'ملف',
     importZpl: 'استيراد ZPL',
+    keepExistingPages: 'الاحتفاظ بالصفحات الحالية',
+    chooseFile: 'اختيار ملف',
     exportZpl: 'تصدير ZPL',
     newDesign: 'تصميم جديد',
     addPage: 'إضافة صفحة',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -97,6 +97,8 @@ const bg = {
   app: {
     file: 'Файл',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Запазване на съществуващите страници',
+    chooseFile: 'Избор на файл',
     exportZpl: 'Export ZPL',
     newDesign: 'Нов дизайн',
     addPage: 'Добавяне на страница',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -97,6 +97,8 @@ const cs = {
   app: {
     file: 'Soubor',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Zachovat stávající stránky',
+    chooseFile: 'Vybrat soubor',
     exportZpl: 'Export ZPL',
     newDesign: 'Nový návrh',
     addPage: 'Přidat stránku',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -97,6 +97,8 @@ const da = {
   app: {
     file: 'Fil',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Behold eksisterende sider',
+    chooseFile: 'Vælg fil',
     exportZpl: 'Export ZPL',
     newDesign: 'Nyt design',
     addPage: 'Tilføj side',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -97,6 +97,8 @@ const de = {
   app: {
     file: 'Datei',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Bestehende Seiten behalten',
+    chooseFile: 'Datei wählen',
     exportZpl: 'Export ZPL',
     newDesign: 'Neues Design',
     addPage: 'Seite hinzufügen',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -97,6 +97,8 @@ const el = {
   app: {
     file: 'Αρχείο',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Διατήρηση υπαρχουσών σελίδων',
+    chooseFile: 'Επιλογή αρχείου',
     exportZpl: 'Export ZPL',
     newDesign: 'Νέο σχέδιο',
     addPage: 'Προσθήκη σελίδας',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -97,6 +97,8 @@ const en = {
   app: {
     file: 'File',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Keep existing pages',
+    chooseFile: 'Choose file',
     exportZpl: 'Export ZPL',
     newDesign: 'New design',
     addPage: 'Add page',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -97,6 +97,8 @@ const es = {
   app: {
     file: 'Archivo',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Conservar páginas existentes',
+    chooseFile: 'Elegir archivo',
     exportZpl: 'Export ZPL',
     newDesign: 'Nuevo diseño',
     addPage: 'Añadir página',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -97,6 +97,8 @@ const et = {
   app: {
     file: 'Fail',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Säilita olemasolevad lehed',
+    chooseFile: 'Vali fail',
     exportZpl: 'Export ZPL',
     newDesign: 'Uus kujundus',
     addPage: 'Lisa leht',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -97,6 +97,8 @@ const fa = {
   app: {
     file: 'فایل',
     importZpl: 'وارد کردن ZPL',
+    keepExistingPages: 'حفظ صفحات موجود',
+    chooseFile: 'انتخاب فایل',
     exportZpl: 'خروجی ZPL',
     newDesign: 'طرح جدید',
     addPage: 'افزودن صفحه',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -97,6 +97,8 @@ const fi = {
   app: {
     file: 'Tiedosto',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Säilytä olemassa olevat sivut',
+    chooseFile: 'Valitse tiedosto',
     exportZpl: 'Export ZPL',
     newDesign: 'Uusi rakenne',
     addPage: 'Lisää sivu',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -97,6 +97,8 @@ const fr = {
   app: {
     file: 'Fichier',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Conserver les pages existantes',
+    chooseFile: 'Choisir un fichier',
     exportZpl: 'Export ZPL',
     newDesign: 'Nouveau design',
     addPage: 'Ajouter une page',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -97,6 +97,8 @@ const he = {
   app: {
     file: 'קובץ',
     importZpl: 'ייבוא ZPL',
+    keepExistingPages: 'שמור על דפים קיימים',
+    chooseFile: 'בחר קובץ',
     exportZpl: 'ייצוא ZPL',
     newDesign: 'עיצוב חדש',
     addPage: 'הוסף דף',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -97,6 +97,8 @@ const hr = {
   app: {
     file: 'Datoteka',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Zadrži postojeće stranice',
+    chooseFile: 'Odaberi datoteku',
     exportZpl: 'Export ZPL',
     newDesign: 'Novi dizajn',
     addPage: 'Dodaj stranicu',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -97,6 +97,8 @@ const hu = {
   app: {
     file: 'Fájl',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Meglévő oldalak megtartása',
+    chooseFile: 'Fájl kiválasztása',
     exportZpl: 'Export ZPL',
     newDesign: 'Új terv',
     addPage: 'Oldal hozzáadása',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -97,6 +97,8 @@ const it = {
   app: {
     file: 'File',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Mantieni pagine esistenti',
+    chooseFile: 'Scegli file',
     exportZpl: 'Export ZPL',
     newDesign: 'Nuovo design',
     addPage: 'Aggiungi pagina',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -97,6 +97,8 @@ const ja = {
   app: {
     file: 'ファイル',
     importZpl: 'ZPL インポート',
+    keepExistingPages: '既存のページを保持',
+    chooseFile: 'ファイルを選択',
     exportZpl: 'ZPL エクスポート',
     newDesign: '新しいデザイン',
     addPage: 'ページを追加',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -97,6 +97,8 @@ const ko = {
   app: {
     file: '파일',
     importZpl: 'ZPL 가져오기',
+    keepExistingPages: '기존 페이지 유지',
+    chooseFile: '파일 선택',
     exportZpl: 'ZPL 내보내기',
     newDesign: '새 디자인',
     addPage: '페이지 추가',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -97,6 +97,8 @@ const lt = {
   app: {
     file: 'Failas',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Išsaugoti esamus puslapius',
+    chooseFile: 'Pasirinkti failą',
     exportZpl: 'Export ZPL',
     newDesign: 'Naujas dizainas',
     addPage: 'Pridėti puslapį',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -97,6 +97,8 @@ const lv = {
   app: {
     file: 'Fails',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Saglabāt esošās lapas',
+    chooseFile: 'Izvēlēties failu',
     exportZpl: 'Export ZPL',
     newDesign: 'Jauns dizains',
     addPage: 'Pievienot lapu',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -97,6 +97,8 @@ const nl = {
   app: {
     file: 'Bestand',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Bestaande pagina\'s behouden',
+    chooseFile: 'Bestand kiezen',
     exportZpl: 'Export ZPL',
     newDesign: 'Nieuw ontwerp',
     addPage: 'Pagina toevoegen',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -97,6 +97,8 @@ const no = {
   app: {
     file: 'Fil',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Behold eksisterende sider',
+    chooseFile: 'Velg fil',
     exportZpl: 'Export ZPL',
     newDesign: 'Nytt design',
     addPage: 'Legg til side',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -97,6 +97,8 @@ const pl = {
   app: {
     file: 'Plik',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Zachowaj istniejące strony',
+    chooseFile: 'Wybierz plik',
     exportZpl: 'Export ZPL',
     newDesign: 'Nowy projekt',
     addPage: 'Dodaj stronę',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -97,6 +97,8 @@ const pt = {
   app: {
     file: 'Arquivo',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Manter páginas existentes',
+    chooseFile: 'Escolher ficheiro',
     exportZpl: 'Export ZPL',
     newDesign: 'Novo design',
     addPage: 'Adicionar página',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -97,6 +97,8 @@ const ro = {
   app: {
     file: 'Fișier',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Păstrează paginile existente',
+    chooseFile: 'Alege fișier',
     exportZpl: 'Export ZPL',
     newDesign: 'Design nou',
     addPage: 'Adaugă pagină',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -97,6 +97,8 @@ const sk = {
   app: {
     file: 'Súbor',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Zachovať existujúce stránky',
+    chooseFile: 'Vybrať súbor',
     exportZpl: 'Export ZPL',
     newDesign: 'Nový návrh',
     addPage: 'Pridať stránku',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -97,6 +97,8 @@ const sl = {
   app: {
     file: 'Datoteka',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Ohrani obstoječe strani',
+    chooseFile: 'Izberi datoteko',
     exportZpl: 'Export ZPL',
     newDesign: 'Nov dizajn',
     addPage: 'Dodaj stran',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -97,6 +97,8 @@ const sr = {
   app: {
     file: 'Датотека',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Задржи постојеће странице',
+    chooseFile: 'Изабери датотеку',
     exportZpl: 'Export ZPL',
     newDesign: 'Нови дизајн',
     addPage: 'Додај страницу',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -97,6 +97,8 @@ const sv = {
   app: {
     file: 'Fil',
     importZpl: 'Import ZPL',
+    keepExistingPages: 'Behåll befintliga sidor',
+    chooseFile: 'Välj fil',
     exportZpl: 'Export ZPL',
     newDesign: 'Nytt design',
     addPage: 'Lägg till sida',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -97,6 +97,8 @@ const tr = {
   app: {
     file: 'Dosya',
     importZpl: 'ZPL İçe Aktar',
+    keepExistingPages: 'Mevcut sayfaları koru',
+    chooseFile: 'Dosya seç',
     exportZpl: 'ZPL Dışa Aktar',
     newDesign: 'Yeni Tasarım',
     addPage: 'Sayfa ekle',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -97,6 +97,8 @@ const zhHans = {
   app: {
     file: '文件',
     importZpl: '导入 ZPL',
+    keepExistingPages: '保留现有页面',
+    chooseFile: '选择文件',
     exportZpl: '导出 ZPL',
     newDesign: '新建设计',
     addPage: '添加页面',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -97,6 +97,8 @@ const zhHant = {
   app: {
     file: '檔案',
     importZpl: '匯入 ZPL',
+    keepExistingPages: '保留現有頁面',
+    chooseFile: '選擇檔案',
     exportZpl: '匯出 ZPL',
     newDesign: '新增設計',
     addPage: '新增頁面',

--- a/src/store/labelStore.test.ts
+++ b/src/store/labelStore.test.ts
@@ -355,6 +355,39 @@ describe('loadDesign', () => {
   });
 });
 
+// ── appendPages ───────────────────────────────────────────────────────────────
+
+describe('appendPages', () => {
+  const sampleObject: LabelObject = {
+    id: 'imp1',
+    type: 'box',
+    x: 5,
+    y: 5,
+    rotation: 0,
+    props: { width: 20, height: 20, thickness: 1, filled: false, color: 'B', rounding: 0 },
+  };
+
+  it('appends pages, keeps the existing label config, and focuses the first appended page', () => {
+    state().addObject('text');
+    const originalLabel = state().label;
+    state().selectObject(defined(objs()[0]).id);
+
+    state().appendPages([{ objects: [sampleObject] }, { objects: [] }]);
+
+    expect(state().label).toEqual(originalLabel);
+    expect(state().pages).toHaveLength(3);
+    expect(state().currentPageIndex).toBe(1);
+    expect(state().selectedIds).toEqual([]);
+  });
+
+  it('is a no-op when given an empty pages array', () => {
+    state().addObject('text');
+    const before = state().pages;
+    state().appendPages([]);
+    expect(state().pages).toBe(before);
+  });
+});
+
 // ── setLabelConfig (partial merge) ────────────────────────────────────────────
 
 describe('setLabelConfig', () => {

--- a/src/store/labelStore.ts
+++ b/src/store/labelStore.ts
@@ -97,6 +97,7 @@ interface LabelState {
   acknowledgeLabelaryNotice: () => void;
   setCanvasSettings: (settings: Partial<CanvasSettings>) => void;
   loadDesign: (label: LabelConfig, pages: Page[]) => void;
+  appendPages: (pages: Page[]) => void;
   moveObjectForward: (id: string) => void;
   moveObjectBackward: (id: string) => void;
   moveObjectToFront: (id: string) => void;
@@ -398,6 +399,21 @@ export const useLabelStore = create<LabelState>()(
           pages: pages.length > 0 ? pages : [{ objects: [] }],
           currentPageIndex: 0,
           selectedIds: [],
+        }),
+
+      // Append-mode counterpart to loadDesign: keeps the current label
+      // config (the user opted into the existing design's dimensions /
+      // dpmm) and just tacks the imported pages onto the end of the
+      // page list, switching focus to the first appended page.
+      appendPages: (pages) =>
+        set((state) => {
+          if (pages.length === 0) return {};
+          const newPages = [...state.pages, ...pages];
+          return {
+            pages: newPages,
+            currentPageIndex: state.pages.length,
+            selectedIds: [],
+          };
         }),
 
       setLabelConfig: (config) =>


### PR DESCRIPTION
Introduces an "append mode" for ZPL imports, allowing users to add imported pages to an existing design without overwriting it. This includes a new toggle and corresponding locale keys.