### PR TITLE
fix(barcode): HRI start/stop glyphs and UPC-E zero normalization

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -21,6 +21,7 @@ import {
 import { objectRotation } from "../../registry/rotation";
 import { rotatedGroupTransform } from "./rotatedGroupTransform";
 import { buildEanUpcDigitOverlay } from "./eanUpcDigitNodes";
+import { buildCode1dStartStopGlyphs } from "./code1dHriOverlay";
 import {
   VERA_MONO_HRI_EM_PER_MODULE,
   VERA_MONO_HRI_CAP_TOP_PAD,
@@ -248,7 +249,8 @@ export function BarcodeObject({
     // Generic 1D subtracts this below the bars so the visible bar-to-cap gap
     // equals textGap and stays module-width-independent (see the constant).
     const glyphTopPad = textFontSize * VERA_MONO_HRI_CAP_TOP_PAD;
-    const displayText = hri?.formatHri?.(rawContent) ?? rawContent;
+    const checkDigit = (obj.props as { checkDigit?: boolean }).checkDigit;
+    const displayText = hri?.formatHri?.(rawContent, checkDigit) ?? rawContent;
     const isTextAbove = hri?.textAbove ?? false;
     // 3px floor matches textGap so HRI stays legible at very small
     // scales regardless of which dots value the spec calls for.
@@ -318,6 +320,8 @@ export function BarcodeObject({
         // ref stays undefined and the bars+text just scale together
         // during a rotated resize drag, a minor visual nit with no broken
         // print output.
+        const fontFamily =
+          resolveMwValue(hri?.fontFamily, moduleWidth) ?? HRI_FONT_A;
         const textY = isTextAbove
           ? ub.barTopPx - textFontSize - aboveGapPx
           : ub.barTopPx + ub.barH + textGap - glyphTopPad;
@@ -326,10 +330,21 @@ export function BarcodeObject({
         const bottomAlign = hri?.fontDots
           ? { height: textFontSize, verticalAlign: "bottom" as const }
           : {};
-        const fontFamily =
-          resolveMwValue(hri?.fontFamily, moduleWidth) ?? HRI_FONT_A;
-        overlayContent = (
+        // Code 11/93: keep the centered text as-is and only add the shape
+        // start/stop glyphs flanking it (Code 11 triangle, Code 93 square).
+        const startStopGlyphs = hri?.startStopGlyph
+          ? buildCode1dStartStopGlyphs({
+              text: displayText, fontFamily, fontSize: textFontSize,
+              barLeftPx: ub.barLeftPx, barW: ub.barW, textY,
+              glyph: hri.startStopGlyph,
+            })
+          : null;
+        // Keyed array (like the EAN path), not a fragment: a keyless data
+        // Text adjacent to keyed start/stop Text nodes of the same type makes
+        // react-konva mis-reconcile and drop the flanking ones (Code 39 *).
+        const dataText = (
           <Text
+            key="hri"
             ref={isUpright ? setTextRef : undefined}
             x={ub.barLeftPx} y={textY} width={Math.max(ub.barW, 1)}
             text={displayText} fontSize={textFontSize}
@@ -338,6 +353,7 @@ export function BarcodeObject({
             {...bottomAlign}
           />
         );
+        overlayContent = startStopGlyphs ? [dataText, ...startStopGlyphs] : dataText;
       }
 
       // Counter-scale only applies to upright Other 1D. textLocalY here

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -3,6 +3,7 @@
 
 import bwipjs from "bwip-js/browser";
 import { ObjectRegistry, type LeafObject } from "../../registry";
+import { upceData6FromFd } from "../../registry/hriFormatters";
 import type { LabelObject } from "../../types/Group";
 import type { Gs1DatabarProps } from "../../registry/gs1databar";
 import { objectRotation } from "../../registry/rotation";
@@ -179,7 +180,9 @@ export interface EanUpcHriFragment {
  *  number-system digit as the firmware does. Shared by the bars and HRI
  *  paths so both encode the identical symbol. */
 function rawEanUpc(type: EanUpcType, text: string): BwipRawLinear | null {
-  const encoded = type === "upce" && text.length === 6 ? `0${text}` : text;
+  // UPC-E: always feed bwip the canonical 7-digit form (NS 0 + 6 data),
+  // NS-aware so a content that already carries the prefix is not doubled.
+  const encoded = type === "upce" ? `0${upceData6FromFd(text)}` : text;
   try {
     const stack = bwipjs.raw({ bcid: type, text: encoded, includetext: true } as never) as BwipRawLinear[];
     return stack?.[0] ?? null;

--- a/src/components/Canvas/code1dHriOverlay.tsx
+++ b/src/components/Canvas/code1dHriOverlay.tsx
@@ -1,0 +1,85 @@
+import { Line, Rect, Text } from "react-konva";
+import type { ReactNode } from "react";
+import { VERA_MONO_HRI_CAP_TOP_PAD } from "./bwipConstants";
+
+// Monospace advance (cell width / em), used to estimate the centered HRI
+// text's width so the glyphs flank it (assumes a monospace fontFamily, which
+// the Vera/Font-A HRI is); the text itself is rendered unchanged.
+const MONO_ADVANCE = 0.6;
+// Cap band within the em box; matches the HRI text's glyphTopPad.
+const CAP_HEIGHT = 1 - 2 * VERA_MONO_HRI_CAP_TOP_PAD;
+// Triangle apex slightly obtuse (Labelary Code 11): width ~= height (~51deg).
+const TRI_W_RATIO = 0.95;
+const TRI_Y_SHIFT = 0.12;
+// Triangle height per cap, asymmetric: small start, larger stop.
+const TRI_H_START = 0.5;
+const TRI_H_STOP = 0.75;
+// Extra horizontal gap (per cell) so the triangle does not crowd the text.
+const TRI_GAP = 0.2;
+// Code 93 oblong: 0.5:1 aspect scaled to ~0.8, bottom-anchored to the baseline.
+const SQ_W = 0.4;
+const SQ_H = 0.8;
+// The font's asterisk sits high; push it down to center it on the digit row.
+const ASTERISK_Y_SHIFT = 0.2;
+// Stroke width per em for the drawn triangle/square outlines.
+const STROKE_RATIO = 0.06;
+
+type Glyph = "triangle" | "square" | "asterisk";
+
+interface BuildArgs {
+  /** The HRI text already rendered (centered) by BarcodeObject. */
+  text: string;
+  fontFamily: string;
+  fontSize: number;
+  /** Upright bar left edge and width in display px. */
+  barLeftPx: number;
+  barW: number;
+  /** Top y of the HRI text box. */
+  textY: number;
+  glyph: Glyph;
+}
+
+/** Start/stop markers flanking the centered HRI text: Code 11 triangle
+ *  (asymmetric, small start / large stop), Code 93 oblong square, Code 39
+ *  asterisk (a real glyph, but lowered to sit centered like Labelary). The
+ *  text stays rendered as-is; markers sit one cell-width past its edges. */
+export function buildCode1dStartStopGlyphs(a: BuildArgs): ReactNode[] {
+  const { text, fontFamily, fontSize, barLeftPx, barW, textY, glyph } = a;
+  const cellW = fontSize * MONO_ADVANCE;
+  const capTop = textY + fontSize * VERA_MONO_HRI_CAP_TOP_PAD;
+  const capH = fontSize * CAP_HEIGHT;
+  const stroke = Math.max(fontSize * STROKE_RATIO, 1);
+  const center = barLeftPx + barW / 2;
+  const textHalf = (text.length * cellW) / 2;
+  const triGap = glyph === "triangle" ? cellW * TRI_GAP : 0;
+  const startCx = center - textHalf - cellW / 2 - triGap;
+  const stopCx = center + textHalf + cellW / 2 + triGap;
+
+  const make = (key: string, cx: number, isStop: boolean): ReactNode => {
+    if (glyph === "asterisk") {
+      // Box must exceed the glyph's measured width or Konva drops the line
+      // (empty textArr -> 0x0, invisible); cellW alone is too tight.
+      return (
+        <Text key={key} x={cx - fontSize / 2} width={fontSize} y={textY + capH * ASTERISK_Y_SHIFT}
+          text="*" fontSize={fontSize} fontFamily={fontFamily}
+          align="center" wrap="none" fill="#000000" listening={false} />
+      );
+    }
+    if (glyph === "square") {
+      const w = capH * SQ_W, h = capH * SQ_H;
+      const cy = capTop + capH - h / 2; // bottom-anchored to the baseline
+      return (
+        <Rect key={key} x={cx - w / 2} y={cy - h / 2} width={w} height={h}
+          stroke="#000000" strokeWidth={stroke} listening={false} />
+      );
+    }
+    const h = capH * (isStop ? TRI_H_STOP : TRI_H_START), w = h * TRI_W_RATIO;
+    const cy = capTop + capH / 2 + capH * TRI_Y_SHIFT;
+    return (
+      <Line key={key} closed listening={false} stroke="#000000" strokeWidth={stroke}
+        points={[cx, cy - h / 2, cx - w / 2, cy + h / 2, cx + w / 2, cy + h / 2]} />
+    );
+  };
+
+  return [make("start", startCx, false), make("stop", stopCx, true)];
+}

--- a/src/components/Properties/LayerRow.tsx
+++ b/src/components/Properties/LayerRow.tsx
@@ -192,7 +192,7 @@ export function LayerRow({
       ) : (
         <span className="w-4 h-4 shrink-0" />
       )}
-      <span className="font-mono text-xs text-accent shrink-0 w-4 text-center">
+      <span className="font-mono text-xs text-accent shrink-0 w-4 text-center whitespace-nowrap">
         {groupRow ? '⊞' : def?.icon}
       </span>
       {boundVariable && (

--- a/src/lib/barcodeCheckDigits.test.ts
+++ b/src/lib/barcodeCheckDigits.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { code11CheckDigits } from './barcodeCheckDigits';
+
+// Verified against Labelary (^B1 ^FD..., HRI shows data + check digit(s)).
+describe('code11CheckDigits', () => {
+  it('computes C+K for "12345" (two=true): C=2, K=8', () => {
+    expect(code11CheckDigits('12345', true)).toBe('28');
+  });
+  it('computes only C for "12345" (two=false): C=2', () => {
+    expect(code11CheckDigits('12345', false)).toBe('2');
+  });
+  it('renders a value-10 check digit as the dash symbol', () => {
+    // "123": C = 3*1+2*2+1*3 = 10 -> "-"; K over "123-" = 4.
+    expect(code11CheckDigits('123', true)).toBe('-4');
+  });
+  it('cycles weights past length 10', () => {
+    // "12345678901" (e=N): C=4, K=10 -> "-".
+    expect(code11CheckDigits('12345678901', true)).toBe('4-');
+  });
+  it('skips non Code 11 characters instead of producing NaN', () => {
+    expect(code11CheckDigits('12A', true)).not.toMatch(/NaN/);
+  });
+});

--- a/src/lib/barcodeCheckDigits.ts
+++ b/src/lib/barcodeCheckDigits.ts
@@ -16,6 +16,27 @@ export function eanCheckDigit(digits: string, w0: number, w1: number): string {
   return String((10 - (sum % 10)) % 10);
 }
 
+/** Code 11 weighted mod-11 over `s` right-to-left; weights cycle 1..maxWeight.
+ *  A result of 10 renders as the dash symbol, Code 11's value-10 character. */
+function code11Weighted(s: string, maxWeight: number): string {
+  let sum = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[s.length - 1 - i] ?? "0";
+    const val = ch === "-" ? 10 : parseInt(ch, 10);
+    if (Number.isNaN(val)) continue; // skip non Code 11 chars instead of NaN
+    sum += val * ((i % maxWeight) + 1);
+  }
+  const r = sum % 11;
+  return r === 10 ? "-" : String(r);
+}
+
+/** Code 11 check digit(s): the C digit, plus the K digit when `two` (the
+ *  ^B1 e=N case). Verified: "12345" -> C=2, K=8. */
+export function code11CheckDigits(data: string, two: boolean): string {
+  const c = code11Weighted(data, 10);
+  return two ? c + code11Weighted(data + c, 9) : c;
+}
+
 /** Compute the UPC-E check digit from the 6 compressed data digits. */
 export function upceCheckDigit(digits6: string): string {
   const [vA, vB, vC, vD, vE, vF] = digits6.padEnd(6, "0").split("");

--- a/src/registry/code11.ts
+++ b/src/registry/code11.ts
@@ -1,4 +1,5 @@
 import { createBarcode1DCore, type Barcode1DCoreConfig } from './barcode1d';
+import { formatCode11Hri } from './hriFormatters';
 export type { Barcode1DProps as Code11Props } from "./barcode1d";
 
 export const code11CoreConfig: Barcode1DCoreConfig = {
@@ -11,6 +12,7 @@ export const code11CoreConfig: Barcode1DCoreConfig = {
     const check = p.checkDigit ? "Y" : "N";
     return `^B1${p.rotation},${check},${p.height},${interp},N`;
   },
+  hri: { formatHri: formatCode11Hri, startStopGlyph: 'triangle' },
 };
 
 export const code11 = createBarcode1DCore(code11CoreConfig);

--- a/src/registry/code39.ts
+++ b/src/registry/code39.ts
@@ -1,5 +1,4 @@
 import { createBarcode1DCore, type Barcode1DCoreConfig } from './barcode1d';
-import { formatCode39Hri } from './hriFormatters';
 export type { Barcode1DProps as Code39Props } from './barcode1d';
 
 export const code39CoreConfig: Barcode1DCoreConfig = {
@@ -12,7 +11,9 @@ export const code39CoreConfig: Barcode1DCoreConfig = {
     const check = p.checkDigit ? 'Y' : 'N';
     return `^B3${p.rotation},${check},${p.height},${interp},N`;
   },
-  hri: { formatHri: formatCode39Hri },
+  // Start/stop is the asterisk; rendered as flanking glyphs (lowered to sit
+  // centered like Labelary), so the data text carries no `*`.
+  hri: { startStopGlyph: 'asterisk' },
 };
 
 export const code39 = createBarcode1DCore(code39CoreConfig);

--- a/src/registry/code93.ts
+++ b/src/registry/code93.ts
@@ -11,6 +11,9 @@ export const code93CoreConfig: Barcode1DCoreConfig = {
     const check = p.checkDigit ? 'Y' : 'N';
     return `^BA${p.rotation},${p.height},${interp},N,${check}`;
   },
+  // Labelary draws Code 93's start/stop as a square; data shows without
+  // the (non-displayed) check chars, so no formatHri.
+  hri: { startStopGlyph: 'square' },
 };
 
 export const code93 = createBarcode1DCore(code93CoreConfig);

--- a/src/registry/hriFormatters.test.ts
+++ b/src/registry/hriFormatters.test.ts
@@ -5,7 +5,7 @@ import {
   formatUpcaHri,
   formatUpceHri,
   upceData6FromFd,
-  formatCode39Hri,
+  formatCode11Hri,
   formatLogmarsHri,
   formatUpcEanExtensionHri,
 } from './hriFormatters';
@@ -43,6 +43,21 @@ describe('HRI formatters', () => {
       expect(r[0]).toBe('0');
       expect(r.slice(1, 7)).toBe('012345');
     });
+    it('is idempotent: NS-prefixed content does not accumulate zeros', () => {
+      expect(formatUpceHri('0012345')).toBe(formatUpceHri('012345'));
+    });
+  });
+
+  describe('formatCode11Hri', () => {
+    it('appends C+K check digits when checkDigit is off (e=N, two checks)', () => {
+      expect(formatCode11Hri('12345', false)).toBe('1234528');
+    });
+    it('appends only the C check digit when checkDigit is on (e=Y, one check)', () => {
+      expect(formatCode11Hri('12345', true)).toBe('123452');
+    });
+    it('defaults to two check digits', () => {
+      expect(formatCode11Hri('12345')).toBe('1234528');
+    });
   });
 
   describe('upceData6FromFd', () => {
@@ -54,12 +69,6 @@ describe('HRI formatters', () => {
     });
     it('strips number-system and check digit from an 8-digit payload', () => {
       expect(upceData6FromFd('00123455')).toBe('012345');
-    });
-  });
-
-  describe('formatCode39Hri', () => {
-    it('wraps content with start/stop asterisks', () => {
-      expect(formatCode39Hri('CODE39')).toBe('*CODE39*');
     });
   });
 

--- a/src/registry/hriFormatters.ts
+++ b/src/registry/hriFormatters.ts
@@ -1,4 +1,4 @@
-import { eanCheckDigit, upceCheckDigit } from '../lib/barcodeCheckDigits';
+import { code11CheckDigits, eanCheckDigit, upceCheckDigit } from '../lib/barcodeCheckDigits';
 
 /**
  * HRI text formatters per 1D symbology. Each takes the user-provided
@@ -27,7 +27,7 @@ export function formatUpcaHri(content: string): string {
 }
 
 /** The 6 UPC-E data digits (number system and check digit excluded). */
-export function upceData6(content: string): string {
+function upceData6(content: string): string {
   return content.replace(/\D/g, "").slice(0, 6).padEnd(6, "0");
 }
 
@@ -40,12 +40,15 @@ export function upceData6FromFd(fd: string): string {
 }
 
 export function formatUpceHri(content: string): string {
-  const d6 = upceData6(content);
+  const d6 = upceData6FromFd(content);
   return `0${d6}${upceCheckDigit(d6)}`;
 }
 
-export function formatCode39Hri(content: string): string {
-  return `*${content}*`;
+/** Code 11 HRI: data plus its check digit(s). ^B1 e=N encodes two (C+K),
+ *  e=Y encodes one (C); checkDigit=true maps to e=Y, hence `two = !checkDigit`.
+ *  The start/stop triangles are drawn as shapes, not part of this string. */
+export function formatCode11Hri(content: string, checkDigit?: boolean): string {
+  return `${content}${code11CheckDigits(content, !checkDigit)}`;
 }
 
 const LOGMARS_CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%';

--- a/src/registry/upce.ts
+++ b/src/registry/upce.ts
@@ -1,5 +1,5 @@
 import { createBarcode1DCore, type Barcode1DCoreConfig } from './barcode1d';
-import { formatUpceHri, upceData6 } from './hriFormatters';
+import { formatUpceHri, upceData6FromFd } from './hriFormatters';
 export type { Barcode1DProps as UpcEProps } from './barcode1d';
 
 export const upceCoreConfig: Barcode1DCoreConfig = {
@@ -15,10 +15,10 @@ export const upceCoreConfig: Barcode1DCoreConfig = {
     return `^B9${p.rotation},${p.height},${interp},N`;
   },
   hri: { formatHri: formatUpceHri },
-  // ^B9 requires the number-system digit in ^FD; without it Labelary lints
-  // and re-pads. Spec allows NS 0 or 1, but the model stores only the 6 data
-  // digits, so we assume 0 (NS 1 round-trips lossily, see follow-up ticket).
-  fdContent: (c) => `0${upceData6(c)}`,
+  // ^B9 needs the number-system digit in ^FD (else Labelary lints/re-pads).
+  // NS-aware so an already-prefixed content is not double-prefixed. NS
+  // assumed 0 (spec allows 0 or 1; NS 1 round-trips lossily, see ticket).
+  fdContent: (c) => `0${upceData6FromFd(c)}`,
 };
 
 export const upce = createBarcode1DCore(upceCoreConfig);

--- a/src/types/ZplEmit.ts
+++ b/src/types/ZplEmit.ts
@@ -35,8 +35,13 @@ export interface HriBehavior {
   textAbove?: boolean;
   /** Bar-to-text gap in dots; function form for moduleWidth dependence (^BS). */
   aboveGapDots?: number | ((moduleWidth: number) => number);
-  /** Transform raw content for display; default identity. */
-  formatHri?: (content: string) => string;
+  /** Transform raw content for display; default identity. `checkDigit` is
+   *  the symbology's check-digit flag (Code 11 shows 1 vs 2 check digits). */
+  formatHri?: (content: string, checkDigit?: boolean) => string;
+  /** Start/stop marker flanking the HRI text: Code 11 triangle and Code 93
+   *  square are shapes (no font glyph); Code 39 asterisk is a real glyph but
+   *  rendered as a flanking node so it can be lowered to sit centered. */
+  startStopGlyph?: "triangle" | "square" | "asterisk";
   /** Override the generic per-module em sizing with explicit per-module
    *  em font dots (^BS reuses the EAN OCR-B step table). */
   fontDots?: (moduleWidth: number) => number;


### PR DESCRIPTION
Code 11/93/39 HRI render their start/stop markers (triangle/square/asterisk) and Code 11 check digits like Labelary; UPC-E content normalization is idempotent.