### PR TITLE
feat(layout): collapsible left/right sidebars with re-open rail

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -33,6 +33,8 @@ import {
   XMarkIcon,
   SunIcon,
   MoonIcon,
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
 } from "@heroicons/react/16/solid";
 import { useLabelStore, useHistory, selectLabelaryNoticeRequired } from "../store/labelStore";
 import { LabelaryNoticeModal } from "./Output/LabelaryNoticeModal";
@@ -47,6 +49,33 @@ import { useDesignFileActions } from "../hooks/useDesignFileActions";
 import { useCsvImportActions } from "../hooks/useCsvImportActions";
 import { useZplImportExport } from "../hooks/useZplImportExport";
 import { useOutputPanel, OUTPUT_DEFAULT_H } from "../hooks/useOutputPanel";
+import { useCollapsiblePanel } from "../hooks/useCollapsiblePanel";
+
+/** Thin clickable rail shown in place of a collapsed side panel; clicking it
+ *  brings the panel back. Chevrons point toward the canvas (the panel's slot). */
+function ExpandStrip({
+  side,
+  onExpand,
+  title,
+}: {
+  side: "left" | "right";
+  onExpand: () => void;
+  title: string;
+}) {
+  const Icon = side === "left" ? ChevronDoubleRightIcon : ChevronDoubleLeftIcon;
+  return (
+    <button
+      onClick={onExpand}
+      title={title}
+      aria-label={title}
+      className={`w-5 shrink-0 ${
+        side === "left" ? "border-r" : "border-l"
+      } border-border bg-surface hover:bg-surface-2 flex items-start justify-center pt-2 text-muted hover:text-text transition-colors`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+    </button>
+  );
+}
 
 export function AppShell() {
   const t = useT();
@@ -111,6 +140,8 @@ export function AppShell() {
     handlePrint,
   } = useZplImportExport();
   const outputPanel = useOutputPanel(OUTPUT_DEFAULT_H);
+  const leftPanel = useCollapsiblePanel("zpl-panel-left");
+  const rightPanel = useCollapsiblePanel("zpl-panel-right");
   // Imperative handle to the canvas for actions PropertiesPanel needs live
   // render bboxes for (e.g. align-to-label centring).
   const canvasRef = useRef<LabelCanvasHandle>(null);
@@ -322,9 +353,23 @@ export function AppShell() {
       {/* Main area: 3 columns */}
       <DndContext sensors={sensors}>
       <div className="flex flex-1 min-h-0">
-        <aside className="w-44 shrink-0 border-r border-border bg-surface overflow-y-auto">
-          <ObjectPalette />
-        </aside>
+        {leftPanel.collapsed ? (
+          <ExpandStrip side="left" onExpand={leftPanel.expand} title={t.app.expand} />
+        ) : (
+          <aside className="w-44 shrink-0 border-r border-border bg-surface overflow-y-auto">
+            <div className="sticky top-0 z-10 flex justify-end border-b border-border bg-surface px-1 py-0.5">
+              <button
+                onClick={leftPanel.collapse}
+                title={t.app.collapse}
+                aria-label={t.app.collapse}
+                className="p-0.5 text-muted hover:text-text transition-colors"
+              >
+                <ChevronDoubleLeftIcon className="w-3.5 h-3.5" />
+              </button>
+            </div>
+            <ObjectPalette />
+          </aside>
+        )}
 
         <main className="flex-1 overflow-hidden">
           <LabelCanvas
@@ -343,7 +388,11 @@ export function AppShell() {
           />
         </main>
 
-        <RightSidebar canvasRef={canvasRef} />
+        {rightPanel.collapsed ? (
+          <ExpandStrip side="right" onExpand={rightPanel.expand} title={t.app.expand} />
+        ) : (
+          <RightSidebar canvasRef={canvasRef} onCollapse={rightPanel.collapse} />
+        )}
       </div>
       </DndContext>
 

--- a/src/components/RightSidebar/RightSidebar.tsx
+++ b/src/components/RightSidebar/RightSidebar.tsx
@@ -3,6 +3,7 @@ import {
   AdjustmentsHorizontalIcon,
   RectangleStackIcon,
   VariableIcon,
+  ChevronDoubleRightIcon,
 } from '@heroicons/react/16/solid';
 import { PropertiesPanel } from '../Properties/PropertiesPanel';
 import { LayersPanel } from '../Properties/LayersPanel';
@@ -18,6 +19,7 @@ type TabId = 'properties' | 'layers' | 'variables' | 'fonts';
 
 interface Props {
   canvasRef: RefObject<LabelCanvasHandle | null>;
+  onCollapse?: () => void;
 }
 
 interface TabDef {
@@ -27,7 +29,7 @@ interface TabDef {
   Icon: ComponentType<{ className?: string }>;
 }
 
-export function RightSidebar({ canvasRef }: Props) {
+export function RightSidebar({ canvasRef, onCollapse }: Props) {
   const t = useT();
   // Tab state lives in the store so canvas interactions (e.g. double-
   // click a text field) can switch the sidebar to Properties +
@@ -46,8 +48,9 @@ export function RightSidebar({ canvasRef }: Props) {
 
   return (
     <aside className="w-64 shrink-0 border-l border-border bg-surface flex flex-col">
-      <div className="flex shrink-0 border-b border-border" role="tablist">
-        {tabs.map(({ id, label, Icon }) => {
+      <div className="flex shrink-0 border-b border-border">
+        <div className="flex flex-1" role="tablist">
+          {tabs.map(({ id, label, Icon }) => {
           const active = tab === id;
           return (
             <Tooltip key={id} content={label} className="flex-1">
@@ -66,7 +69,19 @@ export function RightSidebar({ canvasRef }: Props) {
               </button>
             </Tooltip>
           );
-        })}
+          })}
+        </div>
+        {onCollapse && (
+          <Tooltip content={t.app.collapse}>
+            <button
+              onClick={onCollapse}
+              aria-label={t.app.collapse}
+              className="px-2 flex items-center justify-center border-l border-border text-muted hover:text-text transition-colors"
+            >
+              <ChevronDoubleRightIcon className="w-3.5 h-3.5" />
+            </button>
+          </Tooltip>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto">
         {tab === 'properties' && <PropertiesPanel canvasRef={canvasRef} />}

--- a/src/hooks/useCollapsiblePanel.ts
+++ b/src/hooks/useCollapsiblePanel.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+/** Collapsed flag for a layout panel, persisted to localStorage so the choice
+ *  survives reloads. Mirrors useOutputPanel's storage approach. */
+export function useCollapsiblePanel(lsKey: string, initial = false) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      const v = localStorage.getItem(lsKey);
+      return v === null ? initial : v === "1";
+    } catch {
+      return initial;
+    }
+  });
+  const set = (v: boolean) => {
+    setCollapsed(v);
+    try {
+      localStorage.setItem(lsKey, v ? "1" : "0");
+    } catch {
+      // storage blocked (private browsing); in-memory state still works
+    }
+  };
+  return {
+    collapsed,
+    collapse: () => set(true),
+    expand: () => set(false),
+  };
+}


### PR DESCRIPTION
Palette and properties panels can each collapse to a thin clickable rail (chevron toward the canvas) to free canvas space; state persists via localStorage (mirrors useOutputPanel). Canvas auto-refits via the existing ResizeObserver. Reuses app.collapse/expand strings (no new locale keys).