### PR TITLE
feat(zpl): round-trip fidelity for opaque ^GF and label geometry

### DIFF
--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -12,6 +12,7 @@ import {
   isDefaultClockChars,
 } from './fcTemplate';
 import { getObjectStringContent } from './variableBinding';
+import { formatLabelMetaComment } from './zplLabelMeta';
 import type { ClockOffset, CustomFontMapping, LabelConfig } from '../types/LabelConfig';
 import type { ZplEmitContext } from '../types/ZplEmit';
 import type { Variable } from '../types/Variable';
@@ -236,6 +237,13 @@ export function generateZPL(
   }
 
   lines.push('^XA');
+  // Leading geometry sidecar: recovers exact width/height/dpmm on re-import,
+  // which plain ^PW/^LL (dots, no dpmm) can't. A comment, so print is unaffected.
+  lines.push(formatLabelMetaComment({
+    dpmm: label.dpmm,
+    widthMm: label.widthMm,
+    heightMm: label.heightMm,
+  }));
   // a=D since model is dots-canonical.
   if (label.muResampling) {
     lines.push(`^MUD,${label.muResampling.formatDpi},${label.muResampling.outputDpi}`);

--- a/src/lib/zplLabelMeta.test.ts
+++ b/src/lib/zplLabelMeta.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatLabelMetaComment,
+  parseLabelMetaComment,
+  LABEL_META_PREFIX,
+} from "./zplLabelMeta";
+
+describe("zplLabelMeta", () => {
+  it("round-trips dpmm/width/height through format → parse", () => {
+    const meta = { dpmm: 12, widthMm: 57, heightMm: 32 };
+    const line = formatLabelMetaComment(meta);
+    expect(line).toBe(`^FX${LABEL_META_PREFIX}{"dpmm":12,"wMm":57,"hMm":32}^FS`);
+    // parse consumes the comment BODY (text after ^FX), before the ^FS.
+    expect(parseLabelMetaComment(line.slice(3, line.length - 3))).toEqual(meta);
+  });
+
+  it("emits a caret/tilde-free comment body (spec-safe inside ^FX)", () => {
+    const line = formatLabelMetaComment({ dpmm: 8, widthMm: 100, heightMm: 60 });
+    expect(line.slice(3, line.length - 3)).not.toMatch(/[\^~]/);
+  });
+
+  it("returns null for a non-sentinel comment", () => {
+    expect(parseLabelMetaComment("a human note")).toBeNull();
+    expect(parseLabelMetaComment("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON after the prefix", () => {
+    expect(parseLabelMetaComment(`${LABEL_META_PREFIX}{not json`)).toBeNull();
+  });
+
+  it("rejects an out-of-set dpmm", () => {
+    expect(
+      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":10,"wMm":100,"hMm":60}`),
+    ).toBeNull();
+  });
+
+  it("rejects out-of-range or non-numeric mm", () => {
+    expect(
+      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":0,"hMm":60}`),
+    ).toBeNull();
+    expect(
+      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":100,"hMm":99999}`),
+    ).toBeNull();
+    expect(
+      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":"x","hMm":60}`),
+    ).toBeNull();
+  });
+
+  it("tolerates surrounding whitespace on the body", () => {
+    expect(
+      parseLabelMetaComment(`  ${LABEL_META_PREFIX}{"dpmm":8,"wMm":100,"hMm":60}  `),
+    ).toEqual({ dpmm: 8, widthMm: 100, heightMm: 60 });
+  });
+});

--- a/src/lib/zplLabelMeta.ts
+++ b/src/lib/zplLabelMeta.ts
@@ -1,0 +1,53 @@
+// Label-geometry sidecar carried in a leading ^FX comment. Plain ZPL can't
+// express dpmm and rounds mm through ^PW/^LL dots, so a re-imported label loses
+// the exact width/height/dpmm. We stash them in a namespaced comment the
+// printer and Labelary ignore, and recover them on import.
+
+import { isDpmm } from "../types/LabelConfig";
+
+/** Namespace so a foreign ^FX comment can't be mistaken for our metadata. */
+export const LABEL_META_PREFIX = "ZPLLAB:";
+
+const MM_MIN = 1;
+const MM_MAX = 5000;
+
+export interface LabelMeta {
+  dpmm: number;
+  widthMm: number;
+  heightMm: number;
+}
+
+const isMm = (v: unknown): v is number =>
+  typeof v === "number" && Number.isFinite(v) && v >= MM_MIN && v <= MM_MAX;
+
+/** The leading sidecar line. Numbers only, no `^`/`~`, so it is a valid ^FX
+ *  comment terminated by ^FS (verified against the ZPL spec and Labelary). */
+export function formatLabelMetaComment(meta: LabelMeta): string {
+  const body = JSON.stringify({
+    dpmm: meta.dpmm,
+    wMm: meta.widthMm,
+    hMm: meta.heightMm,
+  });
+  return `^FX${LABEL_META_PREFIX}${body}^FS`;
+}
+
+/** Parse a ^FX comment body (text after `^FX`) into validated label meta, or
+ *  null if it is not our sentinel or any field is out of range. Defensive
+ *  against foreign comments and corrupt payloads. */
+export function parseLabelMetaComment(commentBody: string): LabelMeta | null {
+  const trimmed = commentBody.trim();
+  if (!trimmed.startsWith(LABEL_META_PREFIX)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed.slice(LABEL_META_PREFIX.length));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const { dpmm, wMm, hMm } = parsed as Record<string, unknown>;
+  // Emit assumes dpmm ∈ DPMM_VALUES (the only densities the UI produces); keep
+  // emit and this guard on the same source of truth.
+  if (typeof dpmm !== "number" || !isDpmm(dpmm)) return null;
+  if (!isMm(wMm) || !isMm(hMm)) return null;
+  return { dpmm, widthMm: wMm, heightMm: hMm };
+}

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -919,6 +919,18 @@ describe('parseZPL — ^GFA graphic field', () => {
     expect(importReport.browserLimit).toHaveLength(0);
   });
 
+  it('falls back to a square when an opaque ^GF c is under one full row (height would floor to 0)', () => {
+    // c=1 < d=2 -> floor(1/2)=0; the placeholder must stay grabbable, so height
+    // falls back to the square width (d*8) instead of a 0-dot sliver.
+    const b64 = btoa('not a valid zlib stream');
+    const field = `:Z64:${b64}:${testCrc16(b64)}`;
+    const { objects } = parseZPL(`^XA^FO0,0^GFC,4,1,2,${field}^FS^XZ`, 8);
+    expect(objects).toHaveLength(1);
+    const p = props(objects[0]);
+    expect(p.widthDots).toBe(16);
+    expect(p.heightDots).toBe(16);
+  });
+
   it('normalizes the opaque ^GF header delimiter so a ^CD source survives re-parse', () => {
     // ^CD; switches the delimiter to ';'. The generator never re-emits ^CD, so
     // the preserved header is rebuilt with commas to round-trip a second time.

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { zlibSync } from 'fflate';
 import { parseZPL } from './zplParser';
+import { formatLabelMetaComment } from './zplLabelMeta';
 import { props } from '../test/helpers';
 
 /** CRC-16/XMODEM; same variant used by the parser to validate
@@ -898,18 +899,34 @@ describe('parseZPL — ^GFA graphic field', () => {
     expect(importReport.partial).not.toContain('^GF');
   });
 
-  it('records :Z64: with corrupt deflate stream as browserLimit', () => {
-    // Valid base64 but garbage bytes that fflate will reject as a deflate
-    // stream. CRC must match so we know the failure is in inflate, not the
-    // wrapper-shape detection.
+  it('preserves an undecodable :Z64: ^GF verbatim, sizing height from c not b', () => {
+    // Valid base64, matching CRC, but garbage bytes that fflate rejects as a
+    // deflate stream → can't decode, so preserve the command verbatim instead
+    // of dropping it. b=4 (compressed stream length) is deliberately smaller
+    // than c=16 (uncompressed field count); height must come from c/d, not b/d.
     const b64 = btoa('not a valid zlib stream');
     const field = `:Z64:${b64}:${testCrc16(b64)}`;
     const { objects, importReport } = parseZPL(
-      `^XA^FO0,0^GFC,8,8,1,${field}^FS^XZ`,
+      `^XA^FO0,0^GFC,4,16,2,${field}^FS^XZ`,
       8,
     );
-    expect(objects).toHaveLength(0);
-    expect(importReport.browserLimit.some((s) => s.startsWith('^GF'))).toBe(true);
+    expect(objects).toHaveLength(1);
+    const p = props(objects[0]);
+    expect(p.widthDots).toBe(16); // d=2 → 2*8
+    expect(p.heightDots).toBe(8); // c/d = 16/2, not b/d = 4/2
+    expect(p.rawGf).toBe(`^GFC,4,16,2,${field}`);
+    expect(importReport.partial).toContain('^GF');
+    expect(importReport.browserLimit).toHaveLength(0);
+  });
+
+  it('normalizes the opaque ^GF header delimiter so a ^CD source survives re-parse', () => {
+    // ^CD; switches the delimiter to ';'. The generator never re-emits ^CD, so
+    // the preserved header is rebuilt with commas to round-trip a second time.
+    const b64 = btoa('not a real zlib stream');
+    const field = `:Z64:${b64}:${testCrc16(b64)}`;
+    const { objects } = parseZPL(`^XA^FO0,0^CD;^GFC;4;16;2;${field}^FS^XZ`, 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).rawGf).toBe(`^GFC,4,16,2,${field}`);
   });
 
   it('creates an image object from compressed ^GFA data', () => {
@@ -920,6 +937,38 @@ describe('parseZPL — ^GFA graphic field', () => {
     const { objects } = parseZPL('^XA^FO0,0^GFA,2,2,1,FF,:^FS^XZ', 8);
     expect(objects).toHaveLength(1);
     expect(objects[0]?.type).toBe('image');
+  });
+});
+
+// ── ^FX label metadata sidecar ────────────────────────────────────────────────
+
+describe('parseZPL — ^FX label metadata sidecar', () => {
+  it('recovers dpmm/width/height from the leading sidecar, overriding ^PW/^LL', () => {
+    const zpl = `^XA${formatLabelMetaComment({ dpmm: 12, widthMm: 57, heightMm: 32 })}^PW800^LL600^FO0,0^A0N,30,0^FDx^FS^XZ`;
+    // External dpmm 8 is deliberately wrong; the sidecar must win.
+    const { labelConfig } = parseZPL(zpl, 8);
+    expect(labelConfig.dpmm).toBe(12);
+    expect(labelConfig.widthMm).toBe(57);
+    expect(labelConfig.heightMm).toBe(32);
+  });
+
+  it('does not attach the sidecar as the next object comment', () => {
+    const zpl = `^XA${formatLabelMetaComment({ dpmm: 8, widthMm: 100, heightMm: 60 })}^FO0,0^A0N,30,0^FDx^FS^XZ`;
+    const { objects } = parseZPL(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.comment).toBeUndefined();
+  });
+
+  it('ignores a sidecar that appears after an object (non-leading slot)', () => {
+    const zpl = `^XA^FO0,0^A0N,30,0^FDx^FS${formatLabelMetaComment({ dpmm: 24, widthMm: 20, heightMm: 20 })}^FO0,50^A0N,30,0^FDy^FS^XZ`;
+    const { labelConfig, objects } = parseZPL(zpl, 8);
+    expect(labelConfig.dpmm).not.toBe(24);
+    expect(props(objects[1]).content).toBe('y');
+  });
+
+  it('keeps a foreign ^FX as a normal object comment', () => {
+    const { objects } = parseZPL('^XA^FXserial run 42^FO0,0^A0N,30,0^FDx^FS^XZ', 8);
+    expect(objects[0]?.comment).toBe('serial run 42');
   });
 });
 
@@ -1812,9 +1861,13 @@ describe('parseZPL — importReport.unknown', () => {
     expect(importReport.unknown.some((s) => s.startsWith('^XX'))).toBe(true);
   });
 
-  it('records ^GFB (unsupported GF format) in importReport.browserLimit', () => {
-    const { importReport } = parseZPL('^XA^FO0,0^GFB,32,32,4,AABBCCDD^FS^XZ', 8);
-    expect(importReport.browserLimit.some((s) => s.startsWith('^GF'))).toBe(true);
+  it('preserves an undecodable ^GFB format as an opaque verbatim image', () => {
+    const { objects, importReport } = parseZPL('^XA^FO0,0^GFB,32,32,4,AABBCCDD^FS^XZ', 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('image');
+    expect(props(objects[0]).rawGf).toBe('^GFB,32,32,4,AABBCCDD');
+    expect(importReport.partial).toContain('^GF');
+    expect(importReport.browserLimit.some((s) => s.startsWith('^GF'))).toBe(false);
     expect(importReport.unknown.some((s) => s.startsWith('^GF'))).toBe(false);
   });
 

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CLOCK_CHARS } from "./fcTemplate";
+import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
 import { tokenize } from "./zplParser/helpers";
 import { createParserState } from "./zplParser/context";
 import { createFlushField } from "./zplParser/flushField";
@@ -48,10 +49,21 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
   const resetComment: Handler = (_, rest) => {
     s.comment.pending = rest.trim() || undefined;
   };
+  // Our geometry sidecar, consumed (not shown as an object comment) from the
+  // leading slot only, so a stray body ^FX can't rewrite the label settings.
+  // Holder object so the closure write survives TS flow narrowing.
+  const labelMeta: { value: LabelMeta | null } = { value: null };
   // Multi-line ^FX before a field accumulate; XA/XZ reset at label boundaries.
   const appendComment: Handler = (_, rest) => {
     const next = rest.trim();
     if (!next) return;
+    if (!labelMeta.value && objects.length === 0) {
+      const meta = parseLabelMetaComment(next);
+      if (meta) {
+        labelMeta.value = meta;
+        return;
+      }
+    }
     s.comment.pending = s.comment.pending ? `${s.comment.pending}\n${next}` : next;
   };
 
@@ -93,6 +105,14 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
       skipped.push(token);
       unknown.push(token);
     }
+  }
+
+  // Apply the geometry sidecar last so it wins over ^PW/^LL-derived mm and
+  // restores dpmm, which plain ZPL can't carry.
+  if (labelMeta.value) {
+    labelConfig.dpmm = labelMeta.value.dpmm;
+    labelConfig.widthMm = labelMeta.value.widthMm;
+    labelConfig.heightMm = labelMeta.value.heightMm;
   }
 
   // pageIndex stays 0; zplImportService fills it per ^XA…^XZ block.

--- a/src/lib/zplParser/handlers/graphics.ts
+++ b/src/lib/zplParser/handlers/graphics.ts
@@ -210,6 +210,9 @@ export function createGraphicsHandlers(
         // delimiter so a ^CD source still round-trips (generator never re-emits ^CD).
         const gfFieldCount = int(gfParams[1], 0);
         const opaqueWidth = gfBytesPerRow * 8;
+        // Malformed c (<=0 or under one full row, flooring to a 0-dot sliver)
+        // falls back to a square so the placeholder stays grabbable.
+        const opaqueHeight = gfFieldCount > 0 ? Math.floor(gfFieldCount / gfBytesPerRow) : 0;
         s.result.partialCmds.add("^GF");
         s.result.objects.push(
           makeObj(
@@ -219,8 +222,7 @@ export function createGraphicsHandlers(
             {
               imageId: "",
               widthDots: opaqueWidth,
-              // Fall back to a square (grabbable) placeholder for malformed c<=0.
-              heightDots: gfFieldCount > 0 ? Math.floor(gfFieldCount / gfBytesPerRow) : opaqueWidth,
+              heightDots: opaqueHeight > 0 ? opaqueHeight : opaqueWidth,
               threshold: 128,
               rawGf: `^GF${format},${gfParams[0]},${gfParams[1]},${gfParams[2]},${gfRawData}`,
             } satisfies ImageProps,

--- a/src/lib/zplParser/handlers/graphics.ts
+++ b/src/lib/zplParser/handlers/graphics.ts
@@ -194,7 +194,6 @@ export function createGraphicsHandlers(
         return;
       }
 
-      const gfSummary = `^GF${rest.slice(0, IMPORT_FINDING_PAYLOAD_LIMIT)}…`;
       // Pass bytes-headers verbatim so re-export keeps the firmware buffer hint.
       const gfImage = decodeGraphicToImage(
         gfRawData,
@@ -205,7 +204,30 @@ export function createGraphicsHandlers(
         `imported_${crypto.randomUUID().slice(0, 8)}.png`,
       );
       if (!gfImage) {
-        pushBrowserLimit(s.result, gfSummary);
+        // Undecodable, but the header still describes the bitmap, so preserve
+        // the field verbatim instead of dropping it. Height is param c (field
+        // count), not b (compressed length). Rebuild the header with the default
+        // delimiter so a ^CD source still round-trips (generator never re-emits ^CD).
+        const gfFieldCount = int(gfParams[1], 0);
+        const opaqueWidth = gfBytesPerRow * 8;
+        s.result.partialCmds.add("^GF");
+        s.result.objects.push(
+          makeObj(
+            "image",
+            s.field.x,
+            s.field.y,
+            {
+              imageId: "",
+              widthDots: opaqueWidth,
+              // Fall back to a square (grabbable) placeholder for malformed c<=0.
+              heightDots: gfFieldCount > 0 ? Math.floor(gfFieldCount / gfBytesPerRow) : opaqueWidth,
+              threshold: 128,
+              rawGf: `^GF${format},${gfParams[0]},${gfParams[1]},${gfParams[2]},${gfRawData}`,
+            } satisfies ImageProps,
+            getPosType(s.field),
+            takeComment(),
+          ),
+        );
         return;
       }
       if (!gfImage.crcOk) s.result.partialCmds.add("^GF");

--- a/src/registry/image.ts
+++ b/src/registry/image.ts
@@ -19,6 +19,10 @@ export interface ImageProps {
   threshold: number;
   /** Cached GFA ZPL string; regenerated when image/width/threshold changes */
   _gfaCache?: string;
+  /** Verbatim `^GF` for graphics we can't decode into an editable bitmap
+   *  (binary B, compressed C, `:Z64:`, ACS run-length); re-emitted as-is to
+   *  round-trip. Mutually exclusive with a cached `imageId`. */
+  rawGf?: string;
   /** When set, the image is uploaded once via `~DY` (preamble) and referenced
    *  per-instance via `^XG`. Set by the parser when a ZPL stream uses the
    *  upload+recall pattern, preserved on re-export. Without this the image
@@ -100,6 +104,9 @@ export const image: ObjectTypeCore<ImageProps> = {
   // _gfaCache always cleared; for cached images the hex needs regen at
   // the new width; for placeholders it's empty anyway.
   commitTransform: (obj, ctx) => {
+    // Opaque verbatim graphics carry fixed bytes we can't re-encode, so the
+    // box size is locked; ignore the resize.
+    if (obj.props.rawGf) return {};
     const { sx, sy, snap } = ctx;
     const cached = getImage(obj.props.imageId);
     const widthDots = (scale: number): number =>
@@ -122,6 +129,9 @@ export const image: ObjectTypeCore<ImageProps> = {
 
   toZPL: (obj) => {
     const p = obj.props;
+    // Opaque graphic: re-emit the original ^GF verbatim at the (possibly moved)
+    // field position. The bytes were never decoded, so there's nothing to regen.
+    if (p.rawGf) return `${fieldPos(obj)}${p.rawGf}^FS`;
     // Recall path: upload happened in the preamble; here we just reference
     // it via ^XG. The `.GRF` extension is implicit on `~DY{path},A,G,…`;
     // Zebra firmware persists the file as `path.GRF` and `^XG` resolves

--- a/src/test/zplRoundtrip.test.ts
+++ b/src/test/zplRoundtrip.test.ts
@@ -584,3 +584,51 @@ describe('parseZPL — real-world structural commands are silently ignored', () 
     expect(importReport.unknown.some((s) => s.startsWith('^XF'))).toBe(true);
   });
 });
+
+// ── opaque ^GF pass-through ──────────────────────────────────────────────────
+
+/** CRC-16/XMODEM, matching the parser's :Z64: wrapper check, so the corrupt
+ *  payload passes wrapper validation and fails only at inflate. */
+function crc16(s: string): string {
+  let crc = 0;
+  for (const ch of s) {
+    crc ^= ch.charCodeAt(0) << 8;
+    for (let j = 0; j < 8; j++)
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+  }
+  return crc.toString(16).padStart(4, '0').toUpperCase();
+}
+
+describe('round-trip — label geometry sidecar', () => {
+  it('recovers dpmm + exact mm even when re-parsed at a different dpmm', () => {
+    const label: LabelConfig = { widthMm: 57, heightMm: 32, dpmm: 12 };
+    const zpl = generateZPL(label, []);
+    expect(zpl).toContain('^FXZPLLAB:');
+    // Re-parse at the wrong external dpmm: ^PW/^LL alone would give 85.5×48mm
+    // at 8dpmm, but the sidecar restores the authored geometry exactly.
+    const parsed = parseZPL(zpl, 8);
+    expect(parsed.labelConfig.dpmm).toBe(12);
+    expect(parsed.labelConfig.widthMm).toBe(57);
+    expect(parsed.labelConfig.heightMm).toBe(32);
+  });
+});
+
+describe('round-trip — opaque ^GF pass-through', () => {
+  // Valid wrapper + matching CRC but garbage deflate bytes: we can't decode it,
+  // so the command is preserved verbatim instead of dropped.
+  const b64 = btoa('not a real zlib stream');
+  const field = `:Z64:${b64}:${crc16(b64)}`;
+  const ZPL = `^XA^FO40,60^GFC,4,16,2,${field}^FS^XZ`;
+
+  it('re-emits the undecodable ^GF verbatim and survives re-parse', () => {
+    const { first, second, regenerated } = roundtrip(ZPL);
+    expect(first.objects).toHaveLength(1);
+    expect(props(first.objects[0]).rawGf).toBe(`^GFC,4,16,2,${field}`);
+    expect(regenerated).toContain(`^GFC,4,16,2,${field}`);
+    // Idempotent: same opaque image at the same origin after a full round-trip.
+    expect(second.objects).toHaveLength(1);
+    expect(props(second.objects[0]).rawGf).toBe(`^GFC,4,16,2,${field}`);
+    expect(defined(second.objects[0]).x).toBe(40);
+    expect(defined(second.objects[0]).y).toBe(60);
+  });
+});

--- a/src/types/LabelConfig.ts
+++ b/src/types/LabelConfig.ts
@@ -43,6 +43,13 @@ export const PRINT_ORIENTATION_VALUES = ['N', 'I'] as const;
 export type PrintOrientation = (typeof PRINT_ORIENTATION_VALUES)[number];
 export const isPrintOrientation = makeEnumGuard(PRINT_ORIENTATION_VALUES);
 
+/** Print densities Zebra ships (152/203/300/600 dpi). The label settings UI
+ *  offers exactly these; the ZPL geometry sidecar validates against the set. */
+export const DPMM_VALUES = [6, 8, 12, 24] as const;
+export type Dpmm = (typeof DPMM_VALUES)[number];
+export const isDpmm = (n: number): n is Dpmm =>
+  (DPMM_VALUES as readonly number[]).includes(n);
+
 /** Numeric ranges shared between Zod schema, parser clamps and UI inputs. */
 export const SPEED_RANGE = { min: 2, max: 14 } as const;
 export const DARKNESS_PERMANENT_RANGE = { min: -30, max: 30 } as const;


### PR DESCRIPTION
Preserve undecodable ^GF verbatim instead of dropping, and embed a leading ^FX sidecar so dpmm and exact mm survive ZPL re-import.