### PR TITLE
feat(canvas): whole-row palette drag + clickable rotate-degree chip

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -853,17 +853,19 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
         </button>
         <div className="w-px h-3.5 bg-border mx-0.5" />
         <Tooltip content={`${t.app.rotateView} (R)`}>
+          {/* Degree readout lives inside the button so the whole chip rotates,
+              not just the arrow. */}
           <button
             onClick={rotateView}
             aria-label={t.app.rotateView}
-            className={`w-6 h-6 flex items-center justify-center text-sm transition-colors ${viewRotation !== 0 ? "text-accent" : "text-muted hover:text-text"}`}
+            className={`h-6 px-1.5 flex items-center justify-center gap-1 text-sm transition-colors ${viewRotation !== 0 ? "text-accent" : "text-muted hover:text-text"}`}
           >
-            ↻
+            <span>↻</span>
+            {viewRotation !== 0 && (
+              <span className="font-mono text-[10px]">{viewRotation}°</span>
+            )}
           </button>
         </Tooltip>
-        {viewRotation !== 0 && (
-          <span className="font-mono text-[10px] text-accent w-6 text-center">{viewRotation}°</span>
-        )}
       </div>
       {containerSize.width > 0 && (
         <Stage

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -853,8 +853,8 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
         </button>
         <div className="w-px h-3.5 bg-border mx-0.5" />
         <Tooltip content={`${t.app.rotateView} (R)`}>
-          {/* Degree readout lives inside the button so the whole chip rotates,
-              not just the arrow. */}
+          {/* Degree readout lives inside the button so the whole chip is one
+              click target, not just the arrow with a separate label beside it. */}
           <button
             onClick={rotateView}
             aria-label={t.app.rotateView}

--- a/src/components/Palette/ObjectPalette.tsx
+++ b/src/components/Palette/ObjectPalette.tsx
@@ -50,39 +50,42 @@ function PaletteEntry({ id, type, icon, label, defaultSize, propsOverride, isFav
   };
 
   return (
+    // Pointer-drag listeners live on the whole row so it's grabbable anywhere;
+    // keyboard activation + role=button stay on the grip (setActivatorNodeRef +
+    // attributes) so the row is a plain div, not an interactive element wrapping
+    // the star button. Double-click still spawns.
     <div
       ref={setNodeRef}
+      {...listeners}
       onDoubleClick={handleDoubleClick}
+      style={{ touchAction: 'none' }}
       className={`
         group flex items-center gap-2 px-1.5 py-1.5 rounded
         border border-transparent
         hover:border-border-2 hover:bg-surface-2
-        select-none transition-colors
+        cursor-grab active:cursor-grabbing select-none transition-colors
         ${isDragging ? 'opacity-40' : ''}
       `}
     >
-      {/* The grip is the drag activator so the row stays a plain container;
-          a nested interactive (the star) inside a draggable role=button row
-          would be invalid. The whole row still spawns on double-click. */}
       <button
         ref={setActivatorNodeRef}
         type="button"
         aria-label={label}
-        style={{ touchAction: 'none' }}
         {...attributes}
-        {...listeners}
         className="-mr-1 shrink-0 p-0.5 rounded cursor-grab active:cursor-grabbing text-muted opacity-40 group-hover:opacity-70 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent transition-opacity"
       >
         <DragHandleIcon className="w-2 h-3.5" />
       </button>
       <span className="font-mono text-[11px] text-muted group-hover:text-accent w-6 text-center shrink-0 transition-colors">{icon}</span>
       <span className="text-xs text-text truncate">{label}</span>
-      {/* Stop click + dblclick (the row's double-click spawns an object) so a
-          star tap only toggles. */}
+      {/* Stop pointerdown (the row's drag activator), click, and dblclick (the
+          row's double-click spawns an object) so a star tap only toggles and a
+          small drag on the star never starts a palette drag. */}
       <button
         type="button"
         aria-label={favoriteLabel}
         aria-pressed={isFavorite}
+        onPointerDown={(e) => e.stopPropagation()}
         onDoubleClick={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/components/Palette/ObjectPalette.tsx
+++ b/src/components/Palette/ObjectPalette.tsx
@@ -58,7 +58,9 @@ function PaletteEntry({ id, type, icon, label, defaultSize, propsOverride, isFav
       ref={setNodeRef}
       {...listeners}
       onDoubleClick={handleDoubleClick}
-      style={{ touchAction: 'none' }}
+      // pan-y, not none: lets touch users still scroll the palette list
+      // vertically while a horizontal drag onto the canvas starts a drag.
+      style={{ touchAction: 'pan-y' }}
       className={`
         group flex items-center gap-2 px-1.5 py-1.5 rounded
         border border-transparent


### PR DESCRIPTION
Palette rows are grabbable anywhere again: pointer listeners move to the row while keyboard activation (role=button) stays on the grip, so the row is a plain div (no nested interactive). The view-rotation degree readout now lives inside the button so the whole chip is the click target, not just the arrow.