### PR TITLE
feat(canvas): 90-degree rotation for groups and multi-selection

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -15,11 +15,11 @@ import {
   get1DBwipScale,
   getEanUpcHriFragments,
   renderEanUpcRawCanvas,
-  resolveHriAbove,
   renderTlc39Canvas,
   type BarcodeDisplaySize,
   type EanUpcType,
 } from "./bwipHelpers";
+import { resolveHriAbove } from "../../lib/barcodeHri";
 import { objectRotation } from "../../registry/rotation";
 import { rotatedGroupTransform } from "./rotatedGroupTransform";
 import { buildEanUpcDigitOverlay } from "./eanUpcDigitNodes";

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useLayoutEffect,
   useState,
+  useSyncExternalStore,
   useCallback,
 } from "react";
 import { useDroppable, useDndMonitor } from "@dnd-kit/core";
@@ -22,9 +23,10 @@ import type { SnapGuide } from "../../lib/snapGuides";
 import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/align";
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
 import { objectBoundsDots, selectionUnionDots } from "../../lib/objectBounds";
+import { rotateSelectionChanges } from "../../lib/groupRotation";
 import { selectTidyTargets } from "../../lib/tidyClassify";
 import { safeAreaRectDots } from "../../lib/safeArea";
-import { measuredBoundsMap } from "./measuredBoundsCache";
+import { measuredBoundsMap, subscribeMeasuredBounds, getMeasuredSnapshot } from "./measuredBoundsCache";
 import { mmToDots } from "../../lib/coordinates";
 import { isEditableTarget } from "../../lib/dom";
 import { KonvaObject } from "./KonvaObject";
@@ -139,6 +141,11 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const transformActiveRef = useRef(false);
   const barHalfRef = useRef({ w: 0, h: 0 });
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+  // Reactive view of the measured-footprint cache. The render layer publishes
+  // footprints in a post-render effect (barcodes only after their async draw),
+  // so reading the snapshot here is what makes the selection frame recompute once
+  // they settle, e.g. after a group rotation swaps a barcode's footprint.
+  const measuredSnapshot = useSyncExternalStore(subscribeMeasuredBounds, getMeasuredSnapshot);
   const rotateView = () => onViewRotationChange(nextRotation(viewRotation));
   const [guides, setGuides] = useState<SnapGuide[]>([]);
   // Drag-snap guides live in group-local space (rendered inside the rotation
@@ -438,7 +445,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const isMultiFrame = attachableIds.length > 1;
   // One selected group = solid frame (persistent); several picks = dashed (ad-hoc).
   const isMultiSelection = selectedIds.length > 1;
-  const frameCtx = { label, measured: measuredBoundsMap() };
+  // Snapshot (not the live map) so the frame derivations recompute when a
+  // settled footprint changes; the changing snapshot reference is the signal.
+  const frameCtx = { label, measured: measuredSnapshot };
   // Hidden leaves never render, so the old client-rect path ignored them; keep
   // them out of the model-based bounds too.
   // visibleLeaves carries the cascaded (effective) lock; read it, not the raw
@@ -762,6 +771,19 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     });
   };
 
+  // Group / multi-select rotate: one clockwise quarter turn about the union
+  // centre, applied as a single batch so undo treats it as one step.
+  const canRotateGroup =
+    !allSelectedLocked &&
+    (selectedIds.length > 1 || (!!singleSelected && isGroup(singleSelected)));
+  const handleRotateGroup = () => {
+    if (!canRotateGroup) return;
+    const changes = rotateSelectionChanges(objects, selectedIds, frameCtx, 1);
+    if (changes.size === 0) return;
+    updateObjects([...changes].map(([id, c]) => ({ id, changes: c })));
+    // Frame recomputes via subscribeMeasuredBounds once children republish.
+  };
+
   // Group when 2+ top-level objects are selectable; ungroup when the selection
   // holds at least one top-level group. Both can be true at once (a group plus
   // a loose object), so both buttons can show.
@@ -784,6 +806,14 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       iconPath: ROTATE_ICON,
       tone: "neutral",
       onClick: handleRotateStep,
+    });
+  }
+  if (canRotateGroup) {
+    actionButtons.push({
+      key: "rotate-group",
+      iconPath: ROTATE_ICON,
+      tone: "neutral",
+      onClick: handleRotateGroup,
     });
   }
   if (canGroup) {

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -2,7 +2,8 @@
 // canvas. Per-symbology rationale lives at each case in getUprightDisplaySize.
 
 import bwipjs from "bwip-js/browser";
-import { ObjectRegistry, type LeafObject } from "../../registry";
+import { type LeafObject } from "../../registry";
+import { barcodeTextZoneDots, barcodeZoneAbove } from "../../lib/barcodeHri";
 import { upceData6FromFd } from "../../registry/hriFormatters";
 import type { LabelObject } from "../../types/Group";
 import type { Gs1DatabarProps } from "../../registry/gs1databar";
@@ -15,10 +16,10 @@ import {
   gs1ContentToElementString,
 } from "../../lib/gs1";
 import {
+  barSubRect,
   CODE11_QUIET_ZONE_DELTA_MODULES,
   CODE93_QUIET_ZONE_DELTA_MODULES,
   EAN_TEXT_ZONE_DOTS,
-  EAN_UPC_TYPES,
   GS1_DATABAR_PADDING_ROWS,
   GS1_DATABAR_SPEC_HEIGHT_MODULES,
   LOGMARS_TEXT_ZONE_DOTS,
@@ -582,25 +583,6 @@ export interface BarcodeDisplaySize {
   bitmapCrop?: { x: number; y: number; width: number; height: number };
 }
 
-/** Firmware-reserved text-zone height in dots (below bars in upright). */
-const TEXT_ZONE_DOTS_BY_TYPE: Partial<Record<LabelObject["type"], number>> = {
-  ean13: EAN_TEXT_ZONE_DOTS,
-  ean8: EAN_TEXT_ZONE_DOTS,
-  upca: EAN_TEXT_ZONE_DOTS,
-  upce: EAN_TEXT_ZONE_DOTS,
-  logmars: LOGMARS_TEXT_ZONE_DOTS,
-};
-
-/** HRI sits above the bars when the per-object toggle is set or the symbology
- *  hardcodes it (logmars/^BS). Single source for the render path and the bbox
- *  sizing so overlay and bbox never disagree (PR #90). */
-export function resolveHriAbove(obj: LeafObject): boolean {
-  return !!(
-    (obj.props as { printInterpretationAbove?: boolean }).printInterpretationAbove ||
-    ObjectRegistry[obj.type]?.hri?.textAbove
-  );
-}
-
 export function getDisplaySize(
   obj: LeafObject,
   canvas: HTMLCanvasElement,
@@ -622,48 +604,18 @@ export function getDisplaySize(
   const w = isQuarter ? upright.h : upright.w;
   const h = isQuarter ? upright.w : upright.h;
 
-  // ^BS reserves text zone only when printInterpretation=Y; other EAN/UPC
-  // reserve the 13-dot zone unconditionally (firmware ships a fixed guard).
-  const textZoneDots =
-    obj.type === "upcEanExtension"
-      ? obj.props.printInterpretation
-        ? upcSuppTextZoneDots(obj.props.moduleWidth)
-        : 0
-      : TEXT_ZONE_DOTS_BY_TYPE[obj.type] ?? 0;
-  const textZonePx = dotsToPx(textZoneDots, scale, dpmm);
-  const isTextAbove = resolveHriAbove(obj);
-  // EAN/UPC reserve the zone for the guard tails, which stay below the bars
-  // regardless of HRI position; the above HRI floats over the bars (negative
-  // y in BarcodeObject), so the zone never flips for them.
-  const zoneAbove = isTextAbove && !EAN_UPC_TYPES.has(obj.type);
+  const textZonePx = dotsToPx(barcodeTextZoneDots(obj), scale, dpmm);
+  const zoneAbove = barcodeZoneAbove(obj);
 
   // Map the upright "below the bars" zone onto the rotated bbox: it travels
-  // around the rectangle as the symbol rotates.
-  //   N (0°)   text zone at bottom → barTopPx=0,           barH = h - textZonePx
-  //   R (90°)  text zone at left   → barLeftPx=textZonePx, barW = w - textZonePx
-  //   I (180°) text zone at top    → barTopPx=textZonePx,  barH = h - textZonePx
-  //   B (270°) text zone at right  → barLeftPx=0,          barW = w - textZonePx
-  let barTopPx = 0;
-  let barLeftPx = 0;
-  let barW = w;
-  let barH = h;
-  if (textZonePx > 0) {
-    if (!zoneAbove) {
-      switch (rotation) {
-        case "N": barH = h - textZonePx; break;
-        case "R": barLeftPx = textZonePx; barW = w - textZonePx; break;
-        case "I": barTopPx = textZonePx; barH = h - textZonePx; break;
-        case "B": barW = w - textZonePx; break;
-      }
-    } else {
-      switch (rotation) {
-        case "N": barTopPx = textZonePx; barH = h - textZonePx; break;
-        case "R": barW = w - textZonePx; break;
-        case "I": barH = h - textZonePx; break;
-        case "B": barLeftPx = textZonePx; barW = w - textZonePx; break;
-      }
-    }
-  }
+  // around the rectangle as the symbol rotates (shared with groupRotation's bbox).
+  const { barTop: barTopPx, barLeft: barLeftPx, barW, barH } = barSubRect(
+    rotation,
+    zoneAbove,
+    textZonePx,
+    w,
+    h,
+  );
 
   // Crop GS1 DataBar paddingheight rows so bars fill the firmware-reserved height.
   let bitmapCrop: BarcodeDisplaySize["bitmapCrop"];

--- a/src/components/Canvas/measuredBoundsCache.test.ts
+++ b/src/components/Canvas/measuredBoundsCache.test.ts
@@ -4,6 +4,8 @@ import {
   getMeasuredBounds,
   clearMeasuredBounds,
   measuredBoundsMap,
+  subscribeMeasuredBounds,
+  getMeasuredSnapshot,
 } from "./measuredBoundsCache";
 
 afterEach(() => {
@@ -32,5 +34,53 @@ describe("measuredBoundsCache", () => {
   it("exposes the live map the align handler reads as ctx.measured", () => {
     setMeasuredBounds("b", { width: 10, height: 20 });
     expect(measuredBoundsMap().get("b")).toEqual({ width: 10, height: 20 });
+  });
+
+  it("notifies subscribers on first publish and on a changed footprint", () => {
+    let count = 0;
+    const off = subscribeMeasuredBounds(() => count++);
+    setMeasuredBounds("a", { width: 100, height: 40 });
+    setMeasuredBounds("a", { width: 100, height: 50, barHeightDots: 30 });
+    off();
+    expect(count).toBe(2);
+  });
+
+  it("stays silent when a re-publish doesn't change the footprint", () => {
+    let count = 0;
+    setMeasuredBounds("a", { width: 100, height: 40 });
+    const off = subscribeMeasuredBounds(() => count++);
+    setMeasuredBounds("a", { width: 100, height: 40 });
+    off();
+    expect(count).toBe(0);
+  });
+
+  it("notifies on clear so a consumer can drop stale bounds", () => {
+    let count = 0;
+    setMeasuredBounds("a", { width: 100, height: 40 });
+    const off = subscribeMeasuredBounds(() => count++);
+    clearMeasuredBounds("a");
+    clearMeasuredBounds("a"); // no-op, already gone
+    off();
+    expect(count).toBe(1);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    let count = 0;
+    const off = subscribeMeasuredBounds(() => count++);
+    off();
+    setMeasuredBounds("a", { width: 1, height: 1 });
+    expect(count).toBe(0);
+  });
+
+  it("snapshot identity is stable between renders and changes on a real change", () => {
+    setMeasuredBounds("a", { width: 100, height: 40 });
+    const s1 = getMeasuredSnapshot();
+    expect(getMeasuredSnapshot()).toBe(s1); // stable, no spurious re-render
+    setMeasuredBounds("a", { width: 100, height: 40 }); // equal, no change
+    expect(getMeasuredSnapshot()).toBe(s1);
+    setMeasuredBounds("a", { width: 120, height: 50 });
+    const s2 = getMeasuredSnapshot();
+    expect(s2).not.toBe(s1);
+    expect(s2.get("a")).toEqual({ width: 120, height: 50 });
   });
 });

--- a/src/components/Canvas/measuredBoundsCache.ts
+++ b/src/components/Canvas/measuredBoundsCache.ts
@@ -22,8 +22,46 @@ export interface MeasuredFootprint {
 
 const cache = new Map<string, MeasuredFootprint>();
 
+// useSyncExternalStore plumbing. The cache stays non-reactive for the hot
+// per-render writes; `snapshot` is rebuilt only when a footprint actually
+// changes, so its identity is stable between renders and changes exactly when a
+// consumer (the selection frame) must recompute.
+let snapshot: ReadonlyMap<string, MeasuredFootprint> = cache;
+const listeners = new Set<() => void>();
+
+export function subscribeMeasuredBounds(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** Immutable snapshot for useSyncExternalStore; identity changes only on a real
+ *  footprint change, so getSnapshot stays cache-stable between renders. */
+export function getMeasuredSnapshot(): ReadonlyMap<string, MeasuredFootprint> {
+  return snapshot;
+}
+
+function emitChange(): void {
+  snapshot = new Map(cache);
+  for (const fn of listeners) fn();
+}
+
+function footprintsEqual(a: MeasuredFootprint, b: MeasuredFootprint): boolean {
+  return (
+    a.width === b.width &&
+    a.height === b.height &&
+    a.barHeightDots === b.barHeightDots &&
+    a.barLeftDots === b.barLeftDots &&
+    a.barTopDots === b.barTopDots
+  );
+}
+
 export function setMeasuredBounds(id: string, footprint: MeasuredFootprint): void {
+  const prev = cache.get(id);
+  if (prev && footprintsEqual(prev, footprint)) return;
   cache.set(id, footprint);
+  emitChange();
 }
 
 export function getMeasuredBounds(id: string): MeasuredFootprint | undefined {
@@ -31,7 +69,7 @@ export function getMeasuredBounds(id: string): MeasuredFootprint | undefined {
 }
 
 export function clearMeasuredBounds(id: string): void {
-  cache.delete(id);
+  if (cache.delete(id)) emitChange();
 }
 
 /** The live map for the align handler's ctx.measured. Returned as-is (readonly

--- a/src/lib/barcodeHri.ts
+++ b/src/lib/barcodeHri.ts
@@ -1,0 +1,43 @@
+// Pure HRI text-zone resolution shared by the barcode renderer (getDisplaySize)
+// and the group-rotation bbox probe, so zone height and side never drift apart.
+
+import { ObjectRegistry, type LeafObject } from "../registry";
+import {
+  EAN_TEXT_ZONE_DOTS,
+  LOGMARS_TEXT_ZONE_DOTS,
+  upcSuppTextZoneDots,
+  EAN_UPC_TYPES,
+} from "./bwipConstants";
+
+const TEXT_ZONE_DOTS_BY_TYPE: Partial<Record<string, number>> = {
+  ean13: EAN_TEXT_ZONE_DOTS,
+  ean8: EAN_TEXT_ZONE_DOTS,
+  upca: EAN_TEXT_ZONE_DOTS,
+  upce: EAN_TEXT_ZONE_DOTS,
+  logmars: LOGMARS_TEXT_ZONE_DOTS,
+};
+
+/** Firmware-reserved HRI text-zone height in dots. ^BS reserves it only when
+ *  printInterpretation is on; other EAN/UPC reserve the fixed guard zone always. */
+export function barcodeTextZoneDots(obj: LeafObject): number {
+  if (obj.type === "upcEanExtension") {
+    const p = obj.props as { printInterpretation?: boolean; moduleWidth?: number };
+    return p.printInterpretation ? upcSuppTextZoneDots(p.moduleWidth ?? 2) : 0;
+  }
+  return TEXT_ZONE_DOTS_BY_TYPE[obj.type] ?? 0;
+}
+
+/** HRI sits above the bars when the per-object toggle is set or the symbology
+ *  hardcodes it (logmars/^BS). Single source so render and bbox agree (PR #90). */
+export function resolveHriAbove(obj: LeafObject): boolean {
+  return !!(
+    (obj.props as { printInterpretationAbove?: boolean }).printInterpretationAbove ||
+    ObjectRegistry[obj.type]?.hri?.textAbove
+  );
+}
+
+/** Side the zone trims from the bars. EAN/UPC keep their guard tails below the
+ *  bars regardless of HRI position, so the zone never flips above for them. */
+export function barcodeZoneAbove(obj: LeafObject): boolean {
+  return resolveHriAbove(obj) && !EAN_UPC_TYPES.has(obj.type);
+}

--- a/src/lib/bwipConstants.test.ts
+++ b/src/lib/bwipConstants.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  barSubRect,
   eanUpcHriFontFamily,
   upcSuppAboveGapDots,
   upcSuppTextZoneDots,
@@ -37,4 +38,27 @@ describe("^BS supplement HRI sizing", () => {
       expect(upcSuppTextZoneDots(mw)).toBe(zone);
     });
   }
+});
+
+// The HRI text zone travels around the rotated footprint; render path and the
+// group-rotation bbox probe share this so they can't drift apart.
+describe("barSubRect", () => {
+  it("zero text zone leaves the bars filling the footprint", () => {
+    expect(barSubRect("N", false, 0, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 100, barH: 60 });
+    expect(barSubRect("R", true, 0, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 100, barH: 60 });
+  });
+
+  it("below HRI: zone sits opposite the reading direction (N bottom, R left, I top, B right)", () => {
+    expect(barSubRect("N", false, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 100, barH: 47 });
+    expect(barSubRect("R", false, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 13, barW: 87, barH: 60 });
+    expect(barSubRect("I", false, 13, 100, 60)).toEqual({ barTop: 13, barLeft: 0, barW: 100, barH: 47 });
+    expect(barSubRect("B", false, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 87, barH: 60 });
+  });
+
+  it("above HRI: zone flips to the reading side (N top, R right, I bottom, B left)", () => {
+    expect(barSubRect("N", true, 13, 100, 60)).toEqual({ barTop: 13, barLeft: 0, barW: 100, barH: 47 });
+    expect(barSubRect("R", true, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 87, barH: 60 });
+    expect(barSubRect("I", true, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 0, barW: 100, barH: 47 });
+    expect(barSubRect("B", true, 13, 100, 60)).toEqual({ barTop: 0, barLeft: 13, barW: 87, barH: 60 });
+  });
 });

--- a/src/lib/bwipConstants.ts
+++ b/src/lib/bwipConstants.ts
@@ -1,3 +1,5 @@
+import type { ZplRotation } from "../registry/rotation";
+
 export const QR_FO_Y_OFFSET_DOTS = 10;
 export const QR_FT_MODULE_OFFSET = 3;
 
@@ -124,3 +126,45 @@ export const EAN_UPC_TYPES = new Set<string>([
   "upca",
   "upce",
 ]);
+
+export interface BarSubRect {
+  barTop: number;
+  barLeft: number;
+  barW: number;
+  barH: number;
+}
+
+/** Place the firmware-reserved HRI text zone within the rotated barcode
+ *  footprint; the upright "below the bars" zone travels around the rectangle as
+ *  the symbol rotates. Unit-agnostic (px or dots). Single source for the render
+ *  path (getDisplaySize) and the rotation bbox probe (groupRotation), no drift. */
+export function barSubRect(
+  rotation: ZplRotation,
+  zoneAbove: boolean,
+  textZone: number,
+  width: number,
+  height: number,
+): BarSubRect {
+  let barTop = 0;
+  let barLeft = 0;
+  let barW = width;
+  let barH = height;
+  if (textZone > 0) {
+    if (!zoneAbove) {
+      switch (rotation) {
+        case "N": barH = height - textZone; break;
+        case "R": barLeft = textZone; barW = width - textZone; break;
+        case "I": barTop = textZone; barH = height - textZone; break;
+        case "B": barW = width - textZone; break;
+      }
+    } else {
+      switch (rotation) {
+        case "N": barTop = textZone; barH = height - textZone; break;
+        case "R": barW = width - textZone; break;
+        case "I": barH = height - textZone; break;
+        case "B": barLeft = textZone; barW = width - textZone; break;
+      }
+    }
+  }
+  return { barTop, barLeft, barW, barH };
+}

--- a/src/lib/groupRotation.test.ts
+++ b/src/lib/groupRotation.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import { rotateSelectionChanges } from "./groupRotation";
+import type { LabelObject } from "../types/Group";
+import { objectBoundsDots, type ObjectBoundsCtx } from "./objectBounds";
+import { barSubRect, EAN_TEXT_ZONE_DOTS } from "./bwipConstants";
+
+const LABEL = { widthMm: 100, heightMm: 50, dpmm: 8 };
+const ctx = (measured?: ObjectBoundsCtx["measured"]): ObjectBoundsCtx => ({ label: LABEL, measured });
+
+function leaf(type: string, x: number, y: number, props: object): LabelObject {
+  return { id: `${type}-${x}-${y}`, type, x, y, rotation: 0, props } as unknown as LabelObject;
+}
+const box = (x: number, y: number, w: number, h: number) =>
+  leaf("box", x, y, { width: w, height: h, thickness: 2, filled: false, color: "B", rounding: 0 });
+
+describe("rotateSelectionChanges", () => {
+  it("box 90deg about its own centre swaps w/h and stays centred", () => {
+    const b = box(10, 10, 40, 20); // centre (30,20)
+    const c = rotateSelectionChanges([b], [b.id], ctx(), 1).get(b.id);
+    // centre fixed, dims swap to 20x40 -> top-left (20,0)
+    expect(c).toEqual({ x: 20, y: 0, props: { width: 20, height: 40 } });
+  });
+
+  it("box 180deg keeps dims and position (centre pivot)", () => {
+    const b = box(10, 10, 40, 20);
+    const c = rotateSelectionChanges([b], [b.id], ctx(), 2).get(b.id);
+    expect(c).toEqual({ x: 10, y: 10, props: { width: 40, height: 20 } });
+  });
+
+  it("four quarter turns return a box to its origin", () => {
+    let b = box(10, 10, 40, 20);
+    for (let i = 0; i < 4; i++) {
+      const c = rotateSelectionChanges([b], [b.id], ctx(), 1).get(b.id)!;
+      const props = (b as unknown as { props: object }).props;
+      b = { ...b, x: c.x!, y: c.y!, props: { ...props, ...c.props } } as unknown as LabelObject;
+    }
+    expect(b.x).toBe(10);
+    expect(b.y).toBe(10);
+    expect((b as unknown as { props: { width: number } }).props.width).toBe(40);
+  });
+
+  it("text advances orientation and rotates the anchor about the pivot", () => {
+    const t = leaf("text", 10, 10, { content: "Hi", fontHeight: 10, fontWidth: 0, rotation: "N" });
+    const measured = new Map([[t.id, { width: 30, height: 10 }]]); // bbox (10,10,30,10), centre (25,15)
+    const c = rotateSelectionChanges([t], [t.id], ctx(measured), 1).get(t.id);
+    expect(c).toEqual({ x: 30, y: 0, props: { rotation: "R" } });
+  });
+
+  it("text orientation wraps B -> N on a clockwise turn", () => {
+    const t = leaf("text", 0, 0, { content: "x", fontHeight: 10, fontWidth: 0, rotation: "B" });
+    const measured = new Map([[t.id, { width: 10, height: 10 }]]);
+    const c = rotateSelectionChanges([t], [t.id], ctx(measured), 1).get(t.id);
+    expect(c?.props).toEqual({ rotation: "N" });
+  });
+
+  it("line adds 90deg to the angle and rotates the start point", () => {
+    const ln = leaf("line", 10, 10, { angle: 0, length: 50, thickness: 2, color: "B" });
+    const c = rotateSelectionChanges([ln], [ln.id], ctx(), 1).get(ln.id);
+    // bbox (10,10,50,2) centre (35,11); start (10,10) -> (36,-14); angle 90
+    expect(c).toEqual({ x: 36, y: -14, props: { angle: 90 } });
+  });
+
+  it("multi-select rotates each leaf about the shared union centre", () => {
+    const a = box(0, 0, 20, 20); // centre (10,10)
+    const b = box(40, 0, 20, 20); // centre (50,10); union centre (30,10)
+    const changes = rotateSelectionChanges([a, b], [a.id, b.id], ctx(), 1);
+    // horizontal pair -> vertical stack, both at x=20
+    expect(changes.get(a.id)).toEqual({ x: 20, y: -20, props: { width: 20, height: 20 } });
+    expect(changes.get(b.id)).toEqual({ x: 20, y: 20, props: { width: 20, height: 20 } });
+  });
+
+  it("symbol advances orientation, footprint stays square", () => {
+    const s = leaf("symbol", 10, 10, { symbol: "A", width: 30, height: 30, rotation: "N" });
+    const c = rotateSelectionChanges([s], [s.id], ctx(), 1).get(s.id);
+    expect(c).toEqual({ x: 10, y: 10, props: { rotation: "R" } });
+  });
+
+  it("no drift over four turns with a non-integer union centre", () => {
+    // union (0,0)-(61,20), centre x=30.5 -> a float pivot would round each step
+    // and the two boxes would drift apart, only re-aligning after 360deg.
+    let a = box(0, 0, 20, 20);
+    let b = box(41, 0, 20, 20);
+    const gap = () => {
+      const ca = { x: (a.x as number) + 10, y: (a.y as number) + 10 };
+      const cb = { x: (b.x as number) + 10, y: (b.y as number) + 10 };
+      return Math.hypot(ca.x - cb.x, ca.y - cb.y);
+    };
+    const start = gap();
+    for (let i = 0; i < 4; i++) {
+      const m = rotateSelectionChanges([a, b], [a.id, b.id], ctx(), 1);
+      const ca = m.get(a.id)!, cb = m.get(b.id)!;
+      a = { ...a, x: ca.x!, y: ca.y! } as unknown as LabelObject;
+      b = { ...b, x: cb.x!, y: cb.y! } as unknown as LabelObject;
+      // The real fix: spacing is exact at every step (objects never spread).
+      expect(gap()).toBe(start);
+    }
+    // Absolute position can shift by <=1 dot from the half-pixel pivot snap, but
+    // it never accumulates beyond that (rigid, not a runaway drift).
+    expect(Math.abs((a.x as number) - 0)).toBeLessThanOrEqual(2);
+    expect(Math.abs((b.x as number) - 41)).toBeLessThanOrEqual(2);
+  });
+
+  it("excludes locked leaves: they neither move nor shift the pivot", () => {
+    const a = box(0, 0, 20, 20);
+    const locked = { ...box(40, 0, 20, 20), locked: true } as unknown as LabelObject;
+    const m = rotateSelectionChanges([a, locked], [a.id, locked.id], ctx(), 1);
+    expect(m.has(locked.id)).toBe(false); // locked never gets a change
+    // pivot is a's own centre (locked excluded), so a rotates in place
+    expect(m.get(a.id)).toEqual({ x: 0, y: 0, props: { width: 20, height: 20 } });
+  });
+
+  it("FT EAN13 with HRI stays centre-rigid on a 90deg turn", () => {
+    // A barcode keeps its top-left on an orientation change and its HRI zone
+    // travels, so naive anchor-rotation would shift it. The centre must hold.
+    const tz = EAN_TEXT_ZONE_DOTS;
+    const W = 100, H = 60;
+    const ean = {
+      id: "ean", type: "ean13", x: 200, y: 100, rotation: 0, positionType: "FT",
+      props: { rotation: "N", magnification: 2, printInterpretation: true },
+    } as unknown as LabelObject;
+    const footprint = (rot: "N" | "R", w: number, h: number) => {
+      const r = barSubRect(rot, false, tz, w, h);
+      return new Map([[ean.id, { width: w, height: h, barHeightDots: r.barH, barLeftDots: r.barLeft, barTopDots: r.barTop }]]);
+    };
+    const before = objectBoundsDots(ean, ctx(footprint("N", W, H)));
+    const beforeC = { x: before.x + before.width / 2, y: before.y + before.height / 2 };
+
+    const c = rotateSelectionChanges([ean], [ean.id], ctx(footprint("N", W, H)), 1).get(ean.id)!;
+    expect(c.props).toEqual({ rotation: "R" });
+
+    // Renderer republishes the swapped footprint + R-orientation bar sub-rect.
+    const rotated = { ...ean, x: c.x, y: c.y, props: { rotation: "R", magnification: 2, printInterpretation: true } } as unknown as LabelObject;
+    const after = objectBoundsDots(rotated, ctx(footprint("R", H, W)));
+    const afterC = { x: after.x + after.width / 2, y: after.y + after.height / 2 };
+
+    expect(Math.abs(afterC.x - beforeC.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(afterC.y - beforeC.y)).toBeLessThanOrEqual(1);
+  });
+
+  it("FT EAN13 with HRI returns to origin over four turns (no drift)", () => {
+    // Each turn republishes the swapped footprint, so this exercises all four
+    // orientations and guards the re-anchor against per-step rounding drift.
+    const tz = EAN_TEXT_ZONE_DOTS;
+    const W = 100, H = 60;
+    const rots = ["N", "R", "I", "B"] as const;
+    const dims = (rot: (typeof rots)[number]): [number, number] =>
+      rot === "N" || rot === "I" ? [W, H] : [H, W];
+    const measuredFor = (id: string, rot: (typeof rots)[number]) => {
+      const [w, h] = dims(rot);
+      const r = barSubRect(rot, false, tz, w, h);
+      return new Map([[id, { width: w, height: h, barHeightDots: r.barH, barLeftDots: r.barLeft, barTopDots: r.barTop }]]);
+    };
+    let ean = {
+      id: "ean", type: "ean13", x: 200, y: 100, rotation: 0, positionType: "FT",
+      props: { rotation: "N", magnification: 2, printInterpretation: true },
+    } as unknown as LabelObject;
+    const centreOf = (o: LabelObject, rot: (typeof rots)[number]) => {
+      const b = objectBoundsDots(o, ctx(measuredFor(o.id, rot)));
+      return { x: b.x + b.width / 2, y: b.y + b.height / 2 };
+    };
+    const start = centreOf(ean, "N");
+    for (let i = 0; i < 4; i++) {
+      const c = rotateSelectionChanges([ean], [ean.id], ctx(measuredFor(ean.id, rots[i]!)), 1).get(ean.id)!;
+      const next = rots[(i + 1) % 4]!;
+      ean = { ...ean, x: c.x, y: c.y, props: { rotation: next, magnification: 2, printInterpretation: true } } as unknown as LabelObject;
+      const centre = centreOf(ean, next);
+      expect(Math.abs(centre.x - start.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(centre.y - start.y)).toBeLessThanOrEqual(1);
+    }
+    expect((ean as unknown as { props: { rotation: string } }).props.rotation).toBe("N");
+    expect(Math.abs((ean.x as number) - 200)).toBeLessThanOrEqual(2);
+    expect(Math.abs((ean.y as number) - 100)).toBeLessThanOrEqual(2);
+  });
+
+  it("returns no changes for a zero (mod 4) turn", () => {
+    const b = box(10, 10, 40, 20);
+    expect(rotateSelectionChanges([b], [b.id], ctx(), 4).size).toBe(0);
+  });
+
+  it("excludes leaves under a locked group (cascaded lock) from pivot and changes", () => {
+    const a = box(0, 0, 20, 20); // movable, centre (10,10)
+    const inner = box(40, 0, 20, 20); // would pull the pivot right if counted
+    const grp = { id: "g", type: "group", locked: true, children: [inner] } as unknown as LabelObject;
+    const m = rotateSelectionChanges([a, grp], [a.id, "g"], ctx(), 1);
+    expect(m.has(inner.id)).toBe(false); // store would refuse to move it anyway
+    expect(m.has("g")).toBe(false);
+    // pivot is a's own centre (locked subtree excluded), so a rotates in place
+    expect(m.get(a.id)).toEqual({ x: 0, y: 0, props: { width: 20, height: 20 } });
+  });
+
+  it("excludes hidden children of a selected group from pivot and changes", () => {
+    const vis = box(0, 0, 20, 20); // centre (10,10)
+    const hidden = { ...box(40, 0, 20, 20), visible: false } as unknown as LabelObject;
+    const grp = { id: "g", type: "group", children: [vis, hidden] } as unknown as LabelObject;
+    const m = rotateSelectionChanges([grp], ["g"], ctx(), 1);
+    expect(m.has(hidden.id)).toBe(false); // off screen, must not rotate or skew pivot
+    expect(m.get(vis.id)).toEqual({ x: 0, y: 0, props: { width: 20, height: 20 } });
+  });
+});

--- a/src/lib/groupRotation.ts
+++ b/src/lib/groupRotation.ts
@@ -1,0 +1,181 @@
+// Pure 90deg rotation of a selection (group / multi-select) about its union bbox
+// centre. ZPL only has 0/90/180/270 field orientations, so turns are quarter
+// steps. Every leaf rotates its VISUAL centre to stay rigid despite per-type
+// anchor quirks; see leafChanges for the per-type handling.
+
+import type { LabelObject, LeafObject } from "../types/Group";
+import { isGroup } from "../types/Group";
+import { objectBoundsDots, selectionUnionDots, type ObjectBoundsCtx } from "./objectBounds";
+import { ZPL_ROTATIONS, isZplRotation, type ZplRotation } from "../registry/rotation";
+import { barSubRect } from "./bwipConstants";
+import { barcodeTextZoneDots, barcodeZoneAbove } from "./barcodeHri";
+import type { ObjectChanges } from "../types/LabelObject";
+
+interface Vec { x: number; y: number }
+
+/** Rotate (dx, dy) by `steps` clockwise quarter turns (screen coords, y down). */
+function rotateVec(dx: number, dy: number, steps: number): Vec {
+  switch (((steps % 4) + 4) % 4) {
+    case 1: return { x: -dy, y: dx };
+    case 2: return { x: -dx, y: -dy };
+    case 3: return { x: dy, y: -dx };
+    default: return { x: dx, y: dy };
+  }
+}
+
+function rotateAbout(p: Vec, pivot: Vec, steps: number): Vec {
+  const r = rotateVec(p.x - pivot.x, p.y - pivot.y, steps);
+  return { x: pivot.x + r.x, y: pivot.y + r.y };
+}
+
+function advanceRotation(r: string, steps: number): string {
+  if (!isZplRotation(r)) return r;
+  const i = ZPL_ROTATIONS.indexOf(r);
+  return ZPL_ROTATIONS[(((i + steps) % 4) + 4) % 4] ?? r;
+}
+
+function leafChanges(
+  leaf: LeafObject,
+  pivot: Vec,
+  steps: number,
+  ctx: ObjectBoundsCtx,
+): ObjectChanges {
+  if (leaf.type === "line") {
+    const p = leaf.props as { angle: number };
+    const a = rotateAbout({ x: leaf.x, y: leaf.y }, pivot, steps);
+    const angle = (((p.angle + 90 * steps) % 360) + 360) % 360;
+    return { x: Math.round(a.x), y: Math.round(a.y), props: { angle } };
+  }
+
+  // Box / ellipse: rotate two opposite corners. Integer corners about an integer
+  // pivot stay integer (a quarter turn maps the lattice onto itself), so this is
+  // exact (no rounding drift) and the dims swap for odd steps automatically.
+  if (leaf.type === "box" || leaf.type === "ellipse") {
+    const b = objectBoundsDots(leaf, ctx);
+    const c1 = rotateAbout({ x: b.x, y: b.y }, pivot, steps);
+    const c2 = rotateAbout({ x: b.x + b.width, y: b.y + b.height }, pivot, steps);
+    const x = Math.min(c1.x, c2.x);
+    const y = Math.min(c1.y, c2.y);
+    return { x, y, props: { width: Math.abs(c2.x - c1.x), height: Math.abs(c2.y - c1.y) } };
+  }
+
+  // Symbol / image: footprint can't turn (Zebra rotates only the symbol glyph,
+  // images not at all), so keep w x h and just reposition by the centre. Odd
+  // dims can round here, but that's isolated, not a per-step accumulation.
+  if (leaf.type === "symbol" || leaf.type === "image") {
+    const b = objectBoundsDots(leaf, ctx);
+    const centre = rotateAbout({ x: b.x + b.width / 2, y: b.y + b.height / 2 }, pivot, steps);
+    const x = Math.round(centre.x - b.width / 2);
+    const y = Math.round(centre.y - b.height / 2);
+    if (leaf.type === "symbol") {
+      const r = advanceRotation((leaf.props as { rotation: string }).rotation, steps);
+      return { x, y, props: { rotation: r } };
+    }
+    return { x, y };
+  }
+
+  // text / serial / barcodes: rotate the VISUAL centre, then re-anchor from the
+  // new-orientation bbox. Anchor-rotation assumes the object spins about model
+  // x/y, false for barcodes (they keep top-left on reorient), so centre-based is
+  // what keeps the group rigid.
+  const b = objectBoundsDots(leaf, ctx);
+  const centre = rotateAbout({ x: b.x + b.width / 2, y: b.y + b.height / 2 }, pivot, steps);
+  const props = leaf.props as { rotation?: string };
+  if (typeof props.rotation !== "string") {
+    return { x: Math.round(centre.x - b.width / 2), y: Math.round(centre.y - b.height / 2) };
+  }
+  const newRot = advanceRotation(props.rotation, steps) as ZplRotation;
+  // Feed the probe the post-turn measured footprint + barcode bar sub-rect so
+  // the new-orientation bbox (and thus the anchor offset) is right.
+  const probeCtx = rotateMeasured(ctx, leaf, newRot, ((steps % 2) + 2) % 2 === 1);
+  const probe = objectBoundsDots(
+    { ...leaf, x: 0, y: 0, props: { ...leaf.props, rotation: newRot } } as LeafObject,
+    probeCtx,
+  );
+  return {
+    x: Math.round(centre.x - (probe.x + probe.width / 2)),
+    y: Math.round(centre.y - (probe.y + probe.height / 2)),
+    props: { rotation: newRot },
+  };
+}
+
+/** Clone the bounds ctx with this leaf's measured footprint set for `newRot`:
+ *  axis-swap on an odd turn, plus the barcode bar sub-rect, since the HRI zone
+ *  travels around the rectangle per orientation (N bottom, R left, I top, B
+ *  right). Without this the probe re-anchors a rotated barcode off by the zone. */
+function rotateMeasured(
+  ctx: ObjectBoundsCtx,
+  leaf: LeafObject,
+  newRot: ZplRotation,
+  odd: boolean,
+): ObjectBoundsCtx {
+  const m = ctx.measured?.get(leaf.id);
+  if (!m) return ctx;
+  const width = odd ? m.height : m.width;
+  const height = odd ? m.width : m.height;
+  const next = { ...m, width, height };
+  const tz = barcodeTextZoneDots(leaf);
+  if (tz > 0) {
+    // Same placement the renderer uses; objectBounds only needs the bar's top,
+    // left and height for the FT anchor, so barW is dropped here.
+    const { barTop, barLeft, barH } = barSubRect(newRot, barcodeZoneAbove(leaf), tz, width, height);
+    next.barTopDots = barTop;
+    next.barLeftDots = barLeft;
+    next.barHeightDots = barH;
+  } else if (next.barHeightDots !== undefined) {
+    // Bars fill the rotated footprint when there's no text zone; recomputing the
+    // height keeps the FT y-shift off the stale pre-turn value on an odd turn.
+    next.barHeightDots = height;
+  }
+  const measured = new Map(ctx.measured);
+  measured.set(leaf.id, next);
+  return { ...ctx, measured };
+}
+
+/** Leaves under `ids` that actually move: visible and not locked, with lock and
+ *  visibility cascaded from ancestors (mirrors the store's lock cascade and the
+ *  canvas's visibleLeaves). A leaf inside a locked or hidden group is excluded
+ *  from both the pivot and the changes, so the pivot can't be skewed by objects
+ *  the store will refuse to move (cascaded lock) or that aren't on screen. */
+function selectedMovableLeaves(objects: LabelObject[], ids: readonly string[]): LeafObject[] {
+  const wanted = new Set(ids);
+  const out: LeafObject[] = [];
+  const walk = (nodes: LabelObject[], selected: boolean, locked: boolean, hidden: boolean) => {
+    for (const n of nodes) {
+      const sel = selected || wanted.has(n.id);
+      const lock = locked || !!n.locked;
+      const hide = hidden || n.visible === false;
+      if (isGroup(n)) walk(n.children, sel, lock, hide);
+      else if (sel && !lock && !hide) out.push(n);
+    }
+  };
+  walk(objects, false, false, false);
+  return out;
+}
+
+/** Per-leaf changes for rotating the selection `steps` clockwise quarter turns
+ *  about the centre of its union bbox. Empty when nothing rotatable is selected. */
+export function rotateSelectionChanges(
+  objects: LabelObject[],
+  ids: readonly string[],
+  ctx: ObjectBoundsCtx,
+  steps: number,
+): Map<string, ObjectChanges> {
+  const result = new Map<string, ObjectChanges>();
+  if (((steps % 4) + 4) % 4 === 0) return result;
+  const leaves = selectedMovableLeaves(objects, ids);
+  if (leaves.length === 0) return result;
+  const union = selectionUnionDots(objects, leaves.map((l) => l.id), ctx);
+  if (!union) return result;
+  // Integer pivot: a quarter turn maps the integer lattice onto itself, so
+  // anchors/corners stay exact (no per-step rounding that would drift objects
+  // apart over 1/2/3 turns and only re-align after a full 360deg).
+  const pivot: Vec = {
+    x: Math.round(union.x + union.width / 2),
+    y: Math.round(union.y + union.height / 2),
+  };
+  for (const leaf of leaves) {
+    result.set(leaf.id, leafChanges(leaf, pivot, steps, ctx));
+  }
+  return result;
+}


### PR DESCRIPTION
Quarter-turn rotation about the union centre via a pure geometry lib (anchor+orientation for text/barcodes, centre+swap for box/ellipse, endpoints for lines), applied as one batch. Action-bar button for a selected group or multi-select. 