### PR TITLE
feat(canvas): action-bar redesign + group/ungroup actions

### DIFF
--- a/src/components/Canvas/FloatingCanvasButton.tsx
+++ b/src/components/Canvas/FloatingCanvasButton.tsx
@@ -1,30 +1,47 @@
 import { forwardRef, useEffect, useRef, useState } from "react";
 import { Group, Circle, Path } from "react-konva";
 import type Konva from "konva";
+import { useColorScheme } from "../../lib/useColorScheme";
+
+/** Visual role of a button: drives resting/hover icon colour and the hover
+ *  fill. `neutral` = muted→indigo, `active` = amber (e.g. unlock while locked),
+ *  `destructive` = muted→red with a red-tinted hover fill (delete). */
+export type ButtonTone = "neutral" | "active" | "destructive";
 
 interface Props {
-  color: string;
   onClick: () => void;
   /** 24x24 SVG path data; centred and scaled into the button. */
   iconPath: string;
+  tone?: ButtonTone;
 }
 
-export const RADIUS = 11;
-const ICON_SCALE = 0.55;
+export const RADIUS = 15;
+const FILL_RADIUS = 13;
+const ICON_SCALE = 0.5;
 const ICON_OFFSET = 12; // 24x24 viewBox centre
 
 /**
- * Floating glyph button for the canvas selection action bar (rotate, lock,
- * delete). Mounted in stage-space outside the view-rotation Group so it stays
- * upright; the parent bar Group is positioned imperatively in a beforeDraw hook
- * while each button gets a static row offset.
+ * Floating glyph button for the canvas selection action bar. Icons rest in a
+ * neutral tone and pick up their accent (indigo / amber / red) on hover, with a
+ * soft fill highlight so it's obvious which button is active. Mounted in
+ * stage-space outside the view-rotation Group so it stays upright; the parent
+ * bar Group is positioned imperatively in a beforeDraw hook.
  */
 export const FloatingCanvasButton = forwardRef<Konva.Group, Props>(
-  function FloatingCanvasButton({ color, onClick, iconPath }, ref) {
+  function FloatingCanvasButton({ onClick, iconPath, tone = "neutral" }, ref) {
+    const colors = useColorScheme();
     const [hover, setHover] = useState(false);
     // Track the stage so an unmount-while-hovering (e.g. the action clears the
     // selection) still resets the cursor; onMouseLeave never fires then.
     const cursorStageRef = useRef<Konva.Stage | null>(null);
+
+    const palette =
+      tone === "destructive"
+        ? { rest: colors.muted, active: colors.error, fill: colors.error, fillOpacity: 0.15 }
+        : tone === "active"
+          ? { rest: colors.accent, active: colors.accent, fill: colors.surface2, fillOpacity: 1 }
+          : { rest: colors.muted, active: colors.selection, fill: colors.surface2, fillOpacity: 1 };
+    const iconColor = hover ? palette.active : palette.rest;
 
     const cursorIn = (e: Konva.KonvaEventObject<MouseEvent>) => {
       const stage = e.target.getStage();
@@ -64,6 +81,14 @@ export const FloatingCanvasButton = forwardRef<Konva.Group, Props>(
       >
         {/* Invisible hitbox; gives the thin icon a comfortable click target. */}
         <Circle radius={RADIUS} fill="transparent" />
+        {hover && (
+          <Circle
+            radius={FILL_RADIUS}
+            fill={palette.fill}
+            opacity={palette.fillOpacity}
+            listening={false}
+          />
+        )}
         <Group
           scaleX={ICON_SCALE}
           scaleY={ICON_SCALE}
@@ -73,8 +98,8 @@ export const FloatingCanvasButton = forwardRef<Konva.Group, Props>(
         >
           <Path
             data={iconPath}
-            stroke={color}
-            strokeWidth={hover ? 3 : 2}
+            stroke={iconColor}
+            strokeWidth={2}
             lineCap="round"
             lineJoin="round"
             fill="transparent"

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -12,7 +12,7 @@ import type { PaletteDragData } from "../../dnd/types";
 import { Stage, Layer, Group, Image as KImage, Rect, Transformer } from "react-konva";
 import type Konva from "konva";
 import { useLabelStore, useCurrentObjects, currentObjects, getCurrentObjects, selectPreviewLocksEditor } from "../../store/labelStore";
-import { isGroup, getAllLeaves, expandSelection, selectionTargetId, findObjectById, canDeleteSelection, isSelectionLocked, type LabelObject } from "../../types/Group";
+import { isGroup, getAllLeaves, expandSelection, selectionTargetId, findObjectById, canDeleteSelection, canGroupSelection, canUngroupSelection, isSelectionLocked, type LabelObject } from "../../types/Group";
 import { pxToDots, SCREEN_PX_PER_MM } from "../../lib/coordinates";
 import { SNAP_OPTIONS } from "../../lib/units";
 import type { Unit } from "../../lib/units";
@@ -48,8 +48,8 @@ import {
 } from "./rotationGeometry";
 import { useAltClickCycle } from "./hooks/useAltClickCycle";
 import { useSelectionActionBar } from "./hooks/useSelectionActionBar";
-import { FloatingCanvasButton, RADIUS as BUTTON_RADIUS } from "./FloatingCanvasButton";
-import { ROTATE_ICON, TRASH_ICON, LOCK_ICON, UNLOCK_ICON } from "./canvasIcons";
+import { FloatingCanvasButton, RADIUS as BUTTON_RADIUS, type ButtonTone } from "./FloatingCanvasButton";
+import { ROTATE_ICON, TRASH_ICON, LOCK_ICON, UNLOCK_ICON, GROUP_ICON, UNGROUP_ICON } from "./canvasIcons";
 import {
   getStepRotation,
   nextZplRotation,
@@ -57,7 +57,7 @@ import {
 
 const PADDING = 40;
 // Horizontal stride between action-bar buttons (render-side row layout).
-const BUTTON_STEP_PX = 28;
+const BUTTON_STEP_PX = 32;
 
 interface Props {
   unit: Unit;
@@ -125,6 +125,8 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     selectObjects,
     removeSelectedObjects,
     setSelectionLocked,
+    groupSelection,
+    ungroup,
   } = useLabelStore();
   const objects = useCurrentObjects();
   const previewMode = useLabelStore((s) => s.previewMode);
@@ -539,31 +541,52 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     });
   };
 
+  // Group when 2+ top-level objects are selectable; ungroup when the selection
+  // holds at least one top-level group. Both can be true at once (a group plus
+  // a loose object), so both buttons can show.
+  const canGroup = selectedIds.length > 1 && canGroupSelection(objects, selectedIds);
+  const canUngroup = canUngroupSelection(objects, selectedIds);
+
   // Contextual action bar. Rotate is a 90-degree step (ZPL only stores N/R/I/B,
-  // so a button beats the free-rotation drag handle other tools use); lock and
-  // delete mirror Canva's floating cluster. The bar itself is gated on
-  // !previewLocks at the render site.
+  // so a button beats the free-rotation drag handle other tools use). Icons rest
+  // neutral and accent on hover; delete is set apart (divider) and destructive
+  // (red). The bar itself is gated on !previewLocks at the render site.
   const actionButtons: {
     key: string;
     iconPath: string;
-    color: string;
+    tone: ButtonTone;
     onClick: () => void;
   }[] = [];
   if (singleSelected && stepRotation && !singleSelected.locked) {
     actionButtons.push({
       key: "rotate",
       iconPath: ROTATE_ICON,
-      color: colors.selection,
+      tone: "neutral",
       onClick: handleRotateStep,
+    });
+  }
+  if (canGroup) {
+    actionButtons.push({
+      key: "group",
+      iconPath: GROUP_ICON,
+      tone: "neutral",
+      onClick: groupSelection,
+    });
+  }
+  if (canUngroup) {
+    actionButtons.push({
+      key: "ungroup",
+      iconPath: UNGROUP_ICON,
+      tone: "neutral",
+      onClick: ungroup,
     });
   }
   if (selectedIds.length > 0) {
     actionButtons.push({
       key: "lock",
       iconPath: allSelectedLocked ? UNLOCK_ICON : LOCK_ICON,
-      // Amber unlock matches the locked-state frame; plain lock stays in
-      // selection chrome since the selection is not locked yet.
-      color: allSelectedLocked ? colors.accent : colors.selection,
+      // Amber while locked to match the locked-state frame.
+      tone: allSelectedLocked ? "active" : "neutral",
       onClick: () => setSelectionLocked(!allSelectedLocked),
     });
   }
@@ -571,7 +594,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     actionButtons.push({
       key: "delete",
       iconPath: TRASH_ICON,
-      color: colors.selection,
+      tone: "destructive",
       onClick: removeSelectedObjects,
     });
   }
@@ -1040,27 +1063,41 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
 
             {!previewLocks && attachableIds.length > 0 && actionButtons.length > 0 && (
               <Group ref={actionBarRef}>
-                {/* Semi-transparent scrim so the buttons stay legible over
-                    whatever the selection overlaps (e.g. barcode HRI text). */}
                 {(() => {
-                  const w =
-                    (actionButtons.length - 1) * BUTTON_STEP_PX +
-                    2 * BUTTON_RADIUS +
-                    16;
-                  const h = 2 * BUTTON_RADIUS + 12;
+                  const n = actionButtons.length;
+                  const w = (n - 1) * BUTTON_STEP_PX + 2 * BUTTON_RADIUS + 16;
+                  const h = 2 * BUTTON_RADIUS + 8;
+                  // Divider sits just left of the delete button to set it apart.
+                  const deleteIndex = actionButtons.findIndex((b) => b.key === "delete");
+                  const dividerX =
+                    deleteIndex > 0
+                      ? (deleteIndex - (n - 1) / 2) * BUTTON_STEP_PX - BUTTON_STEP_PX / 2
+                      : null;
                   return (
-                    <Rect
-                      x={-w / 2}
-                      y={-h / 2}
-                      width={w}
-                      height={h}
-                      cornerRadius={h / 2}
-                      fill="rgba(255,255,255,0.9)"
-                      // Amber when locked to match the locked-state frame,
-                      // else selection indigo (mirrors the lock button).
-                      stroke={allSelectedLocked ? colors.accent : colors.selection}
-                      strokeWidth={1}
-                    />
+                    <>
+                      {/* Opaque pill (not alpha) so icons stay legible over busy
+                          content; flat hairline matches the rest of the canvas
+                          chrome (no shadow). Amber while the selection is locked. */}
+                      <Rect
+                        x={-w / 2}
+                        y={-h / 2}
+                        width={w}
+                        height={h}
+                        cornerRadius={h / 2}
+                        fill={colors.surface}
+                        stroke={allSelectedLocked ? colors.accent : colors.selection}
+                        strokeWidth={1}
+                      />
+                      {dividerX !== null && (
+                        <Rect
+                          x={dividerX}
+                          y={-h / 2 + 5}
+                          width={1}
+                          height={h - 10}
+                          fill={colors.border}
+                        />
+                      )}
+                    </>
                   );
                 })()}
                 {actionButtons.map((b, i) => (
@@ -1069,7 +1106,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
                     x={(i - (actionButtons.length - 1) / 2) * BUTTON_STEP_PX}
                   >
                     <FloatingCanvasButton
-                      color={b.color}
+                      tone={b.tone}
                       onClick={b.onClick}
                       iconPath={b.iconPath}
                     />

--- a/src/components/Canvas/canvasIcons.ts
+++ b/src/components/Canvas/canvasIcons.ts
@@ -16,3 +16,11 @@ export const LOCK_ICON =
 /** Lucide "lock-open": open shackle over a body. */
 export const UNLOCK_ICON =
   "M5 11h14a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2z M7 11V7a5 5 0 0 1 9.9-1";
+
+/** Lucide "group": corner brackets framing two overlapping tiles. */
+export const GROUP_ICON =
+  "M3 7V5a2 2 0 0 1 2-2h2 M17 3h2a2 2 0 0 1 2 2v2 M21 17v2a2 2 0 0 1-2 2h-2 M7 21H5a2 2 0 0 1-2-2v-2 M8 8h6v4H8z M11 12h6v4h-6z";
+
+/** Lucide "ungroup": two separated tiles (no frame). */
+export const UNGROUP_ICON =
+  "M5 4h8v6H5z M11 14h8v6h-8z";

--- a/src/components/Canvas/hooks/useSelectionActionBar.ts
+++ b/src/components/Canvas/hooks/useSelectionActionBar.ts
@@ -1,7 +1,6 @@
 import { useLayoutEffect, useRef } from "react";
 import type Konva from "konva";
 import { RULER_SIZE } from "../Ruler";
-import { RADIUS as BUTTON_RADIUS_PX } from "../FloatingCanvasButton";
 
 const ACTION_BAR_GAP_PX = 22;
 
@@ -56,21 +55,21 @@ export function useSelectionActionBar({
 
       const bar = actionBarRef.current;
       if (bar) {
-        const halfW =
-          bar.getClientRect({ relativeTo: stage, skipShadow: true }).width / 2;
+        const barRect = bar.getClientRect({ relativeTo: stage, skipShadow: true });
+        const halfW = barRect.width / 2;
+        const halfH = barRect.height / 2;
         const minCx = RULER_SIZE + halfW;
         const maxCx = Math.max(minCx, stage.width() - halfW);
         const cx = Math.min(Math.max((minX + maxX) / 2, minCx), maxCx);
-        // Prefer above the selection; flip below if it clips the ruler; pin just
-        // under the ruler when a tall selection leaves no room either side.
-        const aboveY = minY - ACTION_BAR_GAP_PX;
-        const belowY = maxY + ACTION_BAR_GAP_PX;
+        // Anchor the bar's near EDGE a fixed gap from the selection (not its
+        // centre), so a tall/rotated/top-sitting object never gets overlapped:
+        // bottom edge `gap` above minY when placed above; top edge `gap` below
+        // maxY when flipped under. Pin just below the ruler if neither fits.
+        const aboveY = minY - ACTION_BAR_GAP_PX - halfH;
+        const belowY = maxY + ACTION_BAR_GAP_PX + halfH;
         let y = aboveY;
-        if (aboveY - BUTTON_RADIUS_PX < RULER_SIZE) {
-          y =
-            belowY + BUTTON_RADIUS_PX <= stage.height()
-              ? belowY
-              : RULER_SIZE + BUTTON_RADIUS_PX;
+        if (aboveY - halfH < RULER_SIZE) {
+          y = belowY + halfH <= stage.height() ? belowY : RULER_SIZE + halfH;
         }
         bar.position({ x: cx, y });
       }

--- a/src/lib/useColorScheme.ts
+++ b/src/lib/useColorScheme.ts
@@ -20,6 +20,13 @@ export interface CanvasColors {
    *  on the canvas; e.g. the ^FB wrap-guide line so the user can tell
    *  it apart from selection/transformer chrome. */
   accent: string;
+  /** Panel surface / muted text / hairline / destructive — mirror the DOM
+   *  theme tokens so canvas chrome (e.g. the action bar pill) matches. */
+  surface: string;
+  surface2: string;
+  border: string;
+  muted: string;
+  error: string;
 }
 
 export const DARK_COLORS: CanvasColors = {
@@ -35,6 +42,11 @@ export const DARK_COLORS: CanvasColors = {
   rulerSeparator: '#2a2a2a',
   selection:      '#6366f1',
   accent:         '#f59e0b',
+  surface:        '#1f1f1f',
+  surface2:       '#282828',
+  border:         '#333333',
+  muted:          '#666666',
+  error:          '#ef4444',
 };
 
 const LIGHT_COLORS: CanvasColors = {
@@ -50,6 +62,11 @@ const LIGHT_COLORS: CanvasColors = {
   rulerSeparator: '#d4d4d8',
   selection:      '#6366f1',
   accent:         '#d97706',
+  surface:        '#fafafa',
+  surface2:       '#f4f4f5',
+  border:         '#d4d4d8',
+  muted:          '#52525b',
+  error:          '#b91c1c',
 };
 
 export function useColorScheme(): CanvasColors {

--- a/src/types/Group.test.ts
+++ b/src/types/Group.test.ts
@@ -10,6 +10,7 @@ import {
   detachObjectById,
   isSelfOrDescendant,
   canGroupSelection,
+  canUngroupSelection,
   canDeleteSelection,
   isSelectionLocked,
   mapObjectById,
@@ -200,6 +201,27 @@ describe('Group helpers', () => {
     it('returns true when one of several selected items is groupable', () => {
       const locked = { ...leaf('a'), locked: true };
       expect(canGroupSelection([locked, leaf('b')], ['a', 'b'])).toBe(true);
+    });
+  });
+
+  describe('canUngroupSelection', () => {
+    it('returns true when a selected top-level group is unlocked', () => {
+      const tree = [group('g', [leaf('a')]), leaf('b')];
+      expect(canUngroupSelection(tree, ['g'])).toBe(true);
+    });
+
+    it('returns false when only leaves are selected', () => {
+      expect(canUngroupSelection([group('g', [leaf('a')]), leaf('b')], ['b'])).toBe(false);
+    });
+
+    it('returns false for a locked group', () => {
+      const locked = { ...group('g', [leaf('a')]), locked: true };
+      expect(canUngroupSelection([locked], ['g'])).toBe(false);
+    });
+
+    it('ignores nested groups (only top-level counts)', () => {
+      const tree = [group('outer', [group('inner', [leaf('a')])])];
+      expect(canUngroupSelection(tree, ['inner'])).toBe(false);
     });
   });
 

--- a/src/types/Group.ts
+++ b/src/types/Group.ts
@@ -179,6 +179,17 @@ export function canDeleteSelection(
   );
 }
 
+/** True when ungroup() would act: a selected top-level object is an unlocked
+ *  group. The lock check mirrors ungroupIds, which skips locked groups. */
+export function canUngroupSelection(
+  objects: LabelObject[],
+  selectedIds: readonly string[],
+): boolean {
+  return objects.some(
+    (o) => selectedIds.includes(o.id) && isGroup(o) && !o.locked,
+  );
+}
+
 /** True when the selection is non-empty and every selected top-level object
  *  is locked; drives the lock/unlock toggle direction. */
 export function isSelectionLocked(


### PR DESCRIPTION
Neutral icons that accent on hover with a soft fill highlight, bigger hit targets, an opaque pill with a flat hairline (no shadow), and delete set apart by a divider with a destructive red hover. Add group/ungroup buttons (group when 2+ selectable, ungroup when a group is selected). Anchor the bar to its near edge so it never overlaps tall/rotated/top-sitting objects.