### PR TITLE
chore: accurate typed-content/gs1 docs + test consistency

### DIFF
--- a/src/lib/gs1.ts
+++ b/src/lib/gs1.ts
@@ -122,7 +122,8 @@ export const GS1_EXPANDED_CHARSET = `0-9A-Za-z!"%&'*+,./:;<=>?_${GS1_GS}-`;
 export const GS1_SAMPLE_CONTENT = "0109501101530003";
 
 /** Escape-sequence control character we emit for GS1 DataMatrix (^BX g param).
- *  FNC1 is then written as `<escape>1`, both leading and as AI separator. */
+ *  FNC1 is then written as `<escape>1`, both leading and as AI separator. Keep
+ *  it outside `^`/`~` so it never collides with fdField's ^FH escaping. */
 export const GS1_DATAMATRIX_ESCAPE = "_";
 
 /** ^FD field data for GS1 DataMatrix: a leading FNC1, each GS separator as the

--- a/src/lib/typedContent.ts
+++ b/src/lib/typedContent.ts
@@ -199,7 +199,7 @@ function parseEmail(content: string): ContentFields {
   return f;
 }
 
-/** Classify and parse existing QR content. Specific prefixes first; URI schemes
+/** Classify and parse existing barcode content. Specific prefixes first; URI schemes
  *  matched case-insensitively. Unknown content becomes plain text. */
 export function parseContent(content: string): { type: ContentType; fields: ContentFields } {
   const t = content.trimStart();

--- a/src/registry/registry.test.ts
+++ b/src/registry/registry.test.ts
@@ -302,7 +302,7 @@ describe('barcode rotation in ZPL output', () => {
     ['code39',     '^B3I,', 'I', { height: 100, moduleWidth: 2, printInterpretation: true, checkDigit: false }],
     ['ean13',      '^BEB,', 'B', { height: 100, moduleWidth: 2, printInterpretation: true }],
     ['qrcode',     '^BQR,', 'R', { magnification: 4, errorCorrection: 'Q' }],
-    ['datamatrix', '^BXI,', 'I', { dimension: 5, quality: 200 }],
+    ['datamatrix', '^BXI,', 'I', { dimension: 5, quality: 200, gs1: false }],
     ['pdf417',     '^B7B,', 'B', { rowHeight: 4, securityLevel: 0, columns: 0, moduleWidth: 2 }],
     ['aztec',      '^B0R,', 'R', { magnification: 4, ecLevel: 0 }],
     ['codabar',    '^BKR,', 'R', { height: 100, moduleWidth: 2, printInterpretation: true, checkDigit: false }],


### PR DESCRIPTION
Review polish: parseContent JSDoc QR->barcode, document the GS1 DataMatrix escape-char invariant, datamatrix rotation test gs1:false.