### PR TITLE
feat(properties): card-based section layout

### DIFF
--- a/src/components/Properties/AlignToolbar.tsx
+++ b/src/components/Properties/AlignToolbar.tsx
@@ -46,11 +46,9 @@ interface AlignOpDef {
 function AlignOpRow({
   ops,
   onClick,
-  disabled = false,
 }: {
   ops: AlignOpDef[];
   onClick: (op: AlignOp) => void;
-  disabled?: boolean;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-1">
@@ -60,7 +58,6 @@ function AlignOpRow({
             type="button"
             className={BUTTON_CLS}
             aria-label={title}
-            disabled={disabled}
             onClick={() => onClick(op)}
           >
             <Icon className="w-3.5 h-3.5" />
@@ -98,15 +95,14 @@ export function AlignToolbar({
     { op: "bottom", title: t.properties.alignBottom, Icon: AlignBottomIcon },
   ];
 
-  // A single object aligns to the label via the section below; "Align" (relative
-  // to the selection) only makes sense for 2+, so disable it to avoid duplicating
-  // "Align to label".
-  const alignSelectionDisabled = selectionCount < 2;
+  // A single object can only align to the label, so the selection-relative
+  // sections (Align, Distribute, Tidy) are hidden for one object and shown
+  // for 2+. Distribute still needs >=3 to act, so it stays guarded.
+  const multi = selectionCount >= 2;
   const distributeDisabled = selectionCount < 3;
-  const tidyDisabled = selectionCount < 2;
 
   const segCls = (active: boolean) =>
-    `px-1.5 py-0.5 transition-colors disabled:opacity-40 disabled:pointer-events-none ${active ? "bg-accent text-bg" : "text-muted hover:text-text"}`;
+    `px-1.5 py-0.5 transition-colors ${active ? "bg-accent text-bg" : "text-muted hover:text-text"}`;
 
   return (
     <div
@@ -114,39 +110,39 @@ export function AlignToolbar({
       role={ariaLabelledBy ? "group" : undefined}
       aria-labelledby={ariaLabelledBy}
     >
-      {/* Align: relative to the selection (or key object). */}
-      <div className="flex flex-col gap-1.5">
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-[10px] uppercase tracking-wide text-muted">
-            {t.properties.alignSectionSelection}
-          </span>
-          <div
-            className="flex rounded overflow-hidden border border-border text-[10px] font-mono"
-            role="group"
-            aria-label={t.properties.alignSectionSelection}
-          >
-            <button
-              type="button"
-              className={segCls(alignRef === "selection")}
-              aria-pressed={alignRef === "selection"}
-              disabled={alignSelectionDisabled}
-              onClick={() => onAlignRefChange("selection")}
+      {/* Align: relative to the selection (or key object). Multi-select only. */}
+      {multi && (
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[10px] uppercase tracking-wide text-muted">
+              {t.properties.alignSectionSelection}
+            </span>
+            <div
+              className="flex rounded overflow-hidden border border-border text-[10px] font-mono"
+              role="group"
+              aria-label={t.properties.alignSectionSelection}
             >
-              {t.properties.alignRefSelection}
-            </button>
-            <button
-              type="button"
-              className={segCls(alignRef === "key")}
-              aria-pressed={alignRef === "key"}
-              disabled={alignSelectionDisabled}
-              onClick={() => onAlignRefChange("key")}
-            >
-              {t.properties.alignRefKey}
-            </button>
+              <button
+                type="button"
+                className={segCls(alignRef === "selection")}
+                aria-pressed={alignRef === "selection"}
+                onClick={() => onAlignRefChange("selection")}
+              >
+                {t.properties.alignRefSelection}
+              </button>
+              <button
+                type="button"
+                className={segCls(alignRef === "key")}
+                aria-pressed={alignRef === "key"}
+                onClick={() => onAlignRefChange("key")}
+              >
+                {t.properties.alignRefKey}
+              </button>
+            </div>
           </div>
+          <AlignOpRow ops={alignOps} onClick={(op) => onAlign(op, alignRef)} />
         </div>
-        <AlignOpRow ops={alignOps} disabled={alignSelectionDisabled} onClick={(op) => onAlign(op, alignRef)} />
-      </div>
+      )}
 
       {/* Align to label: all six edges to the label rect, always visible. */}
       <div className="flex flex-col gap-1.5">
@@ -156,55 +152,59 @@ export function AlignToolbar({
         <AlignOpRow ops={alignOps} onClick={(op) => onAlign(op, "label")} />
       </div>
 
-      {/* Distribute: always selection-relative; needs >=3 objects. */}
-      <div className="flex flex-col gap-1.5">
-        <span className="text-[10px] uppercase tracking-wide text-muted">
-          {t.properties.distributeSection}
-        </span>
-        <div className="flex items-center gap-1">
-          <Tooltip content={distributeDisabled ? t.properties.distributeHint : t.properties.distributeH}>
+      {/* Distribute: selection-relative; multi-select only, needs >=3 to act. */}
+      {multi && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted">
+            {t.properties.distributeSection}
+          </span>
+          <div className="flex items-center gap-1">
+            <Tooltip content={distributeDisabled ? t.properties.distributeHint : t.properties.distributeH}>
+              <button
+                type="button"
+                className={BUTTON_CLS}
+                aria-label={t.properties.distributeH}
+                disabled={distributeDisabled}
+                onClick={() => onDistribute("h")}
+              >
+                <DistributeHIcon className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
+            <Tooltip content={distributeDisabled ? t.properties.distributeHint : t.properties.distributeV}>
+              <button
+                type="button"
+                className={BUTTON_CLS}
+                aria-label={t.properties.distributeV}
+                disabled={distributeDisabled}
+                onClick={() => onDistribute("v")}
+              >
+                <DistributeVIcon className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+
+      {/* Tidy up: auto-arrange the selection into an even row/column.
+          Multi-select only. */}
+      {multi && (
+        <div className="flex flex-col gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted">
+            {t.properties.tidySection}
+          </span>
+          <Tooltip content={t.properties.tidyTooltip} className="self-start">
             <button
               type="button"
-              className={BUTTON_CLS}
-              aria-label={t.properties.distributeH}
-              disabled={distributeDisabled}
-              onClick={() => onDistribute("h")}
+              className={`${BUTTON_CLS} flex items-center gap-1.5`}
+              aria-label={t.properties.tidyUp}
+              onClick={onTidy}
             >
-              <DistributeHIcon className="w-3.5 h-3.5" />
-            </button>
-          </Tooltip>
-          <Tooltip content={distributeDisabled ? t.properties.distributeHint : t.properties.distributeV}>
-            <button
-              type="button"
-              className={BUTTON_CLS}
-              aria-label={t.properties.distributeV}
-              disabled={distributeDisabled}
-              onClick={() => onDistribute("v")}
-            >
-              <DistributeVIcon className="w-3.5 h-3.5" />
+              <TidyIcon className="w-3.5 h-3.5" />
+              <span className="text-[10px]">{t.properties.tidyUp}</span>
             </button>
           </Tooltip>
         </div>
-      </div>
-
-      {/* Tidy up: auto-arrange the selection into an even row/column. */}
-      <div className="flex flex-col gap-1.5">
-        <span className="text-[10px] uppercase tracking-wide text-muted">
-          {t.properties.tidySection}
-        </span>
-        <Tooltip content={tidyDisabled ? t.properties.tidyHint : t.properties.tidyTooltip} className="self-start">
-          <button
-            type="button"
-            className={`${BUTTON_CLS} flex items-center gap-1.5`}
-            aria-label={t.properties.tidyUp}
-            disabled={tidyDisabled}
-            onClick={onTidy}
-          >
-            <TidyIcon className="w-3.5 h-3.5" />
-            <span className="text-[10px]">{t.properties.tidyUp}</span>
-          </button>
-        </Tooltip>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/Properties/BlockTextSettings.tsx
+++ b/src/components/Properties/BlockTextSettings.tsx
@@ -40,10 +40,7 @@ export function BlockTextSettings({ props: p, onChange }: Props) {
   const advance = Math.ceil(zebraGlyphAdvanceDots(p.fontHeight, p.fontWidth));
   const tooNarrow = isBlockTooNarrow(p.blockWidth ?? 0, p.fontHeight, p.fontWidth);
   return (
-    // Indent + left border marks the sub-panel as belonging to the
-    // FELDBLOCK checkbox above; same convention as the Font-Advanced
-    // block in text.tsx.
-    <div className="pl-3 border-l border-border flex flex-col gap-3">
+    <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
         <label className={labelCls}>{t.registry.text.dragMode}</label>
         <div className="flex rounded border border-border overflow-hidden text-xs">

--- a/src/components/Properties/FpSettings.tsx
+++ b/src/components/Properties/FpSettings.tsx
@@ -55,7 +55,7 @@ export function FpSettings({ props: p, onChange }: Props) {
     { v: "R", title: t.registry.text.fpDirR },
   ];
   return (
-    <div className="pl-3 border-l border-border flex flex-col gap-3">
+    <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
         <label className={labelCls}>{t.registry.text.fpDirection}</label>
         <div className="flex gap-1" role="group" aria-label={t.registry.text.fpDirection}>

--- a/src/components/Properties/PropertiesPanel.tsx
+++ b/src/components/Properties/PropertiesPanel.tsx
@@ -223,6 +223,7 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
             <input
               type="text"
               className={inputCls}
+              aria-label={t.properties.name}
               value={obj.name ?? ''}
               placeholder={t.types.group}
               onChange={(e) =>
@@ -256,7 +257,9 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
                 }
               }
             : (props: object) => updateObject(obj.id, { props });
-          return <TypePanel obj={patchedObj} onChange={handleChange} />;
+          // Key by id so switching objects remounts the panel and resets its
+          // transient reveal state (e.g. the Typography "Advanced" toggle).
+          return <TypePanel key={obj.id} obj={patchedObj} onChange={handleChange} />;
         })()}
 
         {/* Position & alignment. Groups have no per-leaf x/y (children store
@@ -311,6 +314,7 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
           )}
           <PositionSectionHeader
             hideHeading
+            unitSuffix={!groupRow ? unitLabel(unit) : undefined}
             onAlign={handleAlign}
             onDistribute={handleDistribute}
             onTidy={handleTidy}

--- a/src/components/Properties/PropertiesPanel.tsx
+++ b/src/components/Properties/PropertiesPanel.tsx
@@ -20,7 +20,7 @@ import {
 import type { Unit } from "../../lib/units";
 import { useT } from "../../lib/useT";
 import { parseIntOrUndef } from "../../lib/inputParse";
-import { CollapsibleSection } from "../ui/CollapsibleSection";
+import { SectionCard, StaticSectionCard } from "./SectionCard";
 import { Tooltip } from "../ui/Tooltip";
 import { AlignToolbar } from "./AlignToolbar";
 import { VariableBindingControl } from "../Variables/VariableBindingControl";
@@ -58,6 +58,7 @@ function BwipApproxIcon({ type }: { type: string }) {
  *  toolbar group so screen readers announce a labelled button group. */
 function PositionSectionHeader({
   unitSuffix,
+  hideHeading,
   onAlign,
   onDistribute,
   onTidy,
@@ -66,6 +67,9 @@ function PositionSectionHeader({
   selectionCount,
 }: {
   unitSuffix?: string;
+  /** Hide the visible heading (kept for screen readers) when a card title
+   *  already names the section, avoiding a duplicate label. */
+  hideHeading?: boolean;
   onAlign: (op: AlignOp, ref: AlignRef) => void;
   onDistribute: (axis: DistributeAxis) => void;
   onTidy: () => void;
@@ -77,7 +81,7 @@ function PositionSectionHeader({
   const labelId = useId();
   return (
     <div className="flex flex-col gap-2">
-      <p id={labelId} className={labelCls}>
+      <p id={labelId} className={hideHeading ? "sr-only" : labelCls}>
         {t.properties.positionSection}
         {unitSuffix ? ` (${unitSuffix})` : ""}
       </p>
@@ -209,14 +213,13 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
         </span>
       </div>
 
-      <div className="p-3 flex flex-col gap-4">
-        {/* Name field: exposed only for groups; leaf rows fall back to
-            their registry label in the layers panel. The field is on
-            LabelObjectBase so adding it for other types would not need
-            a schema change. */}
+      {/* Panel stays bg-surface (bg-bg would merge with the canvas); each
+          SectionCard lifts off it via border + shadow. */}
+      <div className="p-2 flex flex-col gap-2">
+        {/* Name field: groups only (leaf rows fall back to their registry
+            label in the layers panel). */}
         {groupRow && (
-          <div className="flex flex-col gap-1">
-            <label className={labelCls}>{t.properties.name}</label>
+          <StaticSectionCard title={t.properties.name}>
             <input
               type="text"
               className={inputCls}
@@ -226,109 +229,14 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
                 updateObject(obj.id, { name: e.target.value || undefined })
               }
             />
-          </div>
+          </StaticSectionCard>
         )}
 
-        {/* Position: groups have no meaningful x/y of their own (children
-            store world coordinates), so the inputs are hidden. Align
-            still applies; it expands to the group's leaves at the
-            canvas layer. */}
-        <div className="flex flex-col gap-2">
-          {groupRow ? (
-            // Groups have no per-leaf position inputs; header alone.
-            <PositionSectionHeader
-              onAlign={handleAlign}
-              onDistribute={handleDistribute}
-              onTidy={handleTidy}
-              alignRef={alignRef}
-              onAlignRefChange={setAlignRef}
-              selectionCount={selectedIds.length}
-            />
-          ) : (
-            <>
-              <PositionSectionHeader
-                onAlign={handleAlign}
-                onDistribute={handleDistribute}
-                onTidy={handleTidy}
-                alignRef={alignRef}
-                onAlignRefChange={setAlignRef}
-                selectionCount={selectedIds.length}
-                unitSuffix={unitLabel(unit)}
-              />
-              <div className="grid grid-cols-2 gap-2">
-                <div className="flex flex-col gap-1">
-                  <label className={labelCls}>{t.properties.x}</label>
-                  <input
-                    type="number"
-                    className={inputCls}
-                    value={mmToUnit(dotsToMm(obj.x, label.dpmm), unit)}
-                    step={unitStep(unit)}
-                    onChange={(e) =>
-                      updateObject(obj.id, {
-                        x: mmToDots(
-                          unitToMm(Number(e.target.value), unit),
-                          label.dpmm,
-                        ),
-                      })
-                    }
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className={labelCls}>{t.properties.y}</label>
-                  <input
-                    type="number"
-                    className={inputCls}
-                    value={mmToUnit(dotsToMm(obj.y, label.dpmm), unit)}
-                    step={unitStep(unit)}
-                    onChange={(e) =>
-                      updateObject(obj.id, {
-                        y: mmToDots(
-                          unitToMm(Number(e.target.value), unit),
-                          label.dpmm,
-                        ),
-                      })
-                    }
-                  />
-                </div>
-              </div>
-            </>
-          )}
-        </div>
-
-        <div className="border-t border-border" />
-
-        {/* Variable binding: shown for types that emit a ^FD content
-            block (text + barcodes minus serial). Collapsed by default
-            for unbound fields so beginners aren't distracted; opens
-            automatically when the field is already bound so the
-            binding state is visible without an extra click. The
-            CollapsibleSection persists the user's manual toggle
-            per-state in localStorage (separate ids for bound vs
-            unbound), so each preference sticks. */}
-        {definition?.bindable && !groupRow && (
-          <>
-            <CollapsibleSection
-              id={obj.variableId ? 'properties-variable-bound' : 'properties-variable-unbound'}
-              title={t.variables.sectionTitle}
-              defaultOpen={!!obj.variableId}
-            >
-              <VariableBindingControl obj={obj} />
-            </CollapsibleSection>
-            <div className="border-t border-border" />
-          </>
-        )}
-
-        {/* Per-type panel: only leaves have a registry entry, so TypePanel
-            is never present for groups. The isGroup guard narrows obj for
-            TypeScript at the call site since registry panels expect the
-            leaf shape (props field present).
-
-            When a binding is active we hand TypePanel a patched obj where
-            props.content is the variable's defaultValue (so the CONTENT
-            input mirrors the canvas) and we re-route content edits into
-            updateVariable so typing into the per-type input directly
-            edits the variable's default. Non-content props (fontHeight,
-            rotation, …) keep flowing to updateObject untouched. */}
+        {/* Per-type panel first. Text renders its own SectionCards (Content,
+            Typography, Field block); other types still render flat content
+            until their panels are migrated (Phase 2). Binding routing is
+            unchanged: a patched obj feeds the panel and content edits
+            re-route to updateVariable while other props go to updateObject. */}
         {TypePanel && !groupRow && (() => {
           const boundVariable = lookupBoundVariable(obj, variables);
           const patchedObj = boundVariable
@@ -348,65 +256,136 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
                 }
               }
             : (props: object) => updateObject(obj.id, { props });
-          return (
-            <>
-              <TypePanel obj={patchedObj} onChange={handleChange} />
-              <div className="border-t border-border" />
-            </>
-          );
+          return <TypePanel obj={patchedObj} onChange={handleChange} />;
         })()}
 
-        {/* Comment (^FX); leaves only: groups emit no ZPL of their own
-            so the comment would never reach the output. */}
-        {!groupRow && (
-          <div className="flex flex-col gap-1">
-            <label className={labelCls}>{t.properties.comment}</label>
-            <textarea
-              className={`${inputCls} resize-none`}
-              rows={2}
-              value={obj.comment ?? ""}
-              onChange={(e) =>
-                updateObject(obj.id, { comment: stripZplCommandChars(e.target.value) || undefined })
-              }
-            />
-          </div>
+        {/* Position & alignment. Groups have no per-leaf x/y (children store
+            world coordinates), so the inputs are hidden; align still applies
+            and expands to the group's leaves at the canvas layer. The card
+            title names the section, so the inner heading is sr-only. */}
+        <SectionCard
+          id="properties-position"
+          title={
+            groupRow
+              ? t.properties.positionSection
+              : `${t.properties.positionSection} (${unitLabel(unit)})`
+          }
+        >
+          {!groupRow && (
+            <div className="grid grid-cols-2 gap-2">
+              <div className="flex flex-col gap-1">
+                <label className={labelCls}>{t.properties.x}</label>
+                <input
+                  type="number"
+                  className={inputCls}
+                  value={mmToUnit(dotsToMm(obj.x, label.dpmm), unit)}
+                  step={unitStep(unit)}
+                  onChange={(e) =>
+                    updateObject(obj.id, {
+                      x: mmToDots(
+                        unitToMm(Number(e.target.value), unit),
+                        label.dpmm,
+                      ),
+                    })
+                  }
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className={labelCls}>{t.properties.y}</label>
+                <input
+                  type="number"
+                  className={inputCls}
+                  value={mmToUnit(dotsToMm(obj.y, label.dpmm), unit)}
+                  step={unitStep(unit)}
+                  onChange={(e) =>
+                    updateObject(obj.id, {
+                      y: mmToDots(
+                        unitToMm(Number(e.target.value), unit),
+                        label.dpmm,
+                      ),
+                    })
+                  }
+                />
+              </div>
+            </div>
+          )}
+          <PositionSectionHeader
+            hideHeading
+            onAlign={handleAlign}
+            onDistribute={handleDistribute}
+            onTidy={handleTidy}
+            alignRef={alignRef}
+            onAlignRefChange={setAlignRef}
+            selectionCount={selectedIds.length}
+          />
+        </SectionCard>
+
+        {/* Variable binding: types that emit a ^FD content block. Opens
+            automatically when already bound; the open-state persists per
+            bound/unbound id in localStorage. */}
+        {definition?.bindable && !groupRow && (
+          <SectionCard
+            id={obj.variableId ? 'properties-variable-bound' : 'properties-variable-unbound'}
+            title={t.variables.sectionTitle}
+            defaultOpen={!!obj.variableId}
+          >
+            <VariableBindingControl obj={obj} />
+          </SectionCard>
         )}
 
-        {/* Lock; paired with the LayersPanel lock icon; mirroring it here
-            so a user already in PropertiesPanel can flip lock state without
-            jumping panels. Lock itself is a meta-field bypass in the store,
-            so the checkbox stays interactive even when the object is locked. */}
-        <label className="flex items-center gap-2 text-xs text-text cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={!!obj.locked}
-            onChange={(e) =>
-              updateObject(obj.id, { locked: e.target.checked || undefined })
-            }
-          />
-          <span>{t.properties.lock}</span>
-          <Tooltip content={t.properties.lockHint}>
-            <InformationCircleIcon className="w-3.5 h-3.5 text-muted/60 cursor-help shrink-0" />
-          </Tooltip>
-        </label>
+        {/* Options: comment (^FX, leaves only), lock, include-in-export.
+            Collapsed by default since these are set rarely. */}
+        <SectionCard
+          id="properties-options"
+          title={t.properties.optionsSection}
+          defaultOpen={false}
+        >
+          {!groupRow && (
+            <div className="flex flex-col gap-1">
+              <label className={labelCls}>{t.properties.comment}</label>
+              <textarea
+                className={`${inputCls} resize-none`}
+                rows={2}
+                value={obj.comment ?? ""}
+                onChange={(e) =>
+                  updateObject(obj.id, { comment: stripZplCommandChars(e.target.value) || undefined })
+                }
+              />
+            </div>
+          )}
 
-        {/* Include in ZPL output; paired with the LayersPanel eye toggle:
-            visible controls editor render, includeInExport controls ZPL
-            emission. Stored as undefined when on so default state stays
-            absent from persisted JSON. */}
-        <label className="flex items-center gap-2 text-xs text-text cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={obj.includeInExport !== false}
-            onChange={(e) =>
-              updateObject(obj.id, { includeInExport: e.target.checked ? undefined : false })
-            }
-          />
-          <span>{t.properties.includeInExport}</span>
-          <Tooltip content={t.properties.includeInExportHint}>
-            <InformationCircleIcon className="w-3.5 h-3.5 text-muted/60 cursor-help shrink-0" />
-          </Tooltip>
-        </label>
+          {/* Lock mirrors the LayersPanel lock icon; meta-field bypass keeps
+              the checkbox interactive even when the object is locked. */}
+          <label className="flex items-center gap-2 text-xs text-text cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={!!obj.locked}
+              onChange={(e) =>
+                updateObject(obj.id, { locked: e.target.checked || undefined })
+              }
+            />
+            <span>{t.properties.lock}</span>
+            <Tooltip content={t.properties.lockHint}>
+              <InformationCircleIcon className="w-3.5 h-3.5 text-muted/60 cursor-help shrink-0" />
+            </Tooltip>
+          </label>
+
+          {/* includeInExport controls ZPL emission (vs the eye toggle's
+              editor visibility); stored undefined when on. */}
+          <label className="flex items-center gap-2 text-xs text-text cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={obj.includeInExport !== false}
+              onChange={(e) =>
+                updateObject(obj.id, { includeInExport: e.target.checked ? undefined : false })
+              }
+            />
+            <span>{t.properties.includeInExport}</span>
+            <Tooltip content={t.properties.includeInExportHint}>
+              <InformationCircleIcon className="w-3.5 h-3.5 text-muted/60 cursor-help shrink-0" />
+            </Tooltip>
+          </label>
+        </SectionCard>
       </div>
     </div>
   );
@@ -501,7 +480,8 @@ function LabelConfigPanel({
         <span className="text-xs font-medium text-text">{t.label.heading}</span>
       </div>
 
-      <div className="p-3 flex flex-col gap-3">
+      <div className="p-2 flex flex-col gap-2">
+        <StaticSectionCard title={t.label.formatSection}>
         <div className="flex flex-col gap-1">
           <label className={labelCls}>{t.label.preset}</label>
           <select
@@ -517,8 +497,6 @@ function LabelConfigPanel({
             ))}
           </select>
         </div>
-
-        <div className="border-t border-border" />
 
         <div className="flex items-center justify-between">
           <span className={labelCls}>
@@ -602,8 +580,9 @@ function LabelConfigPanel({
             }}
           />
         </div>
+        </StaticSectionCard>
 
-        <CollapsibleSection
+        <SectionCard
           id="label-output"
           title={t.label.outputHeading}
           defaultOpen={false}
@@ -694,9 +673,9 @@ function LabelConfigPanel({
         </div>
 
         </div>
-        </CollapsibleSection>
+        </SectionCard>
 
-        <CollapsibleSection
+        <SectionCard
           id="label-quantity-advanced"
           title={t.label.quantityAdvancedHeading}
           defaultOpen={false}
@@ -746,9 +725,9 @@ function LabelConfigPanel({
           {t.label.overridePauseCount}
         </label>
         </div>
-        </CollapsibleSection>
+        </SectionCard>
 
-        <CollapsibleSection
+        <SectionCard
           id="label-fonts"
           title={t.label.fontsHeading}
           defaultOpen={false}
@@ -812,7 +791,7 @@ function LabelConfigPanel({
           </div>
         </div>
         </div>
-        </CollapsibleSection>
+        </SectionCard>
       </div>
     </div>
   );

--- a/src/components/Properties/SectionCard.tsx
+++ b/src/components/Properties/SectionCard.tsx
@@ -1,0 +1,154 @@
+import { useId, type ReactNode } from 'react';
+import { ChevronDownIcon } from '@heroicons/react/16/solid';
+import { useCollapsibleState } from '../ui/useCollapsibleState';
+
+const titleCls =
+  'font-mono text-[10px] font-semibold uppercase tracking-widest text-text';
+
+/** Status dot: accent when the section is open/active, muted otherwise. */
+function Dot({ active }: { active: boolean }) {
+  return (
+    <span
+      className={`w-1.5 h-1.5 rounded-sm shrink-0 ${active ? 'bg-accent' : 'bg-border-2'}`}
+    />
+  );
+}
+
+/** Dot + title, shared by all three card header variants. `titleId` lets a
+ *  control (e.g. the toggle switch) reference the title as its accessible name. */
+function CardLabel({
+  active,
+  title,
+  titleId,
+}: {
+  active: boolean;
+  title: ReactNode;
+  titleId?: string;
+}) {
+  return (
+    <>
+      <Dot active={active} />
+      <span id={titleId} className={titleCls}>
+        {title}
+      </span>
+    </>
+  );
+}
+
+// bg-surface on a same-coloured panel: the border carries the edge in dark,
+// the shadow lifts the card in light (panel stays bg-surface, not bg-bg, so it
+// keeps a clear border against the canvas).
+const cardCls = 'rounded-lg border border-border bg-surface shadow-sm overflow-hidden';
+const bodyCls = 'px-2.5 pb-3 pt-0.5 flex flex-col gap-3';
+
+interface SectionCardProps {
+  /** Stable id; persists open-state under the shared `zpl:section:` keys. */
+  id: string;
+  title: ReactNode;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Collapsible properties section as a self-contained card. Renders its own
+ * card chrome (dot + title + chevron) for the Properties panel and reuses
+ * CollapsibleSection's persistence via `useCollapsibleState`, so the open
+ * state survives regardless of which renderer drew the section.
+ */
+export function SectionCard({
+  id,
+  title,
+  defaultOpen = true,
+  children,
+}: SectionCardProps) {
+  const [open, setOpen] = useCollapsibleState(id, defaultOpen);
+  const contentId = useId();
+  return (
+    <div className={cardCls}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={contentId}
+        className="flex items-center gap-2 w-full px-2.5 py-2.5 text-left"
+      >
+        <CardLabel active={open} title={title} />
+        <ChevronDownIcon
+          className={`w-3 h-3 shrink-0 ml-auto transition-transform ${open ? '' : '-rotate-90'}`}
+        />
+      </button>
+      {open && (
+        <div id={contentId} className={bodyCls}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Always-open card (no collapse control), for the lead "Content" section
+ * that should never be hidden. Shares the card chrome with SectionCard.
+ */
+export function StaticSectionCard({
+  title,
+  children,
+}: {
+  title: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cardCls}>
+      <div className="flex items-center gap-2 px-2.5 py-2.5">
+        <CardLabel active title={title} />
+      </div>
+      <div className={bodyCls}>{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Card whose header switch toggles a feature on/off (e.g. ^FB field block).
+ * The switch is the section's enable control, so the body shows only while
+ * on; there is no separate collapse and no persisted open-state (the toggled
+ * feature itself is the source of truth).
+ */
+export function ToggleSectionCard({
+  title,
+  checked,
+  onCheckedChange,
+  children,
+}: {
+  title: ReactNode;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  children: ReactNode;
+}) {
+  const contentId = useId();
+  const titleId = useId();
+  return (
+    <div className={cardCls}>
+      <div className="flex items-center gap-2 px-2.5 py-2.5">
+        <CardLabel active={checked} title={title} titleId={titleId} />
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          aria-labelledby={titleId}
+          aria-controls={checked ? contentId : undefined}
+          onClick={() => onCheckedChange(!checked)}
+          className={`ml-auto relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors ${checked ? 'bg-accent' : 'bg-border-2'}`}
+        >
+          <span
+            className={`inline-block h-3 w-3 rounded-full bg-surface transition-transform ${checked ? 'translate-x-3.5' : 'translate-x-0.5'}`}
+          />
+        </button>
+      </div>
+      {checked && (
+        <div id={contentId} className={bodyCls}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/16/solid';
+import { useCollapsibleState } from './useCollapsibleState';
 
 interface CollapsibleSectionProps {
   /** Stable identifier, used as the localStorage key for the open state. */
@@ -7,13 +8,6 @@ interface CollapsibleSectionProps {
   title: ReactNode;
   defaultOpen?: boolean;
   children: ReactNode;
-}
-
-const LS_PREFIX = 'zpl:section:';
-
-function readStored(id: string, fallback: boolean): boolean {
-  const saved = localStorage.getItem(LS_PREFIX + id);
-  return saved === null ? fallback : saved === '1';
 }
 
 /**
@@ -27,22 +21,7 @@ export function CollapsibleSection({
   defaultOpen = true,
   children,
 }: CollapsibleSectionProps) {
-  const [open, setOpen] = useState(() => readStored(id, defaultOpen));
-
-  // Re-sync open state when `id` changes so the component can be reused for
-  // a different section without leaking the previous open state into the new
-  // id's storage slot. React's blessed pattern for deriving state from
-  // props: setState during render under a prev-vs-current guard.
-  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
-  const [prevId, setPrevId] = useState(id);
-  if (prevId !== id) {
-    setPrevId(id);
-    setOpen(readStored(id, defaultOpen));
-  }
-
-  useEffect(() => {
-    localStorage.setItem(LS_PREFIX + id, open ? '1' : '0');
-  }, [id, open]);
+  const [open, setOpen] = useCollapsibleState(id, defaultOpen);
 
   const contentId = `section-content-${id}`;
 

--- a/src/components/ui/useCollapsibleState.ts
+++ b/src/components/ui/useCollapsibleState.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+
+/** Shared so SectionCard persists section open-state under the same keys
+ *  as CollapsibleSection (a section's state survives either renderer). */
+export const SECTION_LS_PREFIX = 'zpl:section:';
+
+function readStored(id: string, fallback: boolean): boolean {
+  const saved = localStorage.getItem(SECTION_LS_PREFIX + id);
+  return saved === null ? fallback : saved === '1';
+}
+
+/**
+ * Open/closed state persisted per `id` in localStorage. Shared by
+ * CollapsibleSection and the Properties-panel SectionCard so the latter can
+ * render its own card chrome while keeping identical persistence (keys +
+ * re-sync-on-id-change).
+ */
+export function useCollapsibleState(
+  id: string,
+  defaultOpen: boolean,
+): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const [open, setOpen] = useState(() => readStored(id, defaultOpen));
+
+  // Re-sync open state when `id` changes so the hook can be reused for a
+  // different section without leaking the previous open state into the new
+  // id's storage slot. React's blessed pattern for deriving state from
+  // props: setState during render under a prev-vs-current guard.
+  // https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [prevId, setPrevId] = useState(id);
+  if (prevId !== id) {
+    setPrevId(id);
+    setOpen(readStored(id, defaultOpen));
+  }
+
+  useEffect(() => {
+    localStorage.setItem(SECTION_LS_PREFIX + id, open ? '1' : '0');
+  }, [id, open]);
+
+  return [open, setOpen];
+}

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -51,6 +51,8 @@ const ar = {
 
   properties: {
     positionSection: 'الموضع (مم)',
+    optionsSection: 'خيارات',
+    typographySection: 'الطباعة',
     name: 'الاسم',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const ar = {
     tidySection: 'ترتيب',
     tidyUp: 'ترتيب',
     tidyTooltip: 'ترتيب تلقائي في صف أو عمود متساوٍ',
-    tidyHint: 'حدّد عنصرين أو أكثر للترتيب',
   },
 
   label: {
@@ -104,6 +105,7 @@ const ar = {
     overridePauseCount: 'تجاوز عدد التوقف',
     overridePauseCountHint: 'قص الملصق الأخير فقط في الدفعة بدلاً من كل حد توقف.',
     outputHeading: 'الإخراج',
+    formatSection: 'تنسيق',
     labelShift: 'إزاحة الملصق (dots)',
     offsetsHeading: 'الإزاحات',
     offsetsHint: 'يزيح أصل الطباعة. تبقى مواضع الحقول في المحرر مطلقة.',
@@ -415,7 +417,6 @@ const ar = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'النص العمودي / من اليمين إلى اليسار',
       fpDirection: 'الاتجاه',
       fpDirH: 'H — أفقي',
       fpDirV: 'V — رأسي (تكديس)',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -51,6 +51,8 @@ const bg = {
 
   properties: {
     positionSection: 'Позиция',
+    optionsSection: 'Опции',
+    typographySection: 'Типография',
     name: 'Име',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const bg = {
     tidySection: 'Подреждане',
     tidyUp: 'Подреждане',
     tidyTooltip: 'Автоматично подреждане в равен ред или колона',
-    tidyHint: 'Изберете 2+ за подреждане',
   },
 
   label: {
@@ -104,6 +105,7 @@ const bg = {
     overridePauseCount: 'Замени брояча на пауза',
     overridePauseCountHint: 'Отрязва само последния етикет от партидата вместо при всяка граница на пауза.',
     outputHeading: 'Изход',
+    formatSection: 'Формат',
     labelShift: 'Отместване на етикета (dots)',
     offsetsHeading: 'Отмествания',
     offsetsHint: 'Премества началото на печат. Позициите на полетата в редактора остават абсолютни.',
@@ -415,7 +417,6 @@ const bg = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Вертикален / RTL текст',
       fpDirection: 'Посока',
       fpDirH: 'H — Хоризонтално',
       fpDirV: 'V — Вертикално (натрупано)',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -51,6 +51,8 @@ const cs = {
 
   properties: {
     positionSection: 'Pozice',
+    optionsSection: 'Možnosti',
+    typographySection: 'Typografie',
     name: 'Název',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const cs = {
     tidySection: 'Uspořádat',
     tidyUp: 'Uspořádat',
     tidyTooltip: 'Automaticky uspořádat do rovnoměrného řádku či sloupce',
-    tidyHint: 'Vyberte 2+ k uspořádání',
   },
 
   label: {
@@ -104,6 +105,7 @@ const cs = {
     overridePauseCount: 'Přepsat počet pauz',
     overridePauseCountHint: 'Řezat pouze poslední štítek dávky místo na každé hranici pauzy.',
     outputHeading: 'Výstup',
+    formatSection: 'Formát',
     labelShift: 'Posun štítku (dots)',
     offsetsHeading: 'Posuny',
     offsetsHint: 'Posune počátek tisku. Pozice polí v editoru zůstávají absolutní.',
@@ -415,7 +417,6 @@ const cs = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Svislý / RTL text',
       fpDirection: 'Směr',
       fpDirH: 'H — Vodorovně',
       fpDirV: 'V — Svisle (stoh)',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -51,6 +51,8 @@ const da = {
 
   properties: {
     positionSection: 'Position',
+    optionsSection: 'Indstillinger',
+    typographySection: 'Typografi',
     name: 'Navn',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const da = {
     tidySection: 'Ryd op',
     tidyUp: 'Ryd op',
     tidyTooltip: 'Arranger automatisk i en jævn række eller kolonne',
-    tidyHint: 'Vælg 2+ for at rydde op',
   },
 
   label: {
@@ -104,6 +105,7 @@ const da = {
     overridePauseCount: 'Tilsidesæt pausetæller',
     overridePauseCountHint: 'Skær kun den sidste etiket i batchen i stedet for ved hver pausegrænse.',
     outputHeading: 'Output',
+    formatSection: 'Format',
     labelShift: 'Etiketforskydning (dots)',
     offsetsHeading: 'Forskydninger',
     offsetsHint: 'Forskyder udskriftens origo. Feltpositioner i editoren forbliver absolutte.',
@@ -415,7 +417,6 @@ const da = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Lodret / højre-mod-venstre tekst',
       fpDirection: 'Retning',
       fpDirH: 'H — Vandret',
       fpDirV: 'V — Lodret (stak)',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -51,6 +51,8 @@ const de = {
 
   properties: {
     positionSection: 'Position',
+    optionsSection: 'Optionen',
+    typographySection: 'Typografie',
     name: 'Name',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const de = {
     tidySection: 'Aufräumen',
     tidyUp: 'Aufräumen',
     tidyTooltip: 'Automatisch in gleichmäßiger Reihe oder Spalte anordnen',
-    tidyHint: '2+ auswählen zum Aufräumen',
   },
 
   label: {
@@ -104,6 +105,7 @@ const de = {
     overridePauseCount: 'Pausenanzahl überschreiben',
     overridePauseCountHint: 'Nur das letzte Etikett der Charge schneiden, statt an jeder Pausengrenze.',
     outputHeading: 'Ausgabe',
+    formatSection: 'Format',
     labelShift: 'Label-Versatz (Punkte)',
     offsetsHeading: 'Offsets',
     offsetsHint: 'Verschiebt den Druckursprung. Feldpositionen im Editor bleiben absolut.',
@@ -436,7 +438,6 @@ const de = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invertieren',
-      fpAdvanced: 'Vertikaler / RTL-Text',
       fpDirection: 'Richtung',
       fpDirH: 'H — Horizontal',
       fpDirV: 'V — Vertikal (Stapel)',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -51,6 +51,8 @@ const el = {
 
   properties: {
     positionSection: 'Θέση',
+    optionsSection: 'Επιλογές',
+    typographySection: 'Τυπογραφία',
     name: 'Όνομα',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const el = {
     tidySection: 'Τακτοποίηση',
     tidyUp: 'Τακτοποίηση',
     tidyTooltip: 'Αυτόματη διάταξη σε ομοιόμορφη γραμμή ή στήλη',
-    tidyHint: 'Επιλέξτε 2+ για τακτοποίηση',
   },
 
   label: {
@@ -104,6 +105,7 @@ const el = {
     overridePauseCount: 'Παράκαμψη μετρητή παύσης',
     overridePauseCountHint: 'Κόψτε μόνο την τελευταία ετικέτα της παρτίδας αντί σε κάθε όριο παύσης.',
     outputHeading: 'Έξοδος',
+    formatSection: 'Μορφή',
     labelShift: 'Μετατόπιση ετικέτας (dots)',
     offsetsHeading: 'Μετατοπίσεις',
     offsetsHint: 'Μετατοπίζει την αρχή εκτύπωσης. Οι θέσεις των πεδίων στον επεξεργαστή παραμένουν απόλυτες.',
@@ -415,7 +417,6 @@ const el = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Κατακόρυφο / RTL κείμενο',
       fpDirection: 'Κατεύθυνση',
       fpDirH: 'H — Οριζόντια',
       fpDirV: 'V — Κατακόρυφα (στοίβα)',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -51,6 +51,8 @@ const en = {
 
   properties: {
     positionSection: 'Position',
+    optionsSection: 'Options',
+    typographySection: 'Typography',
     name: 'Name',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const en = {
     tidySection: 'Tidy up',
     tidyUp: 'Tidy up',
     tidyTooltip: 'Auto-arrange into an even row or column',
-    tidyHint: 'Select 2+ to tidy up',
   },
 
   label: {
@@ -104,6 +105,7 @@ const en = {
     overridePauseCount: 'Override pause count',
     overridePauseCountHint: 'Cut only the last label in the batch instead of every pause-count boundary.',
     outputHeading: 'Output',
+    formatSection: 'Format',
     labelShift: 'Label shift (dots)',
     offsetsHeading: 'Offsets',
     offsetsHint: 'Shifts the print origin. Field positions in the editor stay absolute.',
@@ -436,7 +438,6 @@ const en = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Vertical / right-to-left text',
       fpDirection: 'Direction',
       fpDirH: 'H — Horizontal',
       fpDirV: 'V — Vertical (stack)',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -51,6 +51,8 @@ const es = {
 
   properties: {
     positionSection: 'Posición',
+    optionsSection: 'Opciones',
+    typographySection: 'Tipografía',
     name: 'Nombre',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const es = {
     tidySection: 'Ordenar',
     tidyUp: 'Ordenar',
     tidyTooltip: 'Organizar automáticamente en una fila o columna uniforme',
-    tidyHint: 'Selecciona 2+ para ordenar',
   },
 
   label: {
@@ -104,6 +105,7 @@ const es = {
     overridePauseCount: 'Anular conteo de pausa',
     overridePauseCountHint: 'Cortar solo la última etiqueta del lote en lugar de cada límite de pausa.',
     outputHeading: 'Salida',
+    formatSection: 'Formato',
     labelShift: 'Desplazamiento de etiqueta (dots)',
     offsetsHeading: 'Desplazamientos',
     offsetsHint: 'Desplaza el origen de impresión. Las posiciones de campo en el editor permanecen absolutas.',
@@ -415,7 +417,6 @@ const es = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Texto vertical / RTL',
       fpDirection: 'Dirección',
       fpDirH: 'H — Horizontal',
       fpDirV: 'V — Vertical (apilado)',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -51,6 +51,8 @@ const et = {
 
   properties: {
     positionSection: 'Asukoht',
+    optionsSection: 'Valikud',
+    typographySection: 'Tüpograafia',
     name: 'Nimi',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const et = {
     tidySection: 'Korrasta',
     tidyUp: 'Korrasta',
     tidyTooltip: 'Korralda automaatselt ühtlasse ritta või veergu',
-    tidyHint: 'Korrastamiseks vali 2+',
   },
 
   label: {
@@ -104,6 +105,7 @@ const et = {
     overridePauseCount: 'Tühista pausi loendur',
     overridePauseCountHint: 'Lõika ainult partii viimane silt iga pausi piiri asemel.',
     outputHeading: 'Väljund',
+    formatSection: 'Vorming',
     labelShift: 'Etiketi nihe (dots)',
     offsetsHeading: 'Nihked',
     offsetsHint: 'Nihutab trükikoha alguspunkti. Väljade asukohad redaktoris jäävad absoluutseks.',
@@ -415,7 +417,6 @@ const et = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Vertikaalne / RTL tekst',
       fpDirection: 'Suund',
       fpDirH: 'H — Horisontaalne',
       fpDirV: 'V — Vertikaalne (virn)',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -51,6 +51,8 @@ const fa = {
 
   properties: {
     positionSection: 'موقعیت (میلی‌متر)',
+    optionsSection: 'گزینه‌ها',
+    typographySection: 'تایپوگرافی',
     name: 'نام',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const fa = {
     tidySection: 'مرتب‌سازی',
     tidyUp: 'مرتب‌سازی',
     tidyTooltip: 'چینش خودکار در یک ردیف یا ستون یکنواخت',
-    tidyHint: 'برای مرتب‌سازی ۲+ مورد انتخاب کنید',
   },
 
   label: {
@@ -104,6 +105,7 @@ const fa = {
     overridePauseCount: 'نادیده گرفتن شمارش توقف',
     overridePauseCountHint: 'فقط آخرین برچسب دسته را برش بزن، نه در هر مرز توقف.',
     outputHeading: 'خروجی',
+    formatSection: 'قالب',
     labelShift: 'جابجایی برچسب (dots)',
     offsetsHeading: 'افست‌ها',
     offsetsHint: 'مبدا چاپ را جابجا می‌کند. موقعیت فیلدها در ویرایشگر مطلق باقی می‌ماند.',
@@ -415,7 +417,6 @@ const fa = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'متن عمودی / RTL',
       fpDirection: 'جهت',
       fpDirH: 'H — افقی',
       fpDirV: 'V — عمودی (پشته)',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -51,6 +51,8 @@ const fi = {
 
   properties: {
     positionSection: 'Sijainti',
+    optionsSection: 'Asetukset',
+    typographySection: 'Typografia',
     name: 'Nimi',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const fi = {
     tidySection: 'Järjestä',
     tidyUp: 'Järjestä',
     tidyTooltip: 'Järjestä automaattisesti tasaiseksi riviksi tai sarakkeeksi',
-    tidyHint: 'Valitse 2+ järjestääksesi',
   },
 
   label: {
@@ -104,6 +105,7 @@ const fi = {
     overridePauseCount: 'Ohita taukolaskuri',
     overridePauseCountHint: 'Leikkaa vain erän viimeinen etiketti jokaisen taukorajan sijaan.',
     outputHeading: 'Tuloste',
+    formatSection: 'Muoto',
     labelShift: 'Tarrasiirtymä (dots)',
     offsetsHeading: 'Siirtymät',
     offsetsHint: 'Siirtää tulostuksen origoa. Kenttien sijainnit editorissa pysyvät absoluuttisina.',
@@ -415,7 +417,6 @@ const fi = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Pystysuora / RTL-teksti',
       fpDirection: 'Suunta',
       fpDirH: 'H — Vaakasuora',
       fpDirV: 'V — Pystysuora (pino)',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -51,6 +51,8 @@ const fr = {
 
   properties: {
     positionSection: 'Position',
+    optionsSection: 'Options',
+    typographySection: 'Typographie',
     name: 'Nom',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const fr = {
     tidySection: 'Ranger',
     tidyUp: 'Ranger',
     tidyTooltip: 'Disposer automatiquement en ligne ou colonne régulière',
-    tidyHint: 'Sélectionnez 2+ pour ranger',
   },
 
   label: {
@@ -104,6 +105,7 @@ const fr = {
     overridePauseCount: 'Remplacer le nombre de pauses',
     overridePauseCountHint: 'Couper uniquement la dernière étiquette du lot au lieu de chaque limite de pause.',
     outputHeading: 'Sortie',
+    formatSection: 'Format',
     labelShift: 'Décalage d\'étiquette (dots)',
     offsetsHeading: 'Décalages',
     offsetsHint: 'Décale l\'origine d\'impression. Les positions des champs dans l\'éditeur restent absolues.',
@@ -415,7 +417,6 @@ const fr = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Texte vertical / RTL',
       fpDirection: 'Direction',
       fpDirH: 'H — Horizontal',
       fpDirV: 'V — Vertical (empilé)',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -51,6 +51,8 @@ const he = {
 
   properties: {
     positionSection: 'מיקום (מ"מ)',
+    optionsSection: 'אפשרויות',
+    typographySection: 'טיפוגרפיה',
     name: 'שם',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const he = {
     tidySection: 'סידור',
     tidyUp: 'סידור',
     tidyTooltip: 'סידור אוטומטי בשורה או עמודה אחידה',
-    tidyHint: 'בחר 2+ לסידור',
   },
 
   label: {
@@ -104,6 +105,7 @@ const he = {
     overridePauseCount: 'עקוף ספירת השהיה',
     overridePauseCountHint: 'חתוך רק את התווית האחרונה באצווה במקום בכל גבול השהיה.',
     outputHeading: 'פלט',
+    formatSection: 'פורמט',
     labelShift: 'הסטת תווית (dots)',
     offsetsHeading: 'היסטים',
     offsetsHint: 'מזיז את ראשית ההדפסה. מיקומי השדות בעורך נשארים מוחלטים.',
@@ -415,7 +417,6 @@ const he = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'טקסט אנכי / RTL',
       fpDirection: 'כיוון',
       fpDirH: 'H — אופקי',
       fpDirV: 'V — אנכי (ערימה)',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -51,6 +51,8 @@ const hr = {
 
   properties: {
     positionSection: 'Položaj',
+    optionsSection: 'Opcije',
+    typographySection: 'Tipografija',
     name: 'Naziv',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const hr = {
     tidySection: 'Posloži',
     tidyUp: 'Posloži',
     tidyTooltip: 'Automatski rasporedi u ravnomjeran red ili stupac',
-    tidyHint: 'Odaberi 2+ za slaganje',
   },
 
   label: {
@@ -104,6 +105,7 @@ const hr = {
     overridePauseCount: 'Premosti brojač pauze',
     overridePauseCountHint: 'Reže samo posljednju etiketu serije umjesto na svakoj granici pauze.',
     outputHeading: 'Izlaz',
+    formatSection: 'Format',
     labelShift: 'Pomak naljepnice (dots)',
     offsetsHeading: 'Pomaci',
     offsetsHint: 'Pomiče ishodište ispisa. Pozicije polja u uredniku ostaju apsolutne.',
@@ -415,7 +417,6 @@ const hr = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Okomiti / RTL tekst',
       fpDirection: 'Smjer',
       fpDirH: 'H — Vodoravno',
       fpDirV: 'V — Okomito (snop)',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -51,6 +51,8 @@ const hu = {
 
   properties: {
     positionSection: 'Pozíció',
+    optionsSection: 'Beállítások',
+    typographySection: 'Tipográfia',
     name: 'Név',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const hu = {
     tidySection: 'Rendezés',
     tidyUp: 'Rendezés',
     tidyTooltip: 'Automatikus rendezés egyenletes sorba vagy oszlopba',
-    tidyHint: 'Jelölj ki 2+ a rendezéshez',
   },
 
   label: {
@@ -104,6 +105,7 @@ const hu = {
     overridePauseCount: 'Szünetszám felülbírálása',
     overridePauseCountHint: 'Csak a köteg utolsó címkéjét vágja minden szünethatár helyett.',
     outputHeading: 'Kimenet',
+    formatSection: 'Formátum',
     labelShift: 'Címke eltolás (dots)',
     offsetsHeading: 'Eltolások',
     offsetsHint: 'Eltolja a nyomtatás origóját. A mezők pozíciói a szerkesztőben abszolútak maradnak.',
@@ -415,7 +417,6 @@ const hu = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Függőleges / RTL szöveg',
       fpDirection: 'Irány',
       fpDirH: 'H — Vízszintes',
       fpDirV: 'V — Függőleges (rakott)',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -51,6 +51,8 @@ const it = {
 
   properties: {
     positionSection: 'Posizione',
+    optionsSection: 'Opzioni',
+    typographySection: 'Tipografia',
     name: 'Nome',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const it = {
     tidySection: 'Riordina',
     tidyUp: 'Riordina',
     tidyTooltip: 'Disponi automaticamente in riga o colonna uniforme',
-    tidyHint: 'Seleziona 2+ per riordinare',
   },
 
   label: {
@@ -104,6 +105,7 @@ const it = {
     overridePauseCount: 'Sostituisci conteggio pause',
     overridePauseCountHint: 'Taglia solo l\'ultima etichetta del lotto invece di ogni limite di pausa.',
     outputHeading: 'Output',
+    formatSection: 'Formato',
     labelShift: 'Spostamento etichetta (dots)',
     offsetsHeading: 'Offset',
     offsetsHint: 'Sposta l\'origine di stampa. Le posizioni dei campi nell\'editor restano assolute.',
@@ -415,7 +417,6 @@ const it = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Testo verticale / RTL',
       fpDirection: 'Direzione',
       fpDirH: 'H — Orizzontale',
       fpDirV: 'V — Verticale (impilato)',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -51,6 +51,8 @@ const ja = {
 
   properties: {
     positionSection: '位置',
+    optionsSection: 'オプション',
+    typographySection: 'タイポグラフィ',
     name: '名前',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const ja = {
     tidySection: '整頓',
     tidyUp: '整頓',
     tidyTooltip: '均等な行または列に自動配置',
-    tidyHint: '整頓するには2つ以上選択',
   },
 
   label: {
@@ -104,6 +105,7 @@ const ja = {
     overridePauseCount: '一時停止カウントを上書き',
     overridePauseCountHint: '各一時停止境界ではなく、バッチの最後のラベルのみカットします。',
     outputHeading: '出力',
+    formatSection: 'フォーマット',
     labelShift: 'ラベルシフト (dots)',
     offsetsHeading: 'オフセット',
     offsetsHint: '印刷原点をずらします。エディタ内のフィールド位置は絶対のまま。',
@@ -415,7 +417,6 @@ const ja = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: '縦書き / 右から左 テキスト',
       fpDirection: '方向',
       fpDirH: 'H — 横',
       fpDirV: 'V — 縦 (積み重ね)',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -51,6 +51,8 @@ const ko = {
 
   properties: {
     positionSection: '위치',
+    optionsSection: '옵션',
+    typographySection: '타이포그래피',
     name: '이름',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const ko = {
     tidySection: '정돈',
     tidyUp: '정돈',
     tidyTooltip: '균등한 행 또는 열로 자동 배치',
-    tidyHint: '정돈하려면 2개 이상 선택',
   },
 
   label: {
@@ -104,6 +105,7 @@ const ko = {
     overridePauseCount: '일시정지 카운트 재정의',
     overridePauseCountHint: '각 일시정지 경계가 아닌 배치의 마지막 라벨만 자릅니다.',
     outputHeading: '출력',
+    formatSection: '형식',
     labelShift: '라벨 이동 (dots)',
     offsetsHeading: '오프셋',
     offsetsHint: '인쇄 원점을 이동합니다. 편집기의 필드 위치는 절대값으로 유지됩니다.',
@@ -415,7 +417,6 @@ const ko = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: '세로 / RTL 텍스트',
       fpDirection: '방향',
       fpDirH: 'H — 가로',
       fpDirV: 'V — 세로 (스택)',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -51,6 +51,8 @@ const lt = {
 
   properties: {
     positionSection: 'Padėtis',
+    optionsSection: 'Parinktys',
+    typographySection: 'Tipografija',
     name: 'Pavadinimas',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const lt = {
     tidySection: 'Sutvarkyti',
     tidyUp: 'Sutvarkyti',
     tidyTooltip: 'Automatiškai išdėstyti tolygia eilute ar stulpeliu',
-    tidyHint: 'Pasirinkite 2+, kad sutvarkytumėte',
   },
 
   label: {
@@ -104,6 +105,7 @@ const lt = {
     overridePauseCount: 'Nepaisyti pauzės skaitiklio',
     overridePauseCountHint: 'Kirpti tik paskutinę partijos etiketę vietoj kiekvienos pauzės ribos.',
     outputHeading: 'Išvestis',
+    formatSection: 'Formatas',
     labelShift: 'Etiketės poslinkis (dots)',
     offsetsHeading: 'Poslinkiai',
     offsetsHint: 'Perkelia spaudos pradžios tašką. Laukų pozicijos redaktoriuje lieka absoliučios.',
@@ -415,7 +417,6 @@ const lt = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Vertikalus / RTL tekstas',
       fpDirection: 'Kryptis',
       fpDirH: 'H — Horizontaliai',
       fpDirV: 'V — Vertikaliai (rietuvė)',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -51,6 +51,8 @@ const lv = {
 
   properties: {
     positionSection: 'Pozīcija',
+    optionsSection: 'Opcijas',
+    typographySection: 'Tipogrāfija',
     name: 'Nosaukums',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const lv = {
     tidySection: 'Sakārtot',
     tidyUp: 'Sakārtot',
     tidyTooltip: 'Automātiski izkārtot vienmērīgā rindā vai kolonnā',
-    tidyHint: 'Atlasiet 2+, lai sakārtotu',
   },
 
   label: {
@@ -104,6 +105,7 @@ const lv = {
     overridePauseCount: 'Pārrakstīt pauzes skaitītāju',
     overridePauseCountHint: 'Griezt tikai pēdējo partijas etiķeti, nevis pie katras pauzes robežas.',
     outputHeading: 'Izvade',
+    formatSection: 'Formāts',
     labelShift: 'Etiķetes nobīde (dots)',
     offsetsHeading: 'Nobīdes',
     offsetsHint: 'Pārvieto druku sākumpunktu. Lauku pozīcijas redaktorā paliek absolūtas.',
@@ -415,7 +417,6 @@ const lv = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Vertikāls / RTL teksts',
       fpDirection: 'Virziens',
       fpDirH: 'H — Horizontāli',
       fpDirV: 'V — Vertikāli (kaudze)',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -51,6 +51,8 @@ const nl = {
 
   properties: {
     positionSection: 'Positie',
+    optionsSection: 'Opties',
+    typographySection: 'Typografie',
     name: 'Naam',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const nl = {
     tidySection: 'Opruimen',
     tidyUp: 'Opruimen',
     tidyTooltip: 'Automatisch in een gelijkmatige rij of kolom schikken',
-    tidyHint: 'Selecteer er 2+ om op te ruimen',
   },
 
   label: {
@@ -104,6 +105,7 @@ const nl = {
     overridePauseCount: 'Pauzeteller overschrijven',
     overridePauseCountHint: 'Snijdt alleen het laatste label van de batch in plaats van bij elke pauzegrens.',
     outputHeading: 'Uitvoer',
+    formatSection: 'Formaat',
     labelShift: 'Etiketverschuiving (dots)',
     offsetsHeading: 'Offsets',
     offsetsHint: 'Verschuift de afdrukoorsprong. Veldposities in de editor blijven absoluut.',
@@ -415,7 +417,6 @@ const nl = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Verticale / RTL tekst',
       fpDirection: 'Richting',
       fpDirH: 'H — Horizontaal',
       fpDirV: 'V — Verticaal (gestapeld)',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -51,6 +51,8 @@ const no = {
 
   properties: {
     positionSection: 'Posisjon',
+    optionsSection: 'Alternativer',
+    typographySection: 'Typografi',
     name: 'Navn',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const no = {
     tidySection: 'Rydd opp',
     tidyUp: 'Rydd opp',
     tidyTooltip: 'Ordne automatisk i en jevn rad eller kolonne',
-    tidyHint: 'Velg 2+ for å rydde opp',
   },
 
   label: {
@@ -104,6 +105,7 @@ const no = {
     overridePauseCount: 'Overstyr pauseteller',
     overridePauseCountHint: 'Kutt kun siste etikett i partiet i stedet for ved hver pausegrense.',
     outputHeading: 'Utdata',
+    formatSection: 'Format',
     labelShift: 'Etikettforskyvning (dots)',
     offsetsHeading: 'Forskyvninger',
     offsetsHint: 'Forskyver utskriftsorigo. Feltposisjoner i editoren forblir absolutte.',
@@ -415,7 +417,6 @@ const no = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Loddrett / RTL-tekst',
       fpDirection: 'Retning',
       fpDirH: 'H — Vannrett',
       fpDirV: 'V — Loddrett (stabel)',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -51,6 +51,8 @@ const pl = {
 
   properties: {
     positionSection: 'Pozycja',
+    optionsSection: 'Opcje',
+    typographySection: 'Typografia',
     name: 'Nazwa',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const pl = {
     tidySection: 'Uporządkuj',
     tidyUp: 'Uporządkuj',
     tidyTooltip: 'Automatycznie ułóż w równy wiersz lub kolumnę',
-    tidyHint: 'Zaznacz 2+, aby uporządkować',
   },
 
   label: {
@@ -104,6 +105,7 @@ const pl = {
     overridePauseCount: 'Zastąp licznik pauzy',
     overridePauseCountHint: 'Przytnij tylko ostatnią etykietę partii zamiast przy każdej granicy pauzy.',
     outputHeading: 'Wyjście',
+    formatSection: 'Format',
     labelShift: 'Przesunięcie etykiety (dots)',
     offsetsHeading: 'Przesunięcia',
     offsetsHint: 'Przesuwa początek wydruku. Pozycje pól w edytorze pozostają absolutne.',
@@ -415,7 +417,6 @@ const pl = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Pionowy / RTL tekst',
       fpDirection: 'Kierunek',
       fpDirH: 'H — Poziomo',
       fpDirV: 'V — Pionowo (stos)',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -51,6 +51,8 @@ const pt = {
 
   properties: {
     positionSection: 'Posição',
+    optionsSection: 'Opções',
+    typographySection: 'Tipografia',
     name: 'Nome',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const pt = {
     tidySection: 'Organizar',
     tidyUp: 'Organizar',
     tidyTooltip: 'Organizar automaticamente em linha ou coluna uniforme',
-    tidyHint: 'Selecione 2+ para organizar',
   },
 
   label: {
@@ -104,6 +105,7 @@ const pt = {
     overridePauseCount: 'Substituir contagem de pausa',
     overridePauseCountHint: 'Cortar apenas a última etiqueta do lote em vez de cada limite de pausa.',
     outputHeading: 'Saída',
+    formatSection: 'Formato',
     labelShift: 'Deslocamento da etiqueta (dots)',
     offsetsHeading: 'Deslocamentos',
     offsetsHint: 'Desloca a origem de impressão. As posições dos campos no editor permanecem absolutas.',
@@ -415,7 +417,6 @@ const pt = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Texto vertical / RTL',
       fpDirection: 'Direção',
       fpDirH: 'H — Horizontal',
       fpDirV: 'V — Vertical (empilhado)',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -51,6 +51,8 @@ const ro = {
 
   properties: {
     positionSection: 'Poziție',
+    optionsSection: 'Opțiuni',
+    typographySection: 'Tipografie',
     name: 'Nume',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const ro = {
     tidySection: 'Ordonare',
     tidyUp: 'Ordonare',
     tidyTooltip: 'Aranjează automat într-un rând sau o coloană uniformă',
-    tidyHint: 'Selectați 2+ pentru ordonare',
   },
 
   label: {
@@ -104,6 +105,7 @@ const ro = {
     overridePauseCount: 'Suprascrie nr. pauze',
     overridePauseCountHint: 'Taie doar ultima etichetă din lot în loc de fiecare limită de pauză.',
     outputHeading: 'Ieșire',
+    formatSection: 'Format',
     labelShift: 'Deplasare etichetă (dots)',
     offsetsHeading: 'Decalaje',
     offsetsHint: 'Mută originea de tipărire. Pozițiile câmpurilor în editor rămân absolute.',
@@ -415,7 +417,6 @@ const ro = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Text vertical / RTL',
       fpDirection: 'Direcție',
       fpDirH: 'H — Orizontal',
       fpDirV: 'V — Vertical (stivă)',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -51,6 +51,8 @@ const sk = {
 
   properties: {
     positionSection: 'Pozícia',
+    optionsSection: 'Možnosti',
+    typographySection: 'Typografia',
     name: 'Názov',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const sk = {
     tidySection: 'Usporiadať',
     tidyUp: 'Usporiadať',
     tidyTooltip: 'Automaticky usporiadať do rovnomerného riadka alebo stĺpca',
-    tidyHint: 'Vyberte 2+ na usporiadanie',
   },
 
   label: {
@@ -104,6 +105,7 @@ const sk = {
     overridePauseCount: 'Prepísať počet páuz',
     overridePauseCountHint: 'Rezať iba posledný štítok dávky namiesto pri každej hranici pauzy.',
     outputHeading: 'Výstup',
+    formatSection: 'Formát',
     labelShift: 'Posun štítka (dots)',
     offsetsHeading: 'Posuny',
     offsetsHint: 'Posunie počiatok tlače. Pozície polí v editore zostávajú absolútne.',
@@ -415,7 +417,6 @@ const sk = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Zvislý / RTL text',
       fpDirection: 'Smer',
       fpDirH: 'H — Vodorovne',
       fpDirV: 'V — Zvisle (stoh)',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -51,6 +51,8 @@ const sl = {
 
   properties: {
     positionSection: 'Položaj',
+    optionsSection: 'Možnosti',
+    typographySection: 'Tipografija',
     name: 'Ime',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const sl = {
     tidySection: 'Uredi',
     tidyUp: 'Uredi',
     tidyTooltip: 'Samodejno razporedi v enakomerno vrstico ali stolpec',
-    tidyHint: 'Izberite 2+ za ureditev',
   },
 
   label: {
@@ -104,6 +105,7 @@ const sl = {
     overridePauseCount: 'Razveljavi števec premorov',
     overridePauseCountHint: 'Reže le zadnjo etiketo serije namesto pri vsaki meji premora.',
     outputHeading: 'Izhod',
+    formatSection: 'Oblika',
     labelShift: 'Zamik nalepke (dots)',
     offsetsHeading: 'Odmiki',
     offsetsHint: 'Premakne izhodišče tiska. Položaji polj v urejevalniku ostanejo absolutni.',
@@ -415,7 +417,6 @@ const sl = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Navpično / RTL besedilo',
       fpDirection: 'Smer',
       fpDirH: 'H — Vodoravno',
       fpDirV: 'V — Navpično (sklad)',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -51,6 +51,8 @@ const sr = {
 
   properties: {
     positionSection: 'Položaj',
+    optionsSection: 'Опције',
+    typographySection: 'Типографија',
     name: 'Naziv',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const sr = {
     tidySection: 'Сложи',
     tidyUp: 'Сложи',
     tidyTooltip: 'Аутоматски распореди у равномеран ред или колону',
-    tidyHint: 'Изаберите 2+ за слагање',
   },
 
   label: {
@@ -104,6 +105,7 @@ const sr = {
     overridePauseCount: 'Премости бројач паузе',
     overridePauseCountHint: 'Сече само последњу етикету серије уместо на свакој граници паузе.',
     outputHeading: 'Излаз',
+    formatSection: 'Формат',
     labelShift: 'Померај етикете (dots)',
     offsetsHeading: 'Помераји',
     offsetsHint: 'Помера исходиште штампе. Позиције поља у уреднику остају апсолутне.',
@@ -415,7 +417,6 @@ const sr = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Vertikalni / RTL tekst',
       fpDirection: 'Smer',
       fpDirH: 'H — Vodoravno',
       fpDirV: 'V — Vertikalno (stek)',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -51,6 +51,8 @@ const sv = {
 
   properties: {
     positionSection: 'Position',
+    optionsSection: 'Alternativ',
+    typographySection: 'Typografi',
     name: 'Namn',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const sv = {
     tidySection: 'Städa upp',
     tidyUp: 'Städa upp',
     tidyTooltip: 'Ordna automatiskt i jämn rad eller kolumn',
-    tidyHint: 'Välj 2+ för att städa upp',
   },
 
   label: {
@@ -104,6 +105,7 @@ const sv = {
     overridePauseCount: 'Åsidosätt pausräknare',
     overridePauseCountHint: 'Klipp endast den sista etiketten i partiet istället för vid varje pausgräns.',
     outputHeading: 'Utmatning',
+    formatSection: 'Format',
     labelShift: 'Etikettförskjutning (dots)',
     offsetsHeading: 'Förskjutningar',
     offsetsHint: 'Förskjuter utskriftens ursprung. Fältpositioner i redigeraren förblir absoluta.',
@@ -415,7 +417,6 @@ const sv = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Lodrät / RTL-text',
       fpDirection: 'Riktning',
       fpDirH: 'H — Vågrät',
       fpDirV: 'V — Lodrät (stack)',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -51,6 +51,8 @@ const tr = {
 
   properties: {
     positionSection: 'Konum',
+    optionsSection: 'Seçenekler',
+    typographySection: 'Tipografi',
     name: 'Ad',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const tr = {
     tidySection: 'Düzenle',
     tidyUp: 'Düzenle',
     tidyTooltip: 'Eşit satır veya sütun halinde otomatik düzenle',
-    tidyHint: 'Düzenlemek için 2+ seçin',
   },
 
   label: {
@@ -104,6 +105,7 @@ const tr = {
     overridePauseCount: 'Duraklatma sayısını geçersiz kıl',
     overridePauseCountHint: 'Her duraklatma sınırında değil, partinin yalnızca son etiketini kes.',
     outputHeading: 'Çıktı',
+    formatSection: 'Biçim',
     labelShift: 'Etiket kaydırma (dots)',
     offsetsHeading: 'Ofsetler',
     offsetsHint: 'Yazdırma orijinini kaydırır. Düzenleyicideki alan konumları mutlak kalır.',
@@ -415,7 +417,6 @@ const tr = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: 'Dikey / RTL metin',
       fpDirection: 'Yön',
       fpDirH: 'H — Yatay',
       fpDirV: 'V — Dikey (yığın)',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -51,6 +51,8 @@ const zhHans = {
 
   properties: {
     positionSection: '位置 (毫米)',
+    optionsSection: '选项',
+    typographySection: '排版',
     name: '名称',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const zhHans = {
     tidySection: '整理',
     tidyUp: '整理',
     tidyTooltip: '自动排列成均匀的行或列',
-    tidyHint: '选择 2+ 个以整理',
   },
 
   label: {
@@ -104,6 +105,7 @@ const zhHans = {
     overridePauseCount: '覆盖暂停计数',
     overridePauseCountHint: '仅切批次最后一个标签，而不是每个暂停边界。',
     outputHeading: '输出',
+    formatSection: '格式',
     labelShift: '标签偏移 (dots)',
     offsetsHeading: '偏移',
     offsetsHint: '偏移打印原点。编辑器中字段位置保持绝对。',
@@ -415,7 +417,6 @@ const zhHans = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: '纵向 / 右起 文本',
       fpDirection: '方向',
       fpDirH: 'H — 水平',
       fpDirV: 'V — 垂直 (堆叠)',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -51,6 +51,8 @@ const zhHant = {
 
   properties: {
     positionSection: '位置 (公釐)',
+    optionsSection: '選項',
+    typographySection: '排版',
     name: '名稱',
     x: 'X',
     y: 'Y',
@@ -81,7 +83,6 @@ const zhHant = {
     tidySection: '整理',
     tidyUp: '整理',
     tidyTooltip: '自動排列成均勻的列或欄',
-    tidyHint: '選擇 2+ 個以整理',
   },
 
   label: {
@@ -104,6 +105,7 @@ const zhHant = {
     overridePauseCount: '覆寫暫停計數',
     overridePauseCountHint: '僅切批次最後一個標籤，而不是每個暫停邊界。',
     outputHeading: '輸出',
+    formatSection: '格式',
     labelShift: '標籤偏移 (dots)',
     offsetsHeading: '偏移',
     offsetsHint: '偏移列印原點。編輯器中欄位位置保持絕對。',
@@ -415,7 +417,6 @@ const zhHant = {
       rotationI: '180° (I)',
       rotationB: '270° (B)',
       reverse: 'Invert',
-      fpAdvanced: '縱向 / 右起 文字',
       fpDirection: '方向',
       fpDirH: 'H — 水平',
       fpDirV: 'V — 垂直 (堆疊)',

--- a/src/registry/text.panel.tsx
+++ b/src/registry/text.panel.tsx
@@ -11,6 +11,7 @@ import { NumberInput } from "../components/Properties/NumberInput";
 import { TemplateContentInput } from "../components/Properties/TemplateContentInput";
 import { BlockTextSettings } from "../components/Properties/BlockTextSettings";
 import { FpSettings } from "../components/Properties/FpSettings";
+import { SectionCard, StaticSectionCard, ToggleSectionCard } from "../components/Properties/SectionCard";
 import { deriveBlockTextPatch, FB_DEFAULTS } from "../lib/textBlock";
 import type { TextProps } from "./text";
 
@@ -33,10 +34,10 @@ export const textPanel: ObjectTypeUi<TextProps> = {
     const fontIdOptions = getAvailableFontIds(label);
     const fontLoaded = !!p.printerFontName && !!getFont(p.printerFontName);
     const fontAssignedButMissing = !!p.printerFontName && !fontLoaded;
-    const [showAdvanced, setShowAdvanced] = useState(!!p.printerFontName);
-    // Niche (CJK / RTL); auto-expand only when already in use.
+    // One "Advanced" reveal for both the legacy font-filename override and
+    // the niche ^FP direction/gap (CJK / RTL); auto-open when either is in use.
     const fpInUse = p.fpDirection !== undefined || (p.fpCharGap ?? 0) > 0;
-    const [showFp, setShowFp] = useState(fpInUse);
+    const [showAdvanced, setShowAdvanced] = useState(!!p.printerFontName || fpInUse);
 
     const handleFontUpload = useCallback(
       async (file: File) => {
@@ -52,103 +53,8 @@ export const textPanel: ObjectTypeUi<TextProps> = {
     );
 
     return (
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1">
-          <label className={labelCls}>{t.registry.text.printerFont}</label>
-          <select
-            className={inputCls}
-            value={p.fontId ?? ""}
-            onChange={(e) =>
-              onChange({
-                fontId: e.target.value || undefined,
-                // Selecting an alias supersedes the legacy filename form.
-                printerFontName: e.target.value ? undefined : p.printerFontName,
-              })
-            }
-          >
-            <option value="">{t.registry.text.useLabelDefault}</option>
-            {fontIdOptions.map((opt) => {
-              const previewName =
-                opt.previewFontName ??
-                (opt.path ? stripDrivePrefix(opt.path) : undefined);
-              const suffix = previewName
-                ? ` — ${previewName}`
-                : opt.builtin
-                  ? `  ${t.registry.text.builtinSuffix}`
-                  : "";
-              return (
-                <option key={opt.id} value={opt.id}>
-                  {opt.id}
-                  {suffix}
-                </option>
-              );
-            })}
-          </select>
-          <button
-            type="button"
-            className="text-[10px] text-muted hover:text-text text-left mt-1"
-            onClick={() => setShowAdvanced((v) => !v)}
-          >
-            {showAdvanced
-              ? `▾ ${t.registry.text.fontAdvanced}`
-              : `▸ ${t.registry.text.fontAdvanced}`}
-          </button>
-          {showAdvanced && (
-            <div className="flex flex-col gap-1 mt-1 pl-3 border-l border-border">
-              <label className="text-[10px] text-muted">
-                {t.registry.text.fontFilenameLabel}
-              </label>
-              <input
-                type="text"
-                className={inputCls}
-                placeholder="ARIAL.TTF"
-                value={p.printerFontName ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    printerFontName: e.target.value || undefined,
-                    fontId: e.target.value ? undefined : p.fontId,
-                  })
-                }
-              />
-              {fontLoaded && (
-                <span className="text-[10px] text-accent font-mono">
-                  {t.registry.text.fontLoaded}
-                </span>
-              )}
-              {fontAssignedButMissing && (
-                <>
-                  <span className="text-[10px] text-muted font-mono">
-                    {t.registry.text.fontMissing}
-                  </span>
-                  <input
-                    ref={fileRef}
-                    type="file"
-                    accept=".ttf,.otf,.TTF,.OTF"
-                    className="hidden"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (file) void handleFontUpload(file);
-                      e.target.value = "";
-                    }}
-                  />
-                  <button
-                    type="button"
-                    className={buttonCls}
-                    onClick={() => fileRef.current?.click()}
-                    disabled={uploading}
-                  >
-                    {uploading
-                      ? t.registry.text.uploadingFont
-                      : t.registry.text.uploadFont}
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label className={labelCls}>{t.registry.text.content}</label>
+      <>
+        <StaticSectionCard title={t.registry.text.content}>
           <TemplateContentInput
             objectId={obj.id}
             value={p.content}
@@ -156,82 +62,162 @@ export const textPanel: ObjectTypeUi<TextProps> = {
               onChange(deriveBlockTextPatch(content, p, p.fontHeight, p.fontWidth))
             }
           />
-        </div>
+        </StaticSectionCard>
 
-        {/* Block-Text settings sit directly under the content editor
-            because they govern how that content renders (wrap width,
-            max lines, justify); keeping them adjacent makes the
-            cause/effect relationship obvious. Other settings (font,
-            rotation, reverse) act on the whole field and come below. */}
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            className="accent-accent"
-            checked={!!p.blockWidth}
-            onChange={(e) =>
-              onChange(
-                e.target.checked
-                  ? { ...FB_DEFAULTS, blockLines: 3 }
-                  : {
-                      blockWidth: undefined,
-                      blockLines: undefined,
-                      blockLineSpacing: undefined,
-                      blockJustify: undefined,
-                    },
-              )
-            }
+        <SectionCard id="text-typography" title={t.properties.typographySection}>
+          <div className="flex flex-col gap-1">
+            <label className={labelCls}>{t.registry.text.printerFont}</label>
+            <select
+              className={inputCls}
+              value={p.fontId ?? ""}
+              onChange={(e) =>
+                onChange({
+                  fontId: e.target.value || undefined,
+                  // Selecting an alias supersedes the legacy filename form.
+                  printerFontName: e.target.value ? undefined : p.printerFontName,
+                })
+              }
+            >
+              <option value="">{t.registry.text.useLabelDefault}</option>
+              {fontIdOptions.map((opt) => {
+                const previewName =
+                  opt.previewFontName ??
+                  (opt.path ? stripDrivePrefix(opt.path) : undefined);
+                const suffix = previewName
+                  ? ` — ${previewName}`
+                  : opt.builtin
+                    ? `  ${t.registry.text.builtinSuffix}`
+                    : "";
+                return (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.id}
+                    {suffix}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <NumberInput
+              label={t.registry.text.fontHeight}
+              value={p.fontHeight}
+              min={1}
+              onChange={(fontHeight) => onChange({ fontHeight })}
+            />
+            <NumberInput
+              label={t.registry.text.fontWidth}
+              value={p.fontWidth}
+              min={0}
+              onChange={(fontWidth) => onChange({ fontWidth })}
+            />
+          </div>
+
+          <RotationSelect
+            value={p.rotation}
+            onChange={(rotation) => onChange({ rotation })}
           />
-          <span className={labelCls}>{t.registry.text.fieldBlock}</span>
-        </label>
 
-        {!!p.blockWidth && <BlockTextSettings props={p} onChange={onChange} />}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              className="accent-accent"
+              checked={p.reverse ?? false}
+              onChange={(e) => onChange({ reverse: e.target.checked })}
+            />
+            <span className={labelCls}>{t.registry.text.reverse}</span>
+          </label>
 
-        <div className="grid grid-cols-2 gap-2">
-          <NumberInput
-            label={t.registry.text.fontHeight}
-            value={p.fontHeight}
-            min={1}
-            onChange={(fontHeight) => onChange({ fontHeight })}
-          />
-          <NumberInput
-            label={t.registry.text.fontWidth}
-            value={p.fontWidth}
-            min={0}
-            onChange={(fontWidth) => onChange({ fontWidth })}
-          />
-        </div>
+          <div className="flex flex-col gap-1">
+            <button
+              type="button"
+              className="text-[10px] text-muted hover:text-text text-left"
+              onClick={() => setShowAdvanced((v) => !v)}
+              aria-expanded={showAdvanced}
+            >
+              {showAdvanced
+                ? `▾ ${t.registry.text.fontAdvanced}`
+                : `▸ ${t.registry.text.fontAdvanced}`}
+            </button>
+            {showAdvanced && (
+              <div className="flex flex-col gap-2 mt-1 pl-3 border-l border-border">
+                <div className="flex flex-col gap-1">
+                  <label className="text-[10px] text-muted">
+                    {t.registry.text.fontFilenameLabel}
+                  </label>
+                  <input
+                    type="text"
+                    className={inputCls}
+                    placeholder="ARIAL.TTF"
+                    value={p.printerFontName ?? ""}
+                    onChange={(e) =>
+                      onChange({
+                        printerFontName: e.target.value || undefined,
+                        fontId: e.target.value ? undefined : p.fontId,
+                      })
+                    }
+                  />
+                  {fontLoaded && (
+                    <span className="text-[10px] text-accent font-mono">
+                      {t.registry.text.fontLoaded}
+                    </span>
+                  )}
+                  {fontAssignedButMissing && (
+                    <>
+                      <span className="text-[10px] text-muted font-mono">
+                        {t.registry.text.fontMissing}
+                      </span>
+                      <input
+                        ref={fileRef}
+                        type="file"
+                        accept=".ttf,.otf,.TTF,.OTF"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (file) void handleFontUpload(file);
+                          e.target.value = "";
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className={buttonCls}
+                        onClick={() => fileRef.current?.click()}
+                        disabled={uploading}
+                      >
+                        {uploading
+                          ? t.registry.text.uploadingFont
+                          : t.registry.text.uploadFont}
+                      </button>
+                    </>
+                  )}
+                </div>
+                <FpSettings props={p} onChange={onChange} />
+              </div>
+            )}
+          </div>
+        </SectionCard>
 
-        <RotationSelect
-          value={p.rotation}
-          onChange={(rotation) => onChange({ rotation })}
-        />
-
-        {/* ^FP sits next to Rotation: both govern glyph flow rather
-            than what is painted. */}
-        <div className="flex flex-col gap-1">
-          <button
-            type="button"
-            className="text-[10px] text-muted hover:text-text text-left"
-            onClick={() => setShowFp((v) => !v)}
-            aria-expanded={showFp}
-          >
-            {showFp
-              ? `▾ ${t.registry.text.fpAdvanced}`
-              : `▸ ${t.registry.text.fpAdvanced}`}
-          </button>
-          {showFp && <FpSettings props={p} onChange={onChange} />}
-        </div>
-
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            className="accent-accent"
-            checked={p.reverse ?? false}
-            onChange={(e) => onChange({ reverse: e.target.checked })}
-          />
-          <span className={labelCls}>{t.registry.text.reverse}</span>
-        </label>
-      </div>
+        {/* The card header switch is the ^FB enable control; the body
+            (BlockTextSettings, drag-mode first) shows only while on. */}
+        <ToggleSectionCard
+          title={t.registry.text.fieldBlock}
+          checked={!!p.blockWidth}
+          onCheckedChange={(on) =>
+            onChange(
+              on
+                ? { ...FB_DEFAULTS, blockLines: 3 }
+                : {
+                    blockWidth: undefined,
+                    blockLines: undefined,
+                    blockLineSpacing: undefined,
+                    blockJustify: undefined,
+                  },
+            )
+          }
+        >
+          <BlockTextSettings props={p} onChange={onChange} />
+        </ToggleSectionCard>
+      </>
     );
   },
 };


### PR DESCRIPTION
Cards lift off the bg-surface panel via border + shadow; field block behind a header switch, the two text advanced reveals merged, align compacts for single selection. SectionCard reuses CollapsibleSection persistence via a shared hook.