### PR TITLE
fix(canvas): correct rotated single-line text bounds

### DIFF
--- a/src/lib/objectBounds.test.ts
+++ b/src/lib/objectBounds.test.ts
@@ -110,10 +110,24 @@ describe("objectBoundsDots", () => {
     expect(objectBoundsDots(t, ctx(measured))).toEqual({ x: 12, y: 24, width: 77, height: 30 });
   });
 
-  it("single-line text: measured footprint is used verbatim (producer already rotated it)", () => {
+  it("single-line text: rotated footprint size is verbatim, top-left shifts for R", () => {
     const t = leaf("text", 12, 24, { content: "Hello", fontHeight: 30, fontWidth: 0, rotation: "R" });
     const measured = new Map([[t.id, { width: 30, height: 77 }]]); // already rotated
-    expect(objectBoundsDots(t, ctx(measured))).toEqual({ x: 12, y: 24, width: 30, height: 77 });
+    // Size used verbatim (not re-rotated); R rotates about the anchor, so the
+    // visual top-left moves left by the rotated width (mirrors blockBoundsDots).
+    expect(objectBoundsDots(t, ctx(measured))).toEqual({ x: -18, y: 24, width: 30, height: 77 });
+  });
+
+  it("single-line text: B rotates about the anchor, top-left moves up", () => {
+    const t = leaf("text", 12, 24, { content: "Hello", fontHeight: 30, fontWidth: 0, rotation: "B" });
+    const measured = new Map([[t.id, { width: 30, height: 77 }]]); // already rotated
+    expect(objectBoundsDots(t, ctx(measured))).toEqual({ x: 12, y: -53, width: 30, height: 77 });
+  });
+
+  it("single-line text: I rotates about the anchor, top-left moves left and up", () => {
+    const t = leaf("text", 12, 24, { content: "Hello", fontHeight: 30, fontWidth: 0, rotation: "I" });
+    const measured = new Map([[t.id, { width: 77, height: 30 }]]); // already rotated
+    expect(objectBoundsDots(t, ctx(measured))).toEqual({ x: -65, y: -6, width: 77, height: 30 });
   });
 
   it("single-line text: fallback estimate swaps axes for R", () => {

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -60,6 +60,23 @@ function fallbackSizeDots(
   return def ? resolveDefaultSizeDots(def, label) : { width: 0, height: 0 };
 }
 
+/** Anchor to visual-top-left shift for one rotated line: the renderer rotates
+ *  the node about obj.x/obj.y, so R/I/B move the AABB off the anchor. Takes the
+ *  already-rotated footprint; mirrors blockBoundsDots. */
+function rotatedLineOffset(
+  rotation: ZplRotation,
+  fpWidth: number,
+  fpHeight: number,
+): { x: number; y: number } {
+  switch (rotation) {
+    case "R": return { x: -fpWidth, y: 0 };
+    case "I": return { x: -fpWidth, y: -fpHeight };
+    case "B": return { x: 0, y: -fpHeight };
+    case "N":
+    default: return { x: 0, y: 0 };
+  }
+}
+
 /** Single-line text/serial footprint estimate from props when no measured
  *  size exists. Width is the Font-0 calibrated advance sum; height is the
  *  font height. Rotation swaps the axes. */
@@ -166,11 +183,13 @@ export function objectBoundsDots(obj: LabelObject, ctx: ObjectBoundsCtx): Boundi
       // Measured is the already-rotated footprint (the producer rotates it); the
       // fallback estimate computes upright and rotates itself.
       const fp = ctx.measured?.get(obj.id) ?? singleLineEstimate(obj);
-      return { x: obj.x, y: obj.y, width: fp.width, height: fp.height };
+      const off = rotatedLineOffset(p.rotation, fp.width, fp.height);
+      return { x: obj.x + off.x, y: obj.y + off.y, width: fp.width, height: fp.height };
     }
     case "serial": {
       const fp = ctx.measured?.get(obj.id) ?? singleLineEstimate(obj);
-      return { x: obj.x, y: obj.y, width: fp.width, height: fp.height };
+      const off = rotatedLineOffset(obj.props.rotation, fp.width, fp.height);
+      return { x: obj.x + off.x, y: obj.y + off.y, width: fp.width, height: fp.height };
     }
     default: {
       if (isBarcode(obj)) {


### PR DESCRIPTION
objectBoundsDots returned the raw anchor as the bbox top-left for single-line text/serial; R/I/B rotate about the anchor, so the action bar and align sat off by the line extent. Mirror blockBoundsDots' anchor shift.