### PR TITLE
fix(ui): contain sr-only section headings so the document can't scroll

### DIFF
--- a/src/components/RightSidebar/RightSidebar.tsx
+++ b/src/components/RightSidebar/RightSidebar.tsx
@@ -83,7 +83,11 @@ export function RightSidebar({ canvasRef, onCollapse }: Props) {
           </Tooltip>
         )}
       </div>
-      <div className="flex-1 overflow-y-auto">
+      {/* relative: contains the panels' absolutely-positioned `sr-only` section
+          headings (card layout, #168) so they scroll with the panel instead of
+          escaping to the viewport and stretching the document past 100vh (which
+          let focus-scroll shift the whole app, leaving a grey strip below). */}
+      <div className="relative flex-1 overflow-y-auto">
         {tab === 'properties' && <PropertiesPanel canvasRef={canvasRef} />}
         {tab === 'layers' && <LayersPanel />}
         {tab === 'variables' && <VariablesPanel />}


### PR DESCRIPTION
Since #168 the right-panel section headings render as sr-only (position:absolute). With the scroll container unpositioned, they escaped to the viewport and stretched the document past 100vh; focus-into-view then shifted the whole app, leaving a grey strip below the output. Make the scroll container relative.