### PR TITLE
deploy: TLC39 + ^CC/^CT/^CD parser + CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, prod]
   push:
-    branches: [main]
+    branches: [main, prod]
 
 jobs:
   lint-test-build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,13 @@
-name: PR checks
+name: CI
 
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-  check:
+  lint-test-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Both `.zpl` and `.json` round-trip cleanly. `.zpl` preserves all printable conte
 
 ## Coverage
 
-90 of the 202 ZPL II commands tracked in the [roadmap](docs/zpl-roadmap.md) are supported today. Categorical breakdown:
+93 of the 202 ZPL II commands tracked in the [roadmap](docs/zpl-roadmap.md) are supported today. Categorical breakdown:
 
 | Area | Supported |
 |---|---|
@@ -131,7 +131,7 @@ Both `.zpl` and `.json` round-trip cleanly. `.zpl` preserves all printable conte
 | Media & feed | 4 / 10 |
 | Text & fonts | 6 / 14 |
 | Print quality | 3 / 14 |
-| Configuration & persistence | 0 / 5 |
+| Configuration & persistence | 3 / 5 |
 | Hardware / Host comm / RFID / Network | 0 / 67 |
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The print resolution (dpmm = dots per millimeter) must match your printer. Commo
 
 Drag items from the left panel onto the canvas, or double-click them to add at the center.
 
-Available objects: text, serial (auto-incrementing number fields), barcodes (27 symbologies including Code 128, QR, DataMatrix, PDF417, Maxicode), shapes (box, line, ellipse), and images.
+Available objects: text, serial (auto-incrementing number fields), barcodes (28 symbologies including Code 128, QR, DataMatrix, PDF417, Maxicode), shapes (box, line, ellipse), and images.
 
 <details>
 <summary>Full list of supported barcode symbologies</summary>
 
 **1D linear:** Code 128, Code 39, Code 93, Code 11, Interleaved 2 of 5, Standard 2 of 5, Industrial 2 of 5, Codabar, LOGMARS, MSI, Plessey, GS1 Databar, Planet Code, Postal/POSTNET, EAN-13, EAN-8, UPC-A, UPC-E, UPC/EAN 2- or 5-digit supplement, Code 49
 
-**2D matrix:** QR Code, DataMatrix, PDF417, MicroPDF417, Aztec, Codablock F, Maxicode
+**2D matrix:** QR Code, DataMatrix, PDF417, MicroPDF417, Aztec, Codablock F, Maxicode, TLC39
 
 </details>
 
@@ -116,13 +116,13 @@ Both `.zpl` and `.json` round-trip cleanly. `.zpl` preserves all printable conte
 
 ## Coverage
 
-93 of the 202 ZPL II commands tracked in the [roadmap](docs/zpl-roadmap.md) are supported today. Categorical breakdown:
+94 of the 202 ZPL II commands tracked in the [roadmap](docs/zpl-roadmap.md) are supported today. Categorical breakdown:
 
 | Area | Supported |
 |---|---|
 | Layout & flow | 16 / 16 |
 | Templates & variables | 4 / 4 |
-| Barcodes | 27 / 28 |
+| Barcodes | 28 / 28 |
 | Fields | 15 / 20 |
 | Encoding & language | 3 / 4 |
 | Clock & time | 2 / 3 |

--- a/docs/zpl-roadmap.md
+++ b/docs/zpl-roadmap.md
@@ -213,9 +213,9 @@ The Printer Settings Modal (Media & Feed / Print Quality / Clock & Time / Encodi
 
 | Status | Command | Description | Bucket |
 |:-:|---|---|---|
-| `[ ]` | `^CC` / `~CC` | change caret | `Coming soon` |
-| `[ ]` | `^CD` / `~CD` | change delimiter | `Coming soon` |
-| `[ ]` | `^CT` / `~CT` | change tilde | `Coming soon` |
+| `[x]` | `^CC` / `~CC` | change caret | |
+| `[x]` | `^CD` / `~CD` | change delimiter | |
+| `[x]` | `^CT` / `~CT` | change tilde | |
 | `[ ]` | `^CM` | change memory letter assignment | `Native build` |
 | `[ ]` | `~KB` | kill battery | `Native build` |
 

--- a/docs/zpl-roadmap.md
+++ b/docs/zpl-roadmap.md
@@ -115,7 +115,7 @@ The Printer Settings Modal (Media & Feed / Print Quality / Clock & Time / Encodi
 | `[x]` | `^B0` / `^BO` | Aztec | |
 | `[x]` | `^BB` | CODABLOCK F | |
 | `[x]` | `^BV` | UPS MaxiCode (also accepts `^BD` on some firmware generations as an alias) | |
-| `[ ]` | `^BT` | TLC39 | `Coming soon` |
+| `[x]` | `^BT` | TLC39 | |
 
 ## Graphics
 

--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -12,6 +12,7 @@ import {
   getDisplaySize,
   get1DBwipScale,
   getEanUpcLayout,
+  renderTlc39Canvas,
   type BarcodeDisplaySize,
   type EanUpcType,
 } from "./bwipHelpers";
@@ -61,21 +62,28 @@ export function BarcodeObject({
     }
   }, []);
 
-  const opts = buildBwipOptions(obj, scale, dpmm);
   let barcodeCanvas: HTMLCanvasElement | null = null;
   let errorMsg: string | null = null;
-  if (opts) {
-    const canvas = document.createElement("canvas");
-    try {
-      // buildBwipOptions returns Record<string, unknown> on purpose: the
-      // option fields differ across barcode types (ean13 vs code128 vs …)
-      // and per-type narrowing would duplicate the switch already in
-      // buildBwipOptions. bwip-js' toCanvas signature uses a strict
-      // literal-string union, so the structural cast bridges the two.
-      bwipjs.toCanvas(canvas, opts as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
-      barcodeCanvas = canvas;
-    } catch (e) {
-      errorMsg = cleanBwipError(e);
+  if (obj.type === "tlc39") {
+    // bwip-js has no native tlc39 encoder; render the Code 39 + MicroPDF417
+    // composite ourselves. Goes straight to canvas, bypassing buildBwipOptions.
+    barcodeCanvas = renderTlc39Canvas(obj.props);
+    if (!barcodeCanvas) errorMsg = "TLC39 render failed";
+  } else {
+    const opts = buildBwipOptions(obj, scale, dpmm);
+    if (opts) {
+      const canvas = document.createElement("canvas");
+      try {
+        // buildBwipOptions returns Record<string, unknown> on purpose: the
+        // option fields differ across barcode types (ean13 vs code128 vs …)
+        // and per-type narrowing would duplicate the switch already in
+        // buildBwipOptions. bwip-js' toCanvas signature uses a strict
+        // literal-string union, so the structural cast bridges the two.
+        bwipjs.toCanvas(canvas, opts as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
+        barcodeCanvas = canvas;
+      } catch (e) {
+        errorMsg = cleanBwipError(e);
+      }
     }
   }
 

--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -67,7 +67,7 @@ export function BarcodeObject({
   if (obj.type === "tlc39") {
     // bwip-js has no native tlc39 encoder; render the Code 39 + MicroPDF417
     // composite ourselves. Goes straight to canvas, bypassing buildBwipOptions.
-    barcodeCanvas = renderTlc39Canvas(obj.props);
+    barcodeCanvas = renderTlc39Canvas(obj.props, scale, dpmm);
     if (!barcodeCanvas) errorMsg = "TLC39 render failed";
   } else {
     const opts = buildBwipOptions(obj, scale, dpmm);

--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -234,6 +234,7 @@ const BARCODE_TYPES = new Set([
   "codablock",
   "upcEanExtension",
   "code49",
+  "tlc39",
 ]);
 
 export function KonvaObject(props_: Props) {

--- a/src/components/Canvas/bwipConstants.ts
+++ b/src/components/Canvas/bwipConstants.ts
@@ -29,6 +29,9 @@ export const LOGMARS_TEXT_ZONE_DOTS = 20;
 // bwip-js adds 3 quiet-zone rows to MicroPDF417 canvas output.
 export const MICROPDF417_QUIET_ZONE_ROWS = 3;
 
+// bwip-js renders MicroPDF417 at 2 internal px per data row, independent of `rowheight`.
+export const MICROPDF417_PX_PER_ROW = 2;
+
 /**
  * bwip-vs-Zebra width-correction constants for symbologies whose bar
  * pattern in bwip-js diverges from Zebra firmware.

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -991,3 +991,86 @@ function getUprightDisplaySize(
     }
   }
 }
+
+/** TLC39 spec splits content on the first comma: ECI (6 digits) for
+ *  the Code 39 base line, serial (≤25 alphanum) for the MicroPDF417
+ *  block stacked on top. The "T" linkage flag is appended to the
+ *  Code 39 data when a MicroPDF417 follows; the leading "S" data
+ *  identifier (if any) is stripped from the serial before MicroPDF
+ *  encoding. */
+export function splitTlc39Content(content: string): { eci: string; serial: string } {
+  const comma = content.indexOf(",");
+  if (comma < 0) return { eci: content, serial: "" };
+  const eci = content.slice(0, comma);
+  let serial = content.slice(comma + 1);
+  if (serial.startsWith("S")) serial = serial.slice(1);
+  return { eci, serial };
+}
+
+interface Tlc39RenderProps {
+  content: string;
+  height: number;
+  microPdfRowHeight: number;
+}
+
+/** Render TLC39 as a composite canvas: MicroPDF417 block on top
+ *  (serial) and Code 39 base line below (ECI + "T" linkage flag).
+ *  bwip-js has no native TLC39 encoder, so this composes two standard
+ *  encoders per the TIA spec. Returns null on encoding failure. */
+export function renderTlc39Canvas(props: Tlc39RenderProps): HTMLCanvasElement | null {
+  const { eci, serial } = splitTlc39Content(props.content);
+  const code39Text = serial ? `${eci}T` : eci;
+  // bwip-js `height` is in millimetres at 1x; rough conversion from
+  // the prop's dot value uses /4 (assumes ~8 dpmm / 2x scale) so the
+  // rendered Code 39 height roughly matches print expectations.
+  const code39Height = Math.max(4, Math.round(props.height / 4));
+  const code39Canvas = document.createElement("canvas");
+  try {
+    bwipjs.toCanvas(code39Canvas, {
+      bcid: "code39",
+      text: code39Text || " ",
+      scale: BWIP_SCALE,
+      height: code39Height,
+      includetext: false,
+    } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
+  } catch {
+    return null;
+  }
+
+  if (!serial) return code39Canvas;
+
+  const mpdfCanvas = document.createElement("canvas");
+  try {
+    bwipjs.toCanvas(mpdfCanvas, {
+      bcid: "micropdf417",
+      text: serial,
+      scale: BWIP_SCALE,
+      rowheight: Math.max(2, props.microPdfRowHeight),
+    } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
+  } catch {
+    // Serial encoding failed; degrade gracefully to the Code 39 line.
+    return code39Canvas;
+  }
+
+  // Spec: MicroPDF417 sits ABOVE the Code 39 base (consistent with
+  // GS1 composite symbologies CC-A/B/C, which also place the 2D
+  // component on top of the linear base). The two symbols share the
+  // same printed width; firmware stretches the narrower one
+  // horizontally so modules go non-square but visual alignment
+  // matches the printed output. TCIF spec explicitly states no
+  // separator pattern and no required spacing between components;
+  // Zebra firmware renders them touching, so we do the same.
+  const w = Math.max(code39Canvas.width, mpdfCanvas.width);
+  const h = mpdfCanvas.height + code39Canvas.height;
+  const composite = document.createElement("canvas");
+  composite.width = w;
+  composite.height = h;
+  const ctx = composite.getContext("2d");
+  if (!ctx) return null;
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, w, h);
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(mpdfCanvas, 0, 0, w, mpdfCanvas.height);
+  ctx.drawImage(code39Canvas, 0, mpdfCanvas.height, w, code39Canvas.height);
+  return composite;
+}

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -999,6 +999,7 @@ function getUprightDisplaySize(
  *  identifier (if any) is stripped from the serial before MicroPDF
  *  encoding. */
 export function splitTlc39Content(content: string): { eci: string; serial: string } {
+  if (!content) return { eci: "", serial: "" };
   const comma = content.indexOf(",");
   if (comma < 0) return { eci: content, serial: "" };
   const eci = content.slice(0, comma);
@@ -1009,6 +1010,7 @@ export function splitTlc39Content(content: string): { eci: string; serial: strin
 
 interface Tlc39RenderProps {
   content: string;
+  moduleWidth: number;
   height: number;
   microPdfRowHeight: number;
 }
@@ -1016,20 +1018,30 @@ interface Tlc39RenderProps {
 /** Render TLC39 as a composite canvas: MicroPDF417 block on top
  *  (serial) and Code 39 base line below (ECI + "T" linkage flag).
  *  bwip-js has no native TLC39 encoder, so this composes two standard
- *  encoders per the TIA spec. Returns null on encoding failure. */
-export function renderTlc39Canvas(props: Tlc39RenderProps): HTMLCanvasElement | null {
+ *  encoders per the TIA spec. `scale` is the bwip-js pixel scale
+ *  (matches the canvas zoom) so the composite stays crisp at any
+ *  view-level. Returns null on encoding failure. */
+export function renderTlc39Canvas(
+  props: Tlc39RenderProps,
+  scale: number,
+  dpmm: number,
+): HTMLCanvasElement | null {
   const { eci, serial } = splitTlc39Content(props.content);
   const code39Text = serial ? `${eci}T` : eci;
+  // Match the 1D-barcode render pattern: pick an integer per-module
+  // pixel scale tied to the editor zoom and dpmm so module edges stay
+  // sharp at any view-level.
+  const bwipScale = get1DBwipScale(props.moduleWidth, scale, dpmm);
   // bwip-js `height` is in millimetres at 1x; rough conversion from
-  // the prop's dot value uses /4 (assumes ~8 dpmm / 2x scale) so the
-  // rendered Code 39 height roughly matches print expectations.
+  // the prop's dot value uses /4 (assumes ~8 dpmm) so the rendered
+  // Code 39 height roughly matches print expectations.
   const code39Height = Math.max(4, Math.round(props.height / 4));
   const code39Canvas = document.createElement("canvas");
   try {
     bwipjs.toCanvas(code39Canvas, {
       bcid: "code39",
       text: code39Text || " ",
-      scale: BWIP_SCALE,
+      scale: bwipScale,
       height: code39Height,
       includetext: false,
     } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
@@ -1044,7 +1056,7 @@ export function renderTlc39Canvas(props: Tlc39RenderProps): HTMLCanvasElement | 
     bwipjs.toCanvas(mpdfCanvas, {
       bcid: "micropdf417",
       text: serial,
-      scale: BWIP_SCALE,
+      scale: bwipScale,
       rowheight: Math.max(2, props.microPdfRowHeight),
     } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
   } catch {

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -31,6 +31,7 @@ import {
   GS1_DATABAR_PADDING_ROWS,
   GS1_DATABAR_SPEC_HEIGHT_MODULES,
   LOGMARS_TEXT_ZONE_DOTS,
+  MICROPDF417_PX_PER_ROW,
   MICROPDF417_QUIET_ZONE_ROWS,
   PLESSEY_BWIP_TO_ZEBRA_WIDTH_RATIO,
   UPC_SUPP_TEXT_ZONE_DOTS,
@@ -965,9 +966,7 @@ function getUprightDisplaySize(
     }
     case "micropdf417": {
       const p = obj.props;
-      // bwip-js ignores rowheight for micropdf417 and always uses 2 internal pixels per row.
-      // It also adds MICROPDF417_QUIET_ZONE_ROWS quiet-zone rows (top+bottom) to the canvas.
-      const numRows = Math.max(0, ch / (BWIP_SCALE * 2) - MICROPDF417_QUIET_ZONE_ROWS);
+      const numRows = micropdfDataRows(ch);
       const w =
         (cw / BWIP_SCALE) * dotsToPx(p.moduleWidth, scale, dpmm);
       const h = numRows * dotsToPx(p.rowHeight, scale, dpmm);
@@ -992,6 +991,25 @@ function getUprightDisplaySize(
   }
 }
 
+/** Valid MicroPDF417 row counts in TLC39's linked 4-column geometry. */
+export const TLC39_MICROPDF_ROW_COUNTS = [4, 6, 8, 10] as const;
+
+/** Snap to the nearest valid row count; bwip-js throws on any other value. */
+export function snapTlc39MicroPdfRows(requested: number): number {
+  if (!Number.isFinite(requested)) return 4;
+  for (const r of TLC39_MICROPDF_ROW_COUNTS) if (requested <= r) return r;
+  return 10;
+}
+
+/** Data-row count from a bwip-js MicroPDF417 canvas height (assumes scale=BWIP_SCALE). */
+function micropdfDataRows(canvasHeight: number): number {
+  return Math.max(
+    0,
+    canvasHeight / (BWIP_SCALE * MICROPDF417_PX_PER_ROW)
+      - MICROPDF417_QUIET_ZONE_ROWS,
+  );
+}
+
 /** TLC39 spec splits content on the first comma: ECI (6 digits) for
  *  the Code 39 base line, serial (≤25 alphanum) for the MicroPDF417
  *  block stacked on top. The "T" linkage flag is appended to the
@@ -1013,76 +1031,105 @@ interface Tlc39RenderProps {
   moduleWidth: number;
   height: number;
   microPdfRowHeight: number;
+  microPdfRows: number;
 }
 
-/** Render TLC39 as a composite canvas: MicroPDF417 block on top
- *  (serial) and Code 39 base line below (ECI + "T" linkage flag).
- *  bwip-js has no native TLC39 encoder, so this composes two standard
- *  encoders per the TIA spec. `scale` is the bwip-js pixel scale
- *  (matches the canvas zoom) so the composite stays crisp at any
- *  view-level. Returns null on encoding failure. */
+/** TLC39 composite (MicroPDF417 on top, Code 39 base below). bwip-js has
+ *  no native encoder; composes two encoders at dpmm-aware display sizes
+ *  per the TCIF spec (shared width, no separator). */
 export function renderTlc39Canvas(
   props: Tlc39RenderProps,
   scale: number,
   dpmm: number,
 ): HTMLCanvasElement | null {
   const { eci, serial } = splitTlc39Content(props.content);
-  const code39Text = serial ? `${eci}T` : eci;
-  // Match the 1D-barcode render pattern: pick an integer per-module
-  // pixel scale tied to the editor zoom and dpmm so module edges stay
-  // sharp at any view-level.
   const bwipScale = get1DBwipScale(props.moduleWidth, scale, dpmm);
-  // bwip-js `height` is in millimetres at 1x; rough conversion from
-  // the prop's dot value uses /4 (assumes ~8 dpmm) so the rendered
-  // Code 39 height roughly matches print expectations.
-  const code39Height = Math.max(4, Math.round(props.height / 4));
-  const code39Canvas = document.createElement("canvas");
-  try {
-    bwipjs.toCanvas(code39Canvas, {
-      bcid: "code39",
-      text: code39Text || " ",
-      scale: bwipScale,
-      height: code39Height,
-      includetext: false,
-    } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
-  } catch {
-    return null;
+  const modulePx = dotsToPx(props.moduleWidth, scale, dpmm);
+  const code39H = dotsToPx(props.height, scale, dpmm);
+
+  const renderCode39 = (text: string): HTMLCanvasElement | null => {
+    const c = document.createElement("canvas");
+    try {
+      bwipjs.toCanvas(c, {
+        bcid: "code39",
+        text: text || " ",
+        scale: bwipScale,
+        // bwip `height` is in mm at 1x; constant source height
+        // (stretched to dpmm-correct dots below) matches the standalone
+        // 1D pattern.
+        height: 10,
+        includetext: false,
+      } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
+    } catch {
+      return null;
+    }
+    return c;
+  };
+
+  const stretchTo = (
+    src: HTMLCanvasElement,
+    targetW: number,
+    targetH: number,
+  ): HTMLCanvasElement | null => {
+    const out = document.createElement("canvas");
+    out.width = Math.max(1, Math.round(targetW));
+    out.height = Math.max(1, Math.round(targetH));
+    const c = out.getContext("2d");
+    if (!c) return null;
+    c.fillStyle = "white";
+    c.fillRect(0, 0, out.width, out.height);
+    c.imageSmoothingEnabled = false;
+    c.drawImage(src, 0, 0, out.width, out.height);
+    return out;
+  };
+
+  if (!serial) {
+    const src = renderCode39(eci);
+    if (!src) return null;
+    const w = (src.width / bwipScale) * modulePx;
+    return stretchTo(src, w, code39H);
   }
 
-  if (!serial) return code39Canvas;
-
-  const mpdfCanvas = document.createElement("canvas");
+  // Render MicroPDF first; the "T" linkage flag is only appended to
+  // Code 39 when the linked MicroPDF actually rendered, otherwise the
+  // flag would claim a link that does not exist.
+  const snappedRows = snapTlc39MicroPdfRows(props.microPdfRows);
+  const mpdfSrc = document.createElement("canvas");
+  let mpdfOk = true;
   try {
-    bwipjs.toCanvas(mpdfCanvas, {
+    bwipjs.toCanvas(mpdfSrc, {
       bcid: "micropdf417",
       text: serial,
-      scale: bwipScale,
-      rowheight: Math.max(2, props.microPdfRowHeight),
+      scale: BWIP_SCALE,
+      rows: snappedRows,
+      // TLC39 spec: linked MicroPDF417 is fixed at 4 columns.
+      columns: 4,
     } as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
   } catch {
-    // Serial encoding failed; degrade gracefully to the Code 39 line.
-    return code39Canvas;
+    mpdfOk = false;
   }
 
-  // Spec: MicroPDF417 sits ABOVE the Code 39 base (consistent with
-  // GS1 composite symbologies CC-A/B/C, which also place the 2D
-  // component on top of the linear base). The two symbols share the
-  // same printed width; firmware stretches the narrower one
-  // horizontally so modules go non-square but visual alignment
-  // matches the printed output. TCIF spec explicitly states no
-  // separator pattern and no required spacing between components;
-  // Zebra firmware renders them touching, so we do the same.
-  const w = Math.max(code39Canvas.width, mpdfCanvas.width);
-  const h = mpdfCanvas.height + code39Canvas.height;
+  const code39Src = renderCode39(mpdfOk ? `${eci}T` : eci);
+  if (!code39Src) return null;
+  const code39W = (code39Src.width / bwipScale) * modulePx;
+
+  if (!mpdfOk) return stretchTo(code39Src, code39W, code39H);
+
+  const mpdfW = (mpdfSrc.width / BWIP_SCALE) * modulePx;
+  const mpdfH = snappedRows * dotsToPx(props.microPdfRowHeight, scale, dpmm);
+
+  const w = Math.max(1, Math.round(Math.max(code39W, mpdfW)));
+  const mpdfPxH = Math.max(1, Math.round(mpdfH));
+  const code39PxH = Math.max(1, Math.round(code39H));
   const composite = document.createElement("canvas");
   composite.width = w;
-  composite.height = h;
+  composite.height = mpdfPxH + code39PxH;
   const ctx = composite.getContext("2d");
   if (!ctx) return null;
   ctx.fillStyle = "white";
-  ctx.fillRect(0, 0, w, h);
+  ctx.fillRect(0, 0, composite.width, composite.height);
   ctx.imageSmoothingEnabled = false;
-  ctx.drawImage(mpdfCanvas, 0, 0, w, mpdfCanvas.height);
-  ctx.drawImage(code39Canvas, 0, mpdfCanvas.height, w, code39Canvas.height);
+  ctx.drawImage(mpdfSrc, 0, 0, w, mpdfPxH);
+  ctx.drawImage(code39Src, 0, mpdfPxH, w, code39PxH);
   return composite;
 }

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1278,6 +1278,116 @@ describe('parseZPL — ~ tilde commands', () => {
   });
 });
 
+// ── ^CC / ^CT / ^CD change command-prefix chars ──────────────────────────────
+
+describe('parseZPL — change caret / tilde / delimiter (^CC ^CT ^CD)', () => {
+  it('^CC switches the command prefix; following commands use the new char', () => {
+    const zpl = '^XA^CCYYFO10,10YA0N,30,0YFDhelloYFSYXZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('text');
+    expect(props(objects[0]).content).toBe('hello');
+  });
+
+  it('~CC is a synonym of ^CC', () => {
+    const zpl = '^XA~CCYYFO10,10YA0N,30,0YFDhelloYFSYXZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('text');
+  });
+
+  it('^CT switches the tilde prefix without affecting ^ commands', () => {
+    const zpl = '^XA^CT!^FO10,10^A0N,30,0^FDhello^FS!DGR:LOGO.GRF,10,1,FF^XZ';
+    const { objects, importReport } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(importReport.browserLimit.some((s) => s.startsWith('~DG'))).toBe(true);
+  });
+
+  it('^CD switches the parameter delimiter', () => {
+    const zpl = '^XA^CD;^FO10;10^A0N;30;0^FDhello^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.x).toBe(10);
+    expect(props(objects[0]).fontHeight).toBe(30);
+    expect(props(objects[0]).content).toBe('hello');
+  });
+
+  it('~CD is a synonym of ^CD', () => {
+    const zpl = '^XA~CD;^FO10;10^A0N;30;0^FDhello^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects[0]?.x).toBe(10);
+    expect(props(objects[0]).fontHeight).toBe(30);
+  });
+
+  it('combined ^CC + ^CD: both prefix and delimiter swap', () => {
+    const zpl = '^XA^CD;^CCYYFO10;10YA0N;30;0YFDhelloYFSYXZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.x).toBe(10);
+    expect(props(objects[0]).fontHeight).toBe(30);
+  });
+
+  it('^CC persists across an ^XA boundary within the same parse', () => {
+    const zpl =
+      '^XA^CCYYXZYXAYFO10,10YA0N,30,0YFDhelloYFSYXZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('text');
+  });
+
+  it('^CC^ resets the caret prefix back to ^', () => {
+    const zpl = '^XA^CCYYFO10,10YA0N,30,0YFDfirstYFSYCC^^FO50,50^A0N,30,0^FDsecond^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(2);
+    expect(props(objects[0]).content).toBe('first');
+    expect(props(objects[1]).content).toBe('second');
+  });
+
+  it('^CC always consumes the next char as its argument (even if it is ^)', () => {
+    // Spec: ^CC reads exactly one arg char. With `^CC^FO...`, the ^ of
+    // ^FO is consumed as the (no-op) argument; the FO that follows is
+    // no longer a command, so its position is lost.
+    const zpl = '^XA^CC^FO10,10^A0N,30,0^FDhello^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).content).toBe('hello');
+    expect(objects[0]?.x).toBe(0);
+  });
+
+  it('^CD also affects ^GF parameter parsing', () => {
+    // ^GFA;total;total;bpr;data uses the mutated delimiter for the four
+    // params; a wrong split would push the command into browserLimit.
+    const zpl = '^XA^CD;^FO10;10^GFA;6;6;3;111111111111^FS^XZ';
+    const { objects, importReport } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('image');
+    expect(importReport.browserLimit.some((s) => s.startsWith('^GF'))).toBe(false);
+  });
+
+  it('rejects ^CC / ^CT / ^CD args that would collapse role boundaries', () => {
+    // ^CC~ would make caret == tilde (tokenizer cannot distinguish);
+    // ^CD^ would make delimiter == caret (param-split eats command chars).
+    // Invalid args land in partialCmds and the prefix stays unchanged.
+    const zpl = '^XA^CC~^CD^^FO10,10^A0N,30,0^FDhello^FS^XZ';
+    const { objects, importReport } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).content).toBe('hello');
+    expect(importReport.partial).toContain('^CC');
+    expect(importReport.partial).toContain('^CD');
+  });
+
+  it('rejects ^CC / ^CT / ^CD args that are space or non-printable', () => {
+    // Space/control chars cannot serve as prefixes and would silently
+    // break the subsequent stream; reject them up front.
+    const zpl = '^XA^CC ^CT\t^FO10,10^A0N,30,0^FDhello^FS^XZ';
+    const { objects, importReport } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).content).toBe('hello');
+    expect(importReport.partial).toContain('^CC');
+    expect(importReport.partial).toContain('^CT');
+  });
+});
+
 // ── ^IM image reference ───────────────────────────────────────────────────────
 
 describe('parseZPL — ^IM image reference', () => {

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1388,6 +1388,59 @@ describe('parseZPL — change caret / tilde / delimiter (^CC ^CT ^CD)', () => {
   });
 });
 
+// ── ^BT TLC39 ─────────────────────────────────────────────────────────────────
+
+describe('parseZPL — ^BT TLC39', () => {
+  it('parses ^BT with full param set into a tlc39 object', () => {
+    const zpl = '^XA^FO50,50^BTN,3,3,60,5,3^FD123456,ABC^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('tlc39');
+    const p = props(objects[0]);
+    expect(p.content).toBe('123456,ABC');
+    expect(p.height).toBe(60);
+    expect(p.microPdfRowHeight).toBe(5);
+    expect(p.microPdfRows).toBe(3);
+    expect(p.rotation).toBe('N');
+  });
+
+  it('preserves valid microPdfRows across the Zebra 1-99 range', () => {
+    const zpl = '^XA^FO0,0^BTN,2,3,40,4,6^FD123456,X^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(props(objects[0]).microPdfRows).toBe(6);
+  });
+
+  it('round-trips ^BT via parse → toZPL → parse', async () => {
+    const { ObjectRegistry } = await import('../registry');
+    const original = '^XA^FO50,60^BY3^BTN,3,2,80,5,8^FD654321,ABCDEF^FS^XZ';
+    const { objects } = parseZPL(original, 8);
+    expect(objects).toHaveLength(1);
+    const emitted = ObjectRegistry.tlc39.toZPL(objects[0] as never);
+    expect(emitted).toContain('^BTN,3,2,80,5,8');
+    expect(emitted).toContain('^FD654321,ABCDEF');
+    const { objects: round2 } = parseZPL(`^XA${emitted}^XZ`, 8);
+    expect(round2[0]?.type).toBe('tlc39');
+    expect(props(round2[0])).toMatchObject(props(objects[0]));
+  });
+});
+
+describe('splitTlc39Content', () => {
+  it('splits on first comma; ECI before, serial after', async () => {
+    const { splitTlc39Content } = await import('../components/Canvas/bwipHelpers');
+    expect(splitTlc39Content('123456,ABC123')).toEqual({ eci: '123456', serial: 'ABC123' });
+  });
+
+  it('strips a leading S data identifier from the serial', async () => {
+    const { splitTlc39Content } = await import('../components/Canvas/bwipHelpers');
+    expect(splitTlc39Content('123456,SXYZ789')).toEqual({ eci: '123456', serial: 'XYZ789' });
+  });
+
+  it('returns empty serial when no comma is present', async () => {
+    const { splitTlc39Content } = await import('../components/Canvas/bwipHelpers');
+    expect(splitTlc39Content('123456')).toEqual({ eci: '123456', serial: '' });
+  });
+});
+
 // ── ^IM image reference ───────────────────────────────────────────────────────
 
 describe('parseZPL — ^IM image reference', () => {

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1411,10 +1411,44 @@ describe('parseZPL — ^BT TLC39', () => {
     expect(props(objects[0]).moduleWidth).toBe(5);
   });
 
-  it('preserves valid microPdfRows across the Zebra 1-99 range', () => {
+  it('preserves microPdfRows mid-range', () => {
     const zpl = '^XA^FO0,0^BTN,2,3,40,4,6^FD123456,X^FS^XZ';
     const { objects } = parseZPL(zpl, 8);
     expect(props(objects[0]).microPdfRows).toBe(6);
+  });
+
+  it('accepts microPdfRows=1 and =10 (^BT spec bounds)', () => {
+    const z1 = parseZPL('^XA^FO0,0^BTN,2,3,40,4,1^FD123456,X^FS^XZ', 8).objects;
+    expect(props(z1[0]).microPdfRows).toBe(1);
+    const z10 = parseZPL('^XA^FO0,0^BTN,2,3,40,4,10^FD123456,X^FS^XZ', 8).objects;
+    expect(props(z10[0]).microPdfRows).toBe(10);
+  });
+
+  it('rejects microPdfRows outside ^BT spec range (-1, 0, 11, 20) and falls back to default 4', () => {
+    for (const v of [-1, 0, 11, 20]) {
+      const zpl = `^XA^FO0,0^BTN,2,3,40,4,${v}^FD123456,X^FS^XZ`;
+      const { objects } = parseZPL(zpl, 8);
+      expect(props(objects[0]).microPdfRows, `rows=${v}`).toBe(4);
+    }
+  });
+
+  it('drops non-canonical r1 on round-trip (re-emits as 2)', async () => {
+    const { ObjectRegistry } = await import('../registry');
+    const { objects } = parseZPL('^XA^FO0,0^BTN,2,3,40,4,4^FD123,X^FS^XZ', 8);
+    const emitted = ObjectRegistry.tlc39.toZPL(objects[0] as never);
+    expect(emitted).toContain('^BTN,2,2,40,4,4');
+  });
+
+  it('round-trips ^BT without serial (no MicroPDF block, no trailing comma)', async () => {
+    const { ObjectRegistry } = await import('../registry');
+    const original = '^XA^FO10,20^BY2^BTN,2,2,40,4,4^FD123456^FS^XZ';
+    const { objects } = parseZPL(original, 8);
+    expect(objects[0]?.type).toBe('tlc39');
+    expect(props(objects[0]).content).toBe('123456');
+    const emitted = ObjectRegistry.tlc39.toZPL(objects[0] as never);
+    expect(emitted).toMatch(/\^FD123456\^FS/);
+    const { objects: round2 } = parseZPL(`^XA${emitted}^XZ`, 8);
+    expect(props(round2[0]).content).toBe('123456');
   });
 
   it('round-trips ^BT via parse → toZPL → parse', async () => {
@@ -1428,6 +1462,23 @@ describe('parseZPL — ^BT TLC39', () => {
     const { objects: round2 } = parseZPL(`^XA${emitted}^XZ`, 8);
     expect(round2[0]?.type).toBe('tlc39');
     expect(props(round2[0])).toMatchObject(props(objects[0]));
+  });
+});
+
+describe('snapTlc39MicroPdfRows', () => {
+  it('snaps in-range requests up to the nearest valid {4,6,8,10}', async () => {
+    const { snapTlc39MicroPdfRows } = await import('../components/Canvas/bwipHelpers');
+    expect(snapTlc39MicroPdfRows(1)).toBe(4);
+    expect(snapTlc39MicroPdfRows(4)).toBe(4);
+    expect(snapTlc39MicroPdfRows(5)).toBe(6);
+    expect(snapTlc39MicroPdfRows(7)).toBe(8);
+    expect(snapTlc39MicroPdfRows(9)).toBe(10);
+    expect(snapTlc39MicroPdfRows(10)).toBe(10);
+  });
+
+  it('clamps above-range to the highest valid count', async () => {
+    const { snapTlc39MicroPdfRows } = await import('../components/Canvas/bwipHelpers');
+    expect(snapTlc39MicroPdfRows(99)).toBe(10);
   });
 });
 

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1398,10 +1398,17 @@ describe('parseZPL — ^BT TLC39', () => {
     expect(objects[0]?.type).toBe('tlc39');
     const p = props(objects[0]);
     expect(p.content).toBe('123456,ABC');
+    expect(p.moduleWidth).toBe(3);
     expect(p.height).toBe(60);
     expect(p.microPdfRowHeight).toBe(5);
     expect(p.microPdfRows).toBe(3);
     expect(p.rotation).toBe('N');
+  });
+
+  it('falls back to ^BY moduleWidth when ^BT w1 is empty', () => {
+    const zpl = '^XA^FO0,0^BY5^BTN,,3,40,4,4^FD123456,X^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    expect(props(objects[0]).moduleWidth).toBe(5);
   });
 
   it('preserves valid microPdfRows across the Zebra 1-99 range', () => {

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -27,8 +27,8 @@ export type {
 
 /** Parse a ZPL II byte stream into an editable design model. */
 export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
-  const tokens = tokenize(zpl);
   const s = createParserState();
+  const tokens = tokenize(zpl, s.format);
   const {
     objects, labelConfig, printerProfile, variables,
     skipped, partialCmds, browserLimit, unknown,
@@ -79,7 +79,7 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
   Object.assign(handlers, createUnsupportedHandlers(s.result));
 
   for (const { cmd, rest } of tokens) {
-    const p = rest.split(",");
+    const p = rest.split(s.format.delimiterChar);
     const handler = handlers[cmd];
     if (handler) {
       handler(p, rest);

--- a/src/lib/zplParser/context.ts
+++ b/src/lib/zplParser/context.ts
@@ -63,6 +63,12 @@ export interface FormatState {
   fhActive: boolean;
   fhDelimiter: string;
   fhDecoder: TextDecoder;
+  // Command prefix characters; mutated by ^CC/~CC, ^CT/~CT, ^CD/~CD.
+  // The tokenizer reads caretChar/tildeChar on every char scan so mid-stream
+  // changes take effect on the very next command.
+  caretChar: string;
+  tildeChar: string;
+  delimiterChar: string;
 }
 
 /** Persistent defaults for following fields (^CF, ^FW, ^FB, ^BY). */
@@ -201,6 +207,9 @@ export function createParserState(): ParserState {
       fhActive: false,
       fhDelimiter: "_",
       fhDecoder: getDecoder("utf-8"),
+      caretChar: "^",
+      tildeChar: "~",
+      delimiterChar: ",",
     },
     defaults: {
       cfHeight: 0,

--- a/src/lib/zplParser/context.ts
+++ b/src/lib/zplParser/context.ts
@@ -134,6 +134,10 @@ export interface FieldState {
   mpdfRowHeight: number;
   cbRowHeight: number;
   cbSecurity: CodablockProps["securityLevel"];
+  // TLC39 pending
+  tlcHeight: number;
+  tlcMicroPdfRowHeight: number;
+  tlcMicroPdfRows: number;
   // Pending font reference (^A@ or ^A{id}) — mutually exclusive
   pendingPrinterFontName: string | undefined;
   pendingFontId: string | undefined;
@@ -260,6 +264,9 @@ export function createParserState(): ParserState {
       mpdfRowHeight: 10,
       cbRowHeight: 10,
       cbSecurity: "Y",
+      tlcHeight: 40,
+      tlcMicroPdfRowHeight: 4,
+      tlcMicroPdfRows: 4,
       pendingPrinterFontName: undefined,
       pendingFontId: undefined,
       snPending: false,

--- a/src/lib/zplParser/context.ts
+++ b/src/lib/zplParser/context.ts
@@ -135,6 +135,7 @@ export interface FieldState {
   cbRowHeight: number;
   cbSecurity: CodablockProps["securityLevel"];
   // TLC39 pending
+  tlcModuleWidth: number | undefined;
   tlcHeight: number;
   tlcMicroPdfRowHeight: number;
   tlcMicroPdfRows: number;
@@ -264,6 +265,7 @@ export function createParserState(): ParserState {
       mpdfRowHeight: 10,
       cbRowHeight: 10,
       cbSecurity: "Y",
+      tlcModuleWidth: undefined,
       tlcHeight: 40,
       tlcMicroPdfRowHeight: 4,
       tlcMicroPdfRows: 4,

--- a/src/lib/zplParser/flushField.ts
+++ b/src/lib/zplParser/flushField.ts
@@ -29,6 +29,7 @@ import type { AztecProps } from "../../registry/aztec";
 import type { MaxicodeProps } from "../../registry/maxicode";
 import type { MicroPdf417Props } from "../../registry/micropdf417";
 import type { CodablockProps } from "../../registry/codablock";
+import type { Tlc39Props } from "../../registry/tlc39";
 import { decodeFH, makeObj, variableNameFromComment } from "./helpers";
 import { getPosType, type ParserState, REVERSE_BBOX_TOLERANCE_DOTS } from "./context";
 
@@ -472,6 +473,25 @@ export function createFlushField(
               securityLevel: s.field.cbSecurity,
               rotation: s.field.bcRotation,
             } satisfies CodablockProps,
+            posType,
+            comment,
+          ),
+        );
+        break;
+      case "tlc39":
+        objects.push(
+          makeObj(
+            "tlc39",
+            s.field.x,
+            s.field.y,
+            {
+              content,
+              moduleWidth: s.defaults.byModuleWidth,
+              height: s.field.tlcHeight,
+              microPdfRowHeight: s.field.tlcMicroPdfRowHeight,
+              microPdfRows: s.field.tlcMicroPdfRows,
+              rotation: s.field.bcRotation,
+            } satisfies Tlc39Props,
             posType,
             comment,
           ),

--- a/src/lib/zplParser/flushField.ts
+++ b/src/lib/zplParser/flushField.ts
@@ -486,7 +486,7 @@ export function createFlushField(
             s.field.y,
             {
               content,
-              moduleWidth: s.defaults.byModuleWidth,
+              moduleWidth: s.field.tlcModuleWidth ?? s.defaults.byModuleWidth,
               height: s.field.tlcHeight,
               microPdfRowHeight: s.field.tlcMicroPdfRowHeight,
               microPdfRows: s.field.tlcMicroPdfRows,

--- a/src/lib/zplParser/handlers/barcodes.ts
+++ b/src/lib/zplParser/handlers/barcodes.ts
@@ -151,5 +151,17 @@ export function createBarcodeHandlers(
       field.cbRowHeight = int(p[1], 10);
       field.cbSecurity = (p[2] ?? "Y") === "N" ? "N" : "Y";
     },
+
+    // ^BTo,w1,r1,h1,w2,h2 — TLC39 (Code 39 + optional MicroPDF417 stack)
+    BT(p) {
+      field.fieldType = "tlc39";
+      field.bcRotation = readRotation(p[0]);
+      field.tlcHeight = int(p[3], defaults.byHeight || 40);
+      field.tlcMicroPdfRowHeight = int(p[4], 4);
+      // Zebra ^BT h2 range is 1-99; firmware snaps to a valid MicroPDF417
+      // row count on print, so we keep whatever the user supplied.
+      const rows = int(p[5], 4);
+      field.tlcMicroPdfRows = rows >= 1 && rows <= 99 ? rows : 4;
+    },
   };
 }

--- a/src/lib/zplParser/handlers/barcodes.ts
+++ b/src/lib/zplParser/handlers/barcodes.ts
@@ -152,19 +152,20 @@ export function createBarcodeHandlers(
       field.cbSecurity = (p[2] ?? "Y") === "N" ? "N" : "Y";
     },
 
-    // ^BTo,w1,r1,h1,w2,h2 — TLC39 (Code 39 + optional MicroPDF417 stack)
+    // ^BTo,w1,r1,h1,w2,h2: TLC39 (Code 39 + optional MicroPDF417 stack)
     BT(p) {
       field.fieldType = "tlc39";
       field.bcRotation = readRotation(p[0]);
       // w1 (Code 39 narrow bar) overrides ^BY when present; undefined
       // means fall back to defaults.byModuleWidth at flush time.
       field.tlcModuleWidth = int(p[1]) || undefined;
+      // p[2] (r1) intentionally dropped; canonicalized on emit.
       field.tlcHeight = int(p[3], defaults.byHeight || 40);
       field.tlcMicroPdfRowHeight = int(p[4], 4);
-      // Zebra ^BT h2 range is 1-99; firmware snaps to a valid MicroPDF417
-      // row count on print, so we keep whatever the user supplied.
+      // Zebra ^BT h2 range is 1-10; firmware snaps to a valid linked
+      // MicroPDF417 row count {4,6,8,10} on print.
       const rows = int(p[5], 4);
-      field.tlcMicroPdfRows = rows >= 1 && rows <= 99 ? rows : 4;
+      field.tlcMicroPdfRows = rows >= 1 && rows <= 10 ? rows : 4;
     },
   };
 }

--- a/src/lib/zplParser/handlers/barcodes.ts
+++ b/src/lib/zplParser/handlers/barcodes.ts
@@ -156,6 +156,9 @@ export function createBarcodeHandlers(
     BT(p) {
       field.fieldType = "tlc39";
       field.bcRotation = readRotation(p[0]);
+      // w1 (Code 39 narrow bar) overrides ^BY when present; undefined
+      // means fall back to defaults.byModuleWidth at flush time.
+      field.tlcModuleWidth = int(p[1]) || undefined;
       field.tlcHeight = int(p[3], defaults.byHeight || 40);
       field.tlcMicroPdfRowHeight = int(p[4], 4);
       // Zebra ^BT h2 range is 1-99; firmware snaps to a valid MicroPDF417

--- a/src/lib/zplParser/handlers/fields.ts
+++ b/src/lib/zplParser/handlers/fields.ts
@@ -275,5 +275,36 @@ export function createFieldHandlers(
       const c = p[0]?.[0];
       s.format.embedChar = c && c !== "^" && c !== "~" ? c : "#";
     },
+
+    // ^CC<char> / ~CC<char>: change the command prefix char (default ^).
+    // The tokenizer reads s.format.caretChar live, so the next command in
+    // the stream uses the new prefix. Reject chars that would collapse
+    // a role boundary (tilde, delimiter) and end up parsing nothing.
+    CC(_, rest) {
+      const c = rest[0];
+      if (!c || c <= " " || c === "\x7F" || c === s.format.tildeChar || c === s.format.delimiterChar) {
+        s.result.partialCmds.add("^CC");
+        return;
+      }
+      s.format.caretChar = c;
+    },
+    // ^CT<char> / ~CT<char>: change the tilde-form prefix (default ~).
+    CT(_, rest) {
+      const c = rest[0];
+      if (!c || c <= " " || c === "\x7F" || c === s.format.caretChar || c === s.format.delimiterChar) {
+        s.result.partialCmds.add("^CT");
+        return;
+      }
+      s.format.tildeChar = c;
+    },
+    // ^CD<char> / ~CD<char>: change the parameter delimiter (default ,).
+    CD(_, rest) {
+      const c = rest[0];
+      if (!c || c <= " " || c === "\x7F" || c === s.format.caretChar || c === s.format.tildeChar) {
+        s.result.partialCmds.add("^CD");
+        return;
+      }
+      s.format.delimiterChar = c;
+    },
   };
 }

--- a/src/lib/zplParser/handlers/graphics.ts
+++ b/src/lib/zplParser/handlers/graphics.ts
@@ -169,11 +169,13 @@ export function createGraphicsHandlers(
         return;
       }
 
-      // Extract params: skip "A," then find 3rd comma to separate params from data
+      // Extract params: skip "A," then find 3rd delimiter to separate params from data.
+      // Respects ^CD-mutated delimiter so ^CD;^GFA;total;total;bpr;data still parses.
+      const delim = s.format.delimiterChar;
       const gfRest = rest.slice(2); // "total,total,bytesPerRow,data..."
       let commaPos = -1;
       for (let n = 0; n < 3; n++) {
-        commaPos = gfRest.indexOf(",", commaPos + 1);
+        commaPos = gfRest.indexOf(delim, commaPos + 1);
         if (commaPos === -1) break;
       }
       if (commaPos === -1) {
@@ -181,7 +183,7 @@ export function createGraphicsHandlers(
         return;
       }
 
-      const gfParams = gfRest.slice(0, commaPos).split(",");
+      const gfParams = gfRest.slice(0, commaPos).split(delim);
       const gfBytesPerRow = int(gfParams[2], 0);
       // Everything after the 3rd comma is the (possibly compressed) graphic data
       const gfRawData = gfRest.slice(commaPos + 1);
@@ -287,7 +289,7 @@ export function createGraphicsHandlers(
       //    (admin pre-loaded). Object gets storedAs.embedInZpl=false and
       //    no cached bitmap; the canvas falls back to a placeholder, the
       //    emitter skips the ~DY preamble but keeps the ^XG reference.
-      const firstComma = rest.indexOf(",");
+      const firstComma = rest.indexOf(s.format.delimiterChar);
       const xgPath = firstComma === -1 ? rest : rest.slice(0, firstComma);
       const parsed = parseStoragePath(xgPath);
       if (!parsed) {
@@ -358,9 +360,10 @@ export function createGraphicsHandlers(
       // KB of hex; we want to avoid splitting that into the rest of
       // the params array. Param layout up to and including bytes-per-
       // row is fixed-arity, so we walk commas until we've found 5.
+      const delim = s.format.delimiterChar;
       const c: number[] = [];
       for (let i = 0; i < rest.length && c.length < 5; i++) {
-        if (rest[i] === ",") c.push(i);
+        if (rest[i] === delim) c.push(i);
       }
       if (c.length < 5) {
         pushBrowserLimit(s.result, `~DY${rest}`);

--- a/src/lib/zplParser/helpers.ts
+++ b/src/lib/zplParser/helpers.ts
@@ -19,19 +19,53 @@ export function firstChar(rest: string): string {
   return (rest.trim()[0] ?? "").toUpperCase();
 }
 
-export function tokenize(zpl: string): { cmd: string; rest: string }[] {
-  const tokens: { cmd: string; rest: string }[] = [];
-  // Split on both ^ and ~ delimiters, preserving the delimiter type.
-  const parts = zpl.split(/(?=[\^~])/);
-  for (const part of parts) {
-    if (part.length < 3) continue;
-    const delimiter = part[0];
-    if (delimiter !== "^" && delimiter !== "~") continue;
-    const cmd = part.slice(1, 3).toUpperCase();
-    const rest = part.slice(3);
-    tokens.push({ cmd, rest });
+/** Live command-prefix chars; the tokenizer reads these on every char
+ *  scan so ^CC/^CT mutations take effect on the very next command. */
+export interface TokenizerChars {
+  caretChar: string;
+  tildeChar: string;
+}
+
+/** Stream tokens incrementally so ^CC/^CT changes mid-parse apply to
+ *  subsequent commands. The caller passes a live ref (typically
+ *  `s.format`) whose `caretChar`/`tildeChar` may be mutated between
+ *  iterations. */
+export function* tokenize(
+  zpl: string,
+  chars: TokenizerChars,
+): Generator<{ cmd: string; rest: string }> {
+  let pos = 0;
+  while (pos < zpl.length) {
+    let cmdStart = -1;
+    for (let i = pos; i < zpl.length; i++) {
+      const ch = zpl[i];
+      if (ch === chars.caretChar || ch === chars.tildeChar) {
+        cmdStart = i;
+        break;
+      }
+    }
+    if (cmdStart === -1 || cmdStart + 3 > zpl.length) return;
+    const cmd = zpl.slice(cmdStart + 1, cmdStart + 3).toUpperCase();
+    // ^CC/^CT/^CD take exactly one argument character; everything after
+    // it belongs to the next command (using the new prefix if the handler
+    // mutates it). Generic commands consume rest until the next delimiter.
+    if (cmd === "CC" || cmd === "CT" || cmd === "CD") {
+      const argChar = zpl[cmdStart + 3] ?? "";
+      pos = cmdStart + 4;
+      yield { cmd, rest: argChar };
+      continue;
+    }
+    let endPos = zpl.length;
+    for (let i = cmdStart + 3; i < zpl.length; i++) {
+      const ch = zpl[i];
+      if (ch === chars.caretChar || ch === chars.tildeChar) {
+        endPos = i;
+        break;
+      }
+    }
+    pos = endPos;
+    yield { cmd, rest: zpl.slice(cmdStart + 3, endPos) };
   }
-  return tokens;
 }
 
 export function int(s: string | undefined, fallback = 0): number {

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -45,6 +45,7 @@ const ar = {
     maxicode: 'ماكسي كود',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'مجموعة',
   },
 
@@ -583,6 +584,13 @@ const ar = {
       rowHeight: 'ارتفاع الصف (نقاط)',
       moduleWidth: 'عرض الوحدة',
       security: 'فحص الأمان',
+    },
+    tlc39: {
+      content: 'المحتوى',
+      height: 'الارتفاع (نقاط)',
+      moduleWidth: 'عرض الوحدة',
+      microPdfRowHeight: 'ارتفاع صف MicroPDF',
+      microPdfRows: 'صفوف MicroPDF',
     },
   },
 

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -45,6 +45,7 @@ const bg = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Група',
   },
 
@@ -583,6 +584,13 @@ const bg = {
       rowHeight: 'Височина на ред (точки)',
       moduleWidth: 'Ширина на модул',
       security: 'Проверка за сигурност',
+    },
+    tlc39: {
+      content: 'Съдържание',
+      height: 'Височина (точки)',
+      moduleWidth: 'Ширина на модула',
+      microPdfRowHeight: 'Височина на ред MicroPDF',
+      microPdfRows: 'Редове MicroPDF',
     },
   },
 

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -45,6 +45,7 @@ const cs = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Skupina',
   },
 
@@ -583,6 +584,13 @@ const cs = {
       rowHeight: 'Výška řádku (body)',
       moduleWidth: 'Šířka modulu',
       security: 'Bezpečnostní kontrola',
+    },
+    tlc39: {
+      content: 'Obsah',
+      height: 'Výška (body)',
+      moduleWidth: 'Šířka modulu',
+      microPdfRowHeight: 'Výška řádku MicroPDF',
+      microPdfRows: 'Řádky MicroPDF',
     },
   },
 

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -45,6 +45,7 @@ const da = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Gruppe',
   },
 
@@ -583,6 +584,13 @@ const da = {
       rowHeight: 'Rækkehøjde (punkter)',
       moduleWidth: 'Modulbredde',
       security: 'Sikkerhedskontrol',
+    },
+    tlc39: {
+      content: 'Indhold',
+      height: 'Højde (punkter)',
+      moduleWidth: 'Modulbredde',
+      microPdfRowHeight: 'MicroPDF rækkehøjde',
+      microPdfRows: 'MicroPDF rækker',
     },
   },
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -45,6 +45,7 @@ const de = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Gruppe',
   },
 
@@ -604,6 +605,13 @@ const de = {
       rowHeight: 'Zeilenhöhe (Punkte)',
       moduleWidth: 'Modulbreite',
       security: 'Sicherheitsprüfung',
+    },
+    tlc39: {
+      content: 'Inhalt',
+      height: 'Höhe (Punkte)',
+      moduleWidth: 'Modulbreite',
+      microPdfRowHeight: 'MicroPDF Zeilenhöhe',
+      microPdfRows: 'MicroPDF Zeilen',
     },
   },
 

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -45,6 +45,7 @@ const el = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Ομάδα',
   },
 
@@ -583,6 +584,13 @@ const el = {
       rowHeight: 'Ύψος γραμμής (κουκκίδες)',
       moduleWidth: 'Πλάτος μονάδας',
       security: 'Έλεγχος ασφαλείας',
+    },
+    tlc39: {
+      content: 'Περιεχόμενο',
+      height: 'Ύψος (κουκκίδες)',
+      moduleWidth: 'Πλάτος μονάδας',
+      microPdfRowHeight: 'Ύψος γραμμής MicroPDF',
+      microPdfRows: 'Γραμμές MicroPDF',
     },
   },
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -45,6 +45,7 @@ const en = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Group',
   },
 
@@ -604,6 +605,13 @@ const en = {
       rowHeight: 'Row height (dots)',
       moduleWidth: 'Module width',
       security: 'Security check',
+    },
+    tlc39: {
+      content: 'Content',
+      height: 'Height (dots)',
+      moduleWidth: 'Module width',
+      microPdfRowHeight: 'MicroPDF row height',
+      microPdfRows: 'MicroPDF rows',
     },
   },
 

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -45,6 +45,7 @@ const es = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupo',
   },
 
@@ -583,6 +584,13 @@ const es = {
       rowHeight: 'Altura fila (puntos)',
       moduleWidth: 'Ancho módulo',
       security: 'Control de seguridad',
+    },
+    tlc39: {
+      content: 'Contenido',
+      height: 'Altura (puntos)',
+      moduleWidth: 'Ancho de módulo',
+      microPdfRowHeight: 'Altura de fila MicroPDF',
+      microPdfRows: 'Filas MicroPDF',
     },
   },
 

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -45,6 +45,7 @@ const et = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Rühm',
   },
 
@@ -583,6 +584,13 @@ const et = {
       rowHeight: 'Rea kõrgus (punkti)',
       moduleWidth: 'Mooduli laius',
       security: 'Turvakontroll',
+    },
+    tlc39: {
+      content: 'Sisu',
+      height: 'Kõrgus (punktid)',
+      moduleWidth: 'Mooduli laius',
+      microPdfRowHeight: 'MicroPDF rea kõrgus',
+      microPdfRows: 'MicroPDF read',
     },
   },
 

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -45,6 +45,7 @@ const fa = {
     maxicode: 'ماکسی‌کد',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'گروه',
   },
 
@@ -583,6 +584,13 @@ const fa = {
       rowHeight: 'ارتفاع ردیف (نقطه)',
       moduleWidth: 'عرض ماژول',
       security: 'بررسی امنیتی',
+    },
+    tlc39: {
+      content: 'محتوا',
+      height: 'ارتفاع (نقطه)',
+      moduleWidth: 'عرض ماژول',
+      microPdfRowHeight: 'ارتفاع ردیف MicroPDF',
+      microPdfRows: 'ردیف‌های MicroPDF',
     },
   },
 

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -45,6 +45,7 @@ const fi = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Ryhmä',
   },
 
@@ -583,6 +584,13 @@ const fi = {
       rowHeight: 'Rivikorkeus (pistettä)',
       moduleWidth: 'Moduulin leveys',
       security: 'Turvatarkistus',
+    },
+    tlc39: {
+      content: 'Sisältö',
+      height: 'Korkeus (pisteet)',
+      moduleWidth: 'Moduulin leveys',
+      microPdfRowHeight: 'MicroPDF-rivin korkeus',
+      microPdfRows: 'MicroPDF-rivit',
     },
   },
 

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -45,6 +45,7 @@ const fr = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Groupe',
   },
 
@@ -583,6 +584,13 @@ const fr = {
       rowHeight: 'Hauteur ligne (points)',
       moduleWidth: 'Largeur module',
       security: 'Contrôle de sécurité',
+    },
+    tlc39: {
+      content: 'Contenu',
+      height: 'Hauteur (points)',
+      moduleWidth: 'Largeur de module',
+      microPdfRowHeight: 'Hauteur de ligne MicroPDF',
+      microPdfRows: 'Lignes MicroPDF',
     },
   },
 

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -45,6 +45,7 @@ const he = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'קבוצה',
   },
 
@@ -583,6 +584,13 @@ const he = {
       rowHeight: 'גובה שורה (נקודות)',
       moduleWidth: 'רוחב מודול',
       security: 'בדיקת אבטחה',
+    },
+    tlc39: {
+      content: 'תוכן',
+      height: 'גובה (נקודות)',
+      moduleWidth: 'רוחב מודול',
+      microPdfRowHeight: 'גובה שורה של MicroPDF',
+      microPdfRows: 'שורות MicroPDF',
     },
   },
 

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -45,6 +45,7 @@ const hr = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupa',
   },
 
@@ -583,6 +584,13 @@ const hr = {
       rowHeight: 'Visina retka (točke)',
       moduleWidth: 'Širina modula',
       security: 'Sigurnosna provjera',
+    },
+    tlc39: {
+      content: 'Sadržaj',
+      height: 'Visina (točke)',
+      moduleWidth: 'Širina modula',
+      microPdfRowHeight: 'Visina retka MicroPDF',
+      microPdfRows: 'MicroPDF retci',
     },
   },
 

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -45,6 +45,7 @@ const hu = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Csoport',
   },
 
@@ -583,6 +584,13 @@ const hu = {
       rowHeight: 'Sormagasság (pont)',
       moduleWidth: 'Modulszélesség',
       security: 'Biztonsági ellenőrzés',
+    },
+    tlc39: {
+      content: 'Tartalom',
+      height: 'Magasság (pont)',
+      moduleWidth: 'Modulszélesség',
+      microPdfRowHeight: 'MicroPDF sormagasság',
+      microPdfRows: 'MicroPDF sorok',
     },
   },
 

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -45,6 +45,7 @@ const it = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Gruppo',
   },
 
@@ -583,6 +584,13 @@ const it = {
       rowHeight: 'Altezza riga (punti)',
       moduleWidth: 'Larghezza modulo',
       security: 'Controllo di sicurezza',
+    },
+    tlc39: {
+      content: 'Contenuto',
+      height: 'Altezza (punti)',
+      moduleWidth: 'Larghezza modulo',
+      microPdfRowHeight: 'Altezza riga MicroPDF',
+      microPdfRows: 'Righe MicroPDF',
     },
   },
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -45,6 +45,7 @@ const ja = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'グループ',
   },
 
@@ -583,6 +584,13 @@ const ja = {
       rowHeight: '行高さ（ドット）',
       moduleWidth: 'モジュール幅',
       security: 'セキュリティチェック',
+    },
+    tlc39: {
+      content: 'コンテンツ',
+      height: '高さ (ドット)',
+      moduleWidth: 'モジュール幅',
+      microPdfRowHeight: 'MicroPDF行の高さ',
+      microPdfRows: 'MicroPDF行数',
     },
   },
 

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -45,6 +45,7 @@ const ko = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: '그룹',
   },
 
@@ -583,6 +584,13 @@ const ko = {
       rowHeight: '행 높이 (도트)',
       moduleWidth: '모듈 폭',
       security: '보안 검사',
+    },
+    tlc39: {
+      content: '내용',
+      height: '높이 (도트)',
+      moduleWidth: '모듈 너비',
+      microPdfRowHeight: 'MicroPDF 행 높이',
+      microPdfRows: 'MicroPDF 행 수',
     },
   },
 

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -45,6 +45,7 @@ const lt = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupė',
   },
 
@@ -583,6 +584,13 @@ const lt = {
       rowHeight: 'Eilutės aukštis (taškai)',
       moduleWidth: 'Modulio plotis',
       security: 'Saugumo patikra',
+    },
+    tlc39: {
+      content: 'Turinys',
+      height: 'Aukštis (taškai)',
+      moduleWidth: 'Modulio plotis',
+      microPdfRowHeight: 'MicroPDF eilutės aukštis',
+      microPdfRows: 'MicroPDF eilutės',
     },
   },
 

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -45,6 +45,7 @@ const lv = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupa',
   },
 
@@ -583,6 +584,13 @@ const lv = {
       rowHeight: 'Rindas augstums (punkti)',
       moduleWidth: 'Moduļa platums',
       security: 'Drošības pārbaude',
+    },
+    tlc39: {
+      content: 'Saturs',
+      height: 'Augstums (punkti)',
+      moduleWidth: 'Moduļa platums',
+      microPdfRowHeight: 'MicroPDF rindas augstums',
+      microPdfRows: 'MicroPDF rindas',
     },
   },
 

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -45,6 +45,7 @@ const nl = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Groep',
   },
 
@@ -583,6 +584,13 @@ const nl = {
       rowHeight: 'Rijhoogte (punten)',
       moduleWidth: 'Modulebreedte',
       security: 'Beveiligingscontrole',
+    },
+    tlc39: {
+      content: 'Inhoud',
+      height: 'Hoogte (punten)',
+      moduleWidth: 'Modulebreedte',
+      microPdfRowHeight: 'MicroPDF rijhoogte',
+      microPdfRows: 'MicroPDF rijen',
     },
   },
 

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -45,6 +45,7 @@ const no = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Gruppe',
   },
 
@@ -583,6 +584,13 @@ const no = {
       rowHeight: 'Radhøyde (punkter)',
       moduleWidth: 'Modulbredde',
       security: 'Sikkerhetskontroll',
+    },
+    tlc39: {
+      content: 'Innhold',
+      height: 'Høyde (punkter)',
+      moduleWidth: 'Modulbredde',
+      microPdfRowHeight: 'MicroPDF radhøyde',
+      microPdfRows: 'MicroPDF rader',
     },
   },
 

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -45,6 +45,7 @@ const pl = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupa',
   },
 
@@ -583,6 +584,13 @@ const pl = {
       rowHeight: 'Wysokość wiersza (punkty)',
       moduleWidth: 'Szerokość modułu',
       security: 'Kontrola bezpieczeństwa',
+    },
+    tlc39: {
+      content: 'Treść',
+      height: 'Wysokość (punkty)',
+      moduleWidth: 'Szerokość modułu',
+      microPdfRowHeight: 'Wysokość wiersza MicroPDF',
+      microPdfRows: 'Wiersze MicroPDF',
     },
   },
 

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -45,6 +45,7 @@ const pt = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupo',
   },
 
@@ -583,6 +584,13 @@ const pt = {
       rowHeight: 'Altura linha (pontos)',
       moduleWidth: 'Largura módulo',
       security: 'Verificação de segurança',
+    },
+    tlc39: {
+      content: 'Conteúdo',
+      height: 'Altura (pontos)',
+      moduleWidth: 'Largura do módulo',
+      microPdfRowHeight: 'Altura da linha MicroPDF',
+      microPdfRows: 'Linhas MicroPDF',
     },
   },
 

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -45,6 +45,7 @@ const ro = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grup',
   },
 
@@ -583,6 +584,13 @@ const ro = {
       rowHeight: 'Înălțime rând (puncte)',
       moduleWidth: 'Lățime modul',
       security: 'Verificare securitate',
+    },
+    tlc39: {
+      content: 'Conținut',
+      height: 'Înălțime (puncte)',
+      moduleWidth: 'Lățime modul',
+      microPdfRowHeight: 'Înălțime rând MicroPDF',
+      microPdfRows: 'Rânduri MicroPDF',
     },
   },
 

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -45,6 +45,7 @@ const sk = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Skupina',
   },
 
@@ -583,6 +584,13 @@ const sk = {
       rowHeight: 'Výška riadku (body)',
       moduleWidth: 'Šírka modulu',
       security: 'Bezpečnostná kontrola',
+    },
+    tlc39: {
+      content: 'Obsah',
+      height: 'Výška (body)',
+      moduleWidth: 'Šírka modulu',
+      microPdfRowHeight: 'Výška riadku MicroPDF',
+      microPdfRows: 'Riadky MicroPDF',
     },
   },
 

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -45,6 +45,7 @@ const sl = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Skupina',
   },
 
@@ -583,6 +584,13 @@ const sl = {
       rowHeight: 'Višina vrstice (pike)',
       moduleWidth: 'Širina modula',
       security: 'Varnostno preverjanje',
+    },
+    tlc39: {
+      content: 'Vsebina',
+      height: 'Višina (točke)',
+      moduleWidth: 'Širina modula',
+      microPdfRowHeight: 'Višina vrstice MicroPDF',
+      microPdfRows: 'Vrstice MicroPDF',
     },
   },
 

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -45,6 +45,7 @@ const sr = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupa',
   },
 
@@ -583,6 +584,13 @@ const sr = {
       rowHeight: 'Висина реда (тачке)',
       moduleWidth: 'Ширина модула',
       security: 'Безбедносна провера',
+    },
+    tlc39: {
+      content: 'Sadržaj',
+      height: 'Visina (tačke)',
+      moduleWidth: 'Širina modula',
+      microPdfRowHeight: 'Visina reda MicroPDF',
+      microPdfRows: 'Redovi MicroPDF',
     },
   },
 

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -45,6 +45,7 @@ const sv = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grupp',
   },
 
@@ -583,6 +584,13 @@ const sv = {
       rowHeight: 'Radhöjd (punkter)',
       moduleWidth: 'Modulbredd',
       security: 'Säkerhetskontroll',
+    },
+    tlc39: {
+      content: 'Innehåll',
+      height: 'Höjd (punkter)',
+      moduleWidth: 'Modulbredd',
+      microPdfRowHeight: 'MicroPDF radhöjd',
+      microPdfRows: 'MicroPDF rader',
     },
   },
 

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -45,6 +45,7 @@ const tr = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: 'Grup',
   },
 
@@ -583,6 +584,13 @@ const tr = {
       rowHeight: 'Satır yüksekliği (nokta)',
       moduleWidth: 'Modül genişliği',
       security: 'Güvenlik kontrolü',
+    },
+    tlc39: {
+      content: 'İçerik',
+      height: 'Yükseklik (nokta)',
+      moduleWidth: 'Modül genişliği',
+      microPdfRowHeight: 'MicroPDF satır yüksekliği',
+      microPdfRows: 'MicroPDF satırları',
     },
   },
 

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -45,6 +45,7 @@ const zhHans = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: '组',
   },
 
@@ -583,6 +584,13 @@ const zhHans = {
       rowHeight: '行高（点）',
       moduleWidth: '模块宽度',
       security: '安全检查',
+    },
+    tlc39: {
+      content: '内容',
+      height: '高度 (点)',
+      moduleWidth: '模块宽度',
+      microPdfRowHeight: 'MicroPDF 行高',
+      microPdfRows: 'MicroPDF 行数',
     },
   },
 

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -45,6 +45,7 @@ const zhHant = {
     maxicode: 'Maxicode',
     micropdf417: 'MicroPDF417',
     codablock: 'CODABLOCK',
+    tlc39: 'TLC39',
     group: '群組',
   },
 
@@ -583,6 +584,13 @@ const zhHant = {
       rowHeight: '行高（點）',
       moduleWidth: '模組寬度',
       security: '安全檢查',
+    },
+    tlc39: {
+      content: '內容',
+      height: '高度 (點)',
+      moduleWidth: '模組寬度',
+      microPdfRowHeight: 'MicroPDF 列高',
+      microPdfRows: 'MicroPDF 列數',
     },
   },
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -36,6 +36,7 @@ import { codablock } from './codablock';
 import { upcEanExtension } from './upcEanExtension';
 import { code49 } from './code49';
 import { maxicode } from './maxicode';
+import { tlc39 } from './tlc39';
 import { symbol } from './symbol';
 
 export const BARCODE_1D_TYPES = new Set([
@@ -78,6 +79,7 @@ const _ObjectRegistry = {
   maxicode,
   micropdf417,
   codablock,
+  tlc39,
   // code-postal
   planet,
   postal,

--- a/src/registry/leafObject.ts
+++ b/src/registry/leafObject.ts
@@ -33,6 +33,7 @@ import type { CodablockProps } from './codablock';
 import type { UpcEanExtensionProps } from './upcEanExtension';
 import type { Code49Props } from './code49';
 import type { MaxicodeProps } from './maxicode';
+import type { Tlc39Props } from './tlc39';
 import type { SymbolProps } from './symbol';
 
 /** Single-branch shape for one registry type: the common base plus a
@@ -75,6 +76,7 @@ export type LeafObject =
   | Leaf<'upcEanExtension', UpcEanExtensionProps>
   | Leaf<'code49', Code49Props>
   | Leaf<'maxicode', MaxicodeProps>
+  | Leaf<'tlc39', Tlc39Props>
   | Leaf<'symbol', SymbolProps>;
 
 /** Every registered leaf-type discriminator. */

--- a/src/registry/panels.ts
+++ b/src/registry/panels.ts
@@ -28,6 +28,7 @@ import { aztecPanel } from './aztec.panel';
 import { maxicodePanel } from './maxicode.panel';
 import { micropdf417Panel } from './micropdf417.panel';
 import { codablockPanel } from './codablock.panel';
+import { tlc39Panel } from './tlc39.panel';
 import { planetPanel } from './planet.panel';
 import { postalPanel } from './postal.panel';
 import { boxPanel } from './box.panel';
@@ -65,6 +66,7 @@ const _ObjectPanels = {
   maxicode: maxicodePanel,
   micropdf417: micropdf417Panel,
   codablock: codablockPanel,
+  tlc39: tlc39Panel,
   planet: planetPanel,
   postal: postalPanel,
   box: boxPanel,

--- a/src/registry/registry-isolation.test.ts
+++ b/src/registry/registry-isolation.test.ts
@@ -3,8 +3,8 @@ import { ObjectRegistry, BARCODE_1D_TYPES, STACKED_2D_TYPES } from "./index";
 import { ObjectPanels } from "./panels";
 
 describe("registry isolation baseline", () => {
-  it("registers 34 object types", () => {
-    expect(Object.keys(ObjectRegistry)).toHaveLength(34);
+  it("registers 35 object types", () => {
+    expect(Object.keys(ObjectRegistry)).toHaveLength(35);
   });
 
   it("classifies 20 1D barcodes", () => {

--- a/src/registry/tlc39.panel.tsx
+++ b/src/registry/tlc39.panel.tsx
@@ -1,0 +1,61 @@
+import type { ObjectTypeUi } from "../types/ObjectType";
+import { useT } from "../lib/useT";
+import { inputCls, labelCls } from "../components/Properties/styles";
+import { RotationSelect } from "../components/Properties/RotationSelect";
+import { NumberInput } from "../components/Properties/NumberInput";
+import type { Tlc39Props } from "./tlc39";
+
+export const tlc39Panel: ObjectTypeUi<Tlc39Props> = {
+  PropertiesPanel: ({ obj, onChange }) => {
+    const t = useT();
+    const p = obj.props;
+    const loc = t.registry.tlc39;
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <label className={labelCls}>{loc.content}</label>
+          <input
+            className={inputCls}
+            value={p.content}
+            onChange={(e) => onChange({ content: e.target.value })}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <NumberInput
+            label={loc.height}
+            value={p.height}
+            min={1}
+            onChange={(height) => onChange({ height })}
+          />
+          <NumberInput
+            label={loc.moduleWidth}
+            value={p.moduleWidth}
+            min={1}
+            max={10}
+            onChange={(moduleWidth) => onChange({ moduleWidth })}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <NumberInput
+            label={loc.microPdfRowHeight}
+            value={p.microPdfRowHeight}
+            min={1}
+            max={255}
+            onChange={(microPdfRowHeight) => onChange({ microPdfRowHeight })}
+          />
+          <NumberInput
+            label={loc.microPdfRows}
+            value={p.microPdfRows}
+            min={1}
+            max={99}
+            onChange={(microPdfRows) => onChange({ microPdfRows })}
+          />
+        </div>
+
+        <RotationSelect value={p.rotation} onChange={(rotation) => onChange({ rotation })} />
+      </div>
+    );
+  },
+};

--- a/src/registry/tlc39.panel.tsx
+++ b/src/registry/tlc39.panel.tsx
@@ -49,7 +49,7 @@ export const tlc39Panel: ObjectTypeUi<Tlc39Props> = {
             label={loc.microPdfRows}
             value={p.microPdfRows}
             min={1}
-            max={99}
+            max={10}
             onChange={(microPdfRows) => onChange({ microPdfRows })}
           />
         </div>

--- a/src/registry/tlc39.ts
+++ b/src/registry/tlc39.ts
@@ -1,0 +1,54 @@
+import type { ObjectTypeCore } from "../types/ObjectType";
+import { fieldPos, fdFieldFor } from "./zplHelpers";
+import { commitBarcodeWidthHeightTransform } from "./transformHelpers";
+import { type ZplRotation } from "./rotation";
+
+export interface Tlc39Props {
+  /** TLC39 data: `<ECI>,<serial>`. ECI is 6 digits; serial is up to
+   *  25 alphanumeric characters (and renders as MicroPDF417 below the
+   *  Code 39 line). The comma is the canonical separator per spec. */
+  content: string;
+  /** Code 39 narrow bar width in dots (1-10, default from ^BY). */
+  moduleWidth: number;
+  /** Code 39 height in dots (the dominant visible component). */
+  height: number;
+  /** MicroPDF417 row height in dots (1-255, default 4). */
+  microPdfRowHeight: number;
+  /** MicroPDF417 row count. Zebra ^BT h2 accepts 1-99; firmware snaps
+   *  to a valid MicroPDF417 row count {4,6,8,10,12,15,20,26,32,38,44}.
+   *  Default 4. */
+  microPdfRows: number;
+  rotation: ZplRotation;
+}
+
+export const tlc39: ObjectTypeCore<Tlc39Props> = {
+  label: "TLC39",
+  icon: "▦T",
+  group: "code-2d",
+  bindable: true,
+  defaultProps: {
+    content: "123456,SERIAL",
+    moduleWidth: 2,
+    height: 40,
+    microPdfRowHeight: 4,
+    microPdfRows: 4,
+    rotation: "N",
+  },
+  defaultSize: { width: 200, height: 80 },
+
+  commitTransform: commitBarcodeWidthHeightTransform,
+
+  toZPL: (obj, ctx) => {
+    const p = obj.props;
+    return [
+      `^BY${p.moduleWidth}`,
+      fieldPos(obj),
+      // r1=2 (wide:narrow ratio) is the Zebra default; the editor does
+      // not expose it as a prop so we always emit the canonical value.
+      `^BT${p.rotation},${p.moduleWidth},2,${p.height},${p.microPdfRowHeight},${p.microPdfRows}`,
+      fdFieldFor(obj, p.content, ctx),
+    ]
+      .filter(Boolean)
+      .join("");
+  },
+};

--- a/src/registry/tlc39.ts
+++ b/src/registry/tlc39.ts
@@ -15,9 +15,9 @@ export interface Tlc39Props {
   height: number;
   /** MicroPDF417 row height in dots (1-255, default 4). */
   microPdfRowHeight: number;
-  /** MicroPDF417 row count. Zebra ^BT h2 accepts 1-99; firmware snaps
-   *  to a valid MicroPDF417 row count {4,6,8,10,12,15,20,26,32,38,44}.
-   *  Default 4. */
+  /** MicroPDF417 row count. Zebra ^BT h2 accepts 1-10 (narrower than
+   *  standalone ^BF since TLC39's linked MicroPDF is fixed at 4 columns);
+   *  firmware snaps to a valid row count {4,6,8,10}. Default 4. */
   microPdfRows: number;
   rotation: ZplRotation;
 }
@@ -44,8 +44,8 @@ export const tlc39: ObjectTypeCore<Tlc39Props> = {
     return [
       `^BY${p.moduleWidth}`,
       fieldPos(obj),
-      // r1=2 (wide:narrow ratio) is the Zebra default; the editor does
-      // not expose it as a prop so we always emit the canonical value.
+      // r1 (wide:narrow ratio) is not exposed as a prop; emit the
+      // canonical "2" so the field round-trips.
       `^BT${p.rotation},${p.moduleWidth},2,${p.height},${p.microPdfRowHeight},${p.microPdfRows}`,
       fdFieldFor(obj, p.content, ctx),
     ]

--- a/src/registry/tlc39.ts
+++ b/src/registry/tlc39.ts
@@ -5,8 +5,9 @@ import { type ZplRotation } from "./rotation";
 
 export interface Tlc39Props {
   /** TLC39 data: `<ECI>,<serial>`. ECI is 6 digits; serial is up to
-   *  25 alphanumeric characters (and renders as MicroPDF417 below the
-   *  Code 39 line). The comma is the canonical separator per spec. */
+   *  25 alphanumeric characters (rendered as MicroPDF417 stacked on
+   *  top of the Code 39 base line). Comma is the canonical separator
+   *  per spec. */
   content: string;
   /** Code 39 narrow bar width in dots (1-10, default from ^BY). */
   moduleWidth: number;


### PR DESCRIPTION
Promote main to prod for deploy.

Includes:
- TLC39 (^BT) composite barcode (28/28 barcode coverage)
- Parser change-prefix family (^CC/^CT/^CD)
- CI: run lint/test/build on main pushes and prod branch