### PR TITLE
feat(tooltip): edge-aware placement, smart sizing, consistent usage

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -67,16 +67,17 @@ function ExpandStrip({
 }) {
   const Icon = side === "left" ? ChevronDoubleRightIcon : ChevronDoubleLeftIcon;
   return (
-    <button
-      onClick={onExpand}
-      title={title}
-      aria-label={title}
-      className={`w-5 shrink-0 ${
-        side === "left" ? "border-r" : "border-l"
-      } border-border bg-surface hover:bg-surface-2 flex items-start justify-center pt-2 text-muted hover:text-text transition-colors`}
-    >
-      <Icon className="w-3.5 h-3.5" />
-    </button>
+    <Tooltip content={title} className="shrink-0 h-full">
+      <button
+        onClick={onExpand}
+        aria-label={title}
+        className={`w-5 h-full ${
+          side === "left" ? "border-r" : "border-l"
+        } border-border bg-surface hover:bg-surface-2 flex items-start justify-center pt-2 text-muted hover:text-text transition-colors`}
+      >
+        <Icon className="w-3.5 h-3.5" />
+      </button>
+    </Tooltip>
   );
 }
 
@@ -375,14 +376,15 @@ export function AppShell() {
         ) : (
           <aside className="w-56 shrink-0 border-r border-border bg-surface flex flex-col min-h-0">
             <div className="shrink-0 flex justify-end border-b border-border bg-surface px-1 py-0.5">
-              <button
-                onClick={leftPanel.collapse}
-                title={t.app.collapse}
-                aria-label={t.app.collapse}
-                className="p-0.5 text-muted hover:text-text transition-colors"
-              >
-                <ChevronDoubleLeftIcon className="w-3.5 h-3.5" />
-              </button>
+              <Tooltip content={t.app.collapse}>
+                <button
+                  onClick={leftPanel.collapse}
+                  aria-label={t.app.collapse}
+                  className="p-0.5 text-muted hover:text-text transition-colors"
+                >
+                  <ChevronDoubleLeftIcon className="w-3.5 h-3.5" />
+                </button>
+              </Tooltip>
             </div>
             <ObjectPalette />
           </aside>

--- a/src/components/Barcode/Gs1ContentModal.tsx
+++ b/src/components/Barcode/Gs1ContentModal.tsx
@@ -3,6 +3,7 @@ import { TrashIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { BarcodeContentModalShell } from "./BarcodeContentModalShell";
 import { useT } from "../../lib/useT";
 import { inputCls } from "../ui/formStyles";
+import { Tooltip } from "../ui/Tooltip";
 import { useLabelStore, getCurrentObjects } from "../../store/labelStore";
 import { findObjectById } from "../../types/Group";
 import {
@@ -139,7 +140,9 @@ function Gs1Builder({ objectId }: { objectId: string }) {
                       aria-label={aiName(seg.ai)}
                     />
                     {fnc1After(i) && (
-                      <span className="font-mono text-[9px] text-muted shrink-0" title={tg.fnc1}>FNC1</span>
+                      <Tooltip content={tg.fnc1} className="shrink-0">
+                        <span className="font-mono text-[9px] text-muted">FNC1</span>
+                      </Tooltip>
                     )}
                     <button type="button" aria-label={tg.remove} onClick={() => removeAt(i)} className="text-muted hover:text-error shrink-0">
                       <TrashIcon className="w-4 h-4" />

--- a/src/components/Fonts/FontManager.tsx
+++ b/src/components/Fonts/FontManager.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback, type FocusEvent } from 'react';
-import { PlusIcon, TrashIcon } from '@heroicons/react/16/solid';
+import { PlusIcon, TrashIcon, InformationCircleIcon } from '@heroicons/react/16/solid';
 import {
   getAllFonts,
   loadFontFile,
@@ -411,7 +411,6 @@ function ManualMappingsSection({
 
   return (
     <div className="flex flex-col gap-2">
-      <p className="text-xs text-muted px-1 leading-relaxed">{hint}</p>
       {rows.map(({ entry: m, index }) => {
         const dup = isDuplicateAlias(m.alias);
         const path = m.path ?? '';
@@ -458,10 +457,17 @@ function ManualMappingsSection({
           </div>
         );
       })}
-      <button type="button" className={addBtnCls} onClick={onAdd}>
-        <PlusIcon className="w-3 h-3 text-accent" />
-        {addLabel}
-      </button>
+      <div className="flex items-center gap-1.5">
+        <button type="button" className={addBtnCls} onClick={onAdd}>
+          <PlusIcon className="w-3 h-3 text-accent" />
+          {addLabel}
+        </button>
+        <Tooltip content={hint}>
+          <button type="button" aria-label={hint} className="shrink-0 text-muted/60 hover:text-text cursor-help">
+            <InformationCircleIcon className="w-3.5 h-3.5" aria-hidden="true" />
+          </button>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/src/components/Properties/FpSettings.tsx
+++ b/src/components/Properties/FpSettings.tsx
@@ -81,16 +81,18 @@ export function FpSettings({ props: p, onChange }: Props) {
           })}
         </div>
       </div>
-      <div title={gapDisabled ? t.registry.text.fpCharGapVHint : undefined}>
-        <UnitNumberInput
-          label={t.registry.text.fpCharGap}
-          valueDots={p.fpCharGap}
-          minDots={0}
-          allowUnset
-          disabled={gapDisabled}
-          onChangeDots={(fpCharGap) => onChange({ fpCharGap })}
-        />
-      </div>
+      <Tooltip content={gapDisabled ? t.registry.text.fpCharGapVHint : undefined} className="w-full">
+        <div>
+          <UnitNumberInput
+            label={t.registry.text.fpCharGap}
+            valueDots={p.fpCharGap}
+            minDots={0}
+            allowUnset
+            disabled={gapDisabled}
+            onChangeDots={(fpCharGap) => onChange({ fpCharGap })}
+          />
+        </div>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Properties/PropertiesPanel.tsx
+++ b/src/components/Properties/PropertiesPanel.tsx
@@ -700,21 +700,20 @@ function LabelConfigPanel({
           />
         </div>
 
-        <label
-          className="flex items-center gap-2 text-xs"
-          title={t.label.overridePauseCountHint}
-        >
-          <input
-            type="checkbox"
-            checked={label.overridePauseCount === "Y"}
-            onChange={(e) =>
-              onUpdate({
-                overridePauseCount: e.target.checked ? "Y" : undefined,
-              })
-            }
-          />
-          {t.label.overridePauseCount}
-        </label>
+        <Tooltip content={t.label.overridePauseCountHint} className="w-full">
+          <label className="flex w-full items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={label.overridePauseCount === "Y"}
+              onChange={(e) =>
+                onUpdate({
+                  overridePauseCount: e.target.checked ? "Y" : undefined,
+                })
+              }
+            />
+            {t.label.overridePauseCount}
+          </label>
+        </Tooltip>
         </div>
         </SectionCard>
 

--- a/src/components/Properties/PropertiesPanel.tsx
+++ b/src/components/Properties/PropertiesPanel.tsx
@@ -700,8 +700,8 @@ function LabelConfigPanel({
           />
         </div>
 
-        <Tooltip content={t.label.overridePauseCountHint} className="w-full">
-          <label className="flex w-full items-center gap-2 text-xs">
+        <label className="flex w-full items-center gap-2 text-xs">
+          <Tooltip content={t.label.overridePauseCountHint}>
             <input
               type="checkbox"
               checked={label.overridePauseCount === "Y"}
@@ -711,9 +711,9 @@ function LabelConfigPanel({
                 })
               }
             />
-            {t.label.overridePauseCount}
-          </label>
-        </Tooltip>
+          </Tooltip>
+          {t.label.overridePauseCount}
+        </label>
         </div>
         </SectionCard>
 

--- a/src/components/Properties/TextModeSection.tsx
+++ b/src/components/Properties/TextModeSection.tsx
@@ -5,6 +5,7 @@ import { BlockTextSettings } from "./BlockTextSettings";
 import { BlockDragModeToggle } from "./BlockDragModeToggle";
 import { SectionCard } from "./SectionCard";
 import { ZplCmd } from "./ZplCmd";
+import { Tooltip } from "../ui/Tooltip";
 import { fieldGridCols, fieldGridCell } from "../ui/formStyles";
 import { FB_DEFAULTS } from "../../lib/textBlock";
 import { resolveTextMode, type TextMode, type TextProps } from "../../registry/text";
@@ -79,23 +80,23 @@ export function TextModeSection({
     <SectionCard id="text-mode" title={t.registry.text.textMode}>
       <div className="grid grid-cols-3 gap-1">
         {modes.map((m) => (
-          <button
-            key={m.key}
-            type="button"
-            title={m.hint}
-            aria-label={`${m.label}: ${m.hint}`}
-            aria-pressed={mode === m.key}
-            className={`flex flex-col items-center gap-0.5 rounded border px-1 py-1.5 text-[11px] transition-colors ${
-              mode === m.key
-                ? "border-accent ring-1 ring-accent text-text"
-                : "border-border text-muted hover:text-text"
-            }`}
-            onClick={() => setMode(m.key)}
-          >
-            <ModeIcon icon={m.icon} />
-            <span>{m.label}</span>
-            <ZplCmd cmd={m.cmd} />
-          </button>
+          <Tooltip key={m.key} content={m.hint} className="w-full">
+            <button
+              type="button"
+              aria-label={`${m.label}: ${m.hint}`}
+              aria-pressed={mode === m.key}
+              className={`w-full flex flex-col items-center gap-0.5 rounded border px-1 py-1.5 text-[11px] transition-colors ${
+                mode === m.key
+                  ? "border-accent ring-1 ring-accent text-text"
+                  : "border-border text-muted hover:text-text"
+              }`}
+              onClick={() => setMode(m.key)}
+            >
+              <ModeIcon icon={m.icon} />
+              <span>{m.label}</span>
+              <ZplCmd cmd={m.cmd} />
+            </button>
+          </Tooltip>
         ))}
       </div>
 

--- a/src/components/Properties/TextModeSection.tsx
+++ b/src/components/Properties/TextModeSection.tsx
@@ -83,7 +83,6 @@ export function TextModeSection({
           <Tooltip key={m.key} content={m.hint} className="w-full">
             <button
               type="button"
-              aria-label={`${m.label}: ${m.hint}`}
               aria-pressed={mode === m.key}
               className={`w-full flex flex-col items-center gap-0.5 rounded border px-1 py-1.5 text-[11px] transition-colors ${
                 mode === m.key

--- a/src/components/Variables/VariableMappingModal.tsx
+++ b/src/components/Variables/VariableMappingModal.tsx
@@ -482,10 +482,8 @@ export function VariableMappingModal({ onClose }: Props) {
         </div>
 
         {virtualRows.length > 0 && (
-          <div
-            className="flex items-center gap-2 font-mono text-xs text-text"
-            title={tv.csvActiveRowTooltip}
-          >
+          <Tooltip content={tv.csvActiveRowTooltip} className="w-full">
+          <div className="flex w-full items-center gap-2 font-mono text-xs text-text">
             <label htmlFor="variable-mapping-preview-row" className="text-muted">
               {tv.csvActiveRowLabel}:
             </label>
@@ -510,6 +508,7 @@ export function VariableMappingModal({ onClose }: Props) {
               {tv.csvActiveRowOf} {virtualRows.length}
             </span>
           </div>
+          </Tooltip>
         )}
 
         <CollapsibleSection

--- a/src/components/Variables/VariableSourceBadge.tsx
+++ b/src/components/Variables/VariableSourceBadge.tsx
@@ -4,6 +4,7 @@ import {
   TableCellsIcon,
 } from '@heroicons/react/16/solid';
 import { useT } from '../../lib/useT';
+import { Tooltip } from '../ui/Tooltip';
 import type { VariableSource } from '../../lib/variableBinding';
 
 interface Props {
@@ -63,17 +64,18 @@ export function VariableSourceBadge({
         : 'default';
 
   return (
-    <span
-      title={tip}
-      aria-label={label}
-      className={`inline-flex items-center gap-1 ${colorCls}`}
-    >
-      <Icon className={`${iconSize} shrink-0`} />
-      {showLabel && (
-        <span className="font-mono text-[9px] normal-case tracking-normal">
-          {label}
-        </span>
-      )}
-    </span>
+    <Tooltip content={tip}>
+      <span
+        aria-label={label}
+        className={`inline-flex items-center gap-1 ${colorCls}`}
+      >
+        <Icon className={`${iconSize} shrink-0`} />
+        {showLabel && (
+          <span className="font-mono text-[9px] normal-case tracking-normal">
+            {label}
+          </span>
+        )}
+      </span>
+    </Tooltip>
   );
 }

--- a/src/components/Variables/VariablesPanel.tsx
+++ b/src/components/Variables/VariablesPanel.tsx
@@ -3,6 +3,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   Cog6ToothIcon,
+  InformationCircleIcon,
   PlusIcon,
   TableCellsIcon,
   TrashIcon,
@@ -108,11 +109,8 @@ export function VariablesPanel() {
 
   return (
     <div className="flex flex-col gap-3 p-3">
-      <div className="flex items-start justify-between gap-2">
-        <p className="font-mono text-[10px] text-muted leading-relaxed flex-1">
-          {tv.panelHint}
-        </p>
-        {variables.length > 0 && (
+      {variables.length > 0 && (
+        <div className="flex items-start justify-end gap-2">
           <Tooltip
             content={
               csvRenderMode === 'preview'
@@ -138,8 +136,8 @@ export function VariablesPanel() {
               {csvRenderMode === 'preview' ? tv.csvBadgePreviewMode : tv.csvBadgeSchemaMode}
             </button>
           </Tooltip>
-        )}
-      </div>
+        </div>
+      )}
 
       {!csvDataset && csvMapping && Object.keys(csvMapping.bindings).length > 0 && (
         /* Mapping persisted (design.json or localStorage) but no CSV
@@ -299,14 +297,21 @@ export function VariablesPanel() {
         </ul>
       )}
 
-      <button
-        onClick={handleAdd}
-        disabled={allSlotsTaken}
-        className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs font-mono border border-dashed border-border text-muted hover:text-text hover:border-border-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        <PlusIcon className="w-3.5 h-3.5" />
-        {tv.add}
-      </button>
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={handleAdd}
+          disabled={allSlotsTaken}
+          className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs font-mono border border-dashed border-border text-muted hover:text-text hover:border-border-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <PlusIcon className="w-3.5 h-3.5" />
+          {tv.add}
+        </button>
+        <Tooltip content={tv.panelHint}>
+          <button type="button" aria-label={tv.panelHint} className="shrink-0 text-muted/60 hover:text-text cursor-help">
+            <InformationCircleIcon className="w-3.5 h-3.5" aria-hidden="true" />
+          </button>
+        </Tooltip>
+      </div>
 
       {panelError && (
         <p className="font-mono text-[10px] text-amber-400">{panelError}</p>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -2,12 +2,14 @@ import { cloneElement, isValidElement, useEffect, useId, useRef, useState } from
 import type { ReactElement, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useAnchoredPosition } from "../../hooks/useAnchoredPosition";
+import { resolveTooltipPosition } from "../../lib/tooltipPosition";
 
 interface TooltipProps {
   /** Hover/focus hint. Falsy renders the child untouched (no wrapper). */
   content: ReactNode;
   /** Single focusable element; gets aria-describedby while the tip is open. */
   children: ReactElement;
+  /** Preferred side; flips automatically when there's no room. */
   placement?: "top" | "bottom";
   /** Hover dwell before showing; shorter than native title's ~1s. */
   delayMs?: number;
@@ -18,18 +20,28 @@ interface TooltipProps {
 /**
  * Hover/focus tooltip that replaces native `title`. Listeners sit on a wrapper
  * span so a `disabled` child still triggers it (disabled controls swallow their
- * own events). Portaled to body with fixed coords so the scrollable properties
- * panel can't clip it; repositions on scroll/resize.
+ * own events). Portaled to body with fixed coords; the position is measured from
+ * the rendered tip so it flips to the side with room and clamps into the
+ * viewport (never clipped behind the top menu bar or a side edge).
  */
 export function Tooltip({ content, children, placement = "top", delayMs = 120, className }: TooltipProps) {
   const id = useId();
   const wrapRef = useRef<HTMLSpanElement>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef(0);
   const [open, setOpen] = useState(false);
-  const pos = useAnchoredPosition(wrapRef, open, (r) => ({
-    top: placement === "top" ? r.top - 6 : r.bottom + 6,
-    left: r.left + r.width / 2,
-  }));
+
+  // The tip is rendered (hidden) whenever open, so its size is known by the time
+  // useAnchoredPosition measures; resolveTooltipPosition then flips/clamps it.
+  const pos = useAnchoredPosition(wrapRef, open, (a) => {
+    const t = tipRef.current?.getBoundingClientRect();
+    return resolveTooltipPosition(
+      a,
+      { width: t?.width ?? 0, height: t?.height ?? 0 },
+      { width: window.innerWidth, height: window.innerHeight },
+      { preferred: placement },
+    );
+  });
 
   useEffect(() => () => window.clearTimeout(timerRef.current), []);
 
@@ -65,17 +77,15 @@ export function Tooltip({ content, children, placement = "top", delayMs = 120, c
       onBlur={hide}
     >
       {trigger}
-      {open && pos &&
+      {open &&
         createPortal(
           <div
+            ref={tipRef}
             id={id}
             role="tooltip"
-            className="fixed z-[60] px-2 py-1 rounded bg-surface border border-border text-[10px] font-mono text-text shadow-lg pointer-events-none max-w-64 whitespace-normal"
-            style={{
-              top: pos.top,
-              left: pos.left,
-              transform: placement === "top" ? "translate(-50%, -100%)" : "translateX(-50%)",
-            }}
+            // Hidden until measured to avoid a flash at the provisional 0,0.
+            className="fixed z-[60] px-2 py-1 rounded bg-surface border border-border text-[10px] font-mono text-text shadow-lg pointer-events-none max-w-xs whitespace-normal break-words"
+            style={{ top: pos?.top ?? 0, left: pos?.left ?? 0, opacity: pos ? 1 : 0 }}
           >
             {content}
           </div>,

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -38,7 +38,7 @@ export function Tooltip({ content, children, placement = "top", delayMs = 120, c
     return resolveTooltipPosition(
       a,
       { width: t?.width ?? 0, height: t?.height ?? 0 },
-      { width: window.innerWidth, height: window.innerHeight },
+      { width: document.documentElement.clientWidth, height: document.documentElement.clientHeight },
       { preferred: placement },
     );
   });

--- a/src/lib/tooltipPosition.test.ts
+++ b/src/lib/tooltipPosition.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { resolveTooltipPosition, type AnchorRect } from "./tooltipPosition";
+
+const VP = { width: 1000, height: 800 };
+const tip = { width: 120, height: 40 };
+// Anchor mid-viewport with plenty of room on all sides.
+const mid: AnchorRect = { top: 400, left: 500, width: 60, height: 20 };
+
+describe("resolveTooltipPosition", () => {
+  it("places above and horizontally centred when there is room", () => {
+    const p = resolveTooltipPosition(mid, tip, VP, { preferred: "top" });
+    expect(p.placement).toBe("top");
+    expect(p.top).toBe(400 - 6 - 40); // anchor.top - gap - tipHeight
+    expect(p.left).toBe(530 - 60); // centreX(530) - tipWidth/2
+  });
+
+  it("flips to bottom when the anchor hugs the top edge (menu bar)", () => {
+    const topBar: AnchorRect = { top: 4, left: 500, width: 60, height: 24 };
+    const p = resolveTooltipPosition(topBar, tip, VP, { preferred: "top" });
+    expect(p.placement).toBe("bottom");
+    expect(p.top).toBe(4 + 24 + 6); // below the anchor
+  });
+
+  it("flips a bottom-preferred tip to top when it hugs the bottom edge", () => {
+    const bottom: AnchorRect = { top: 780, left: 500, width: 60, height: 16 };
+    const p = resolveTooltipPosition(bottom, tip, VP, { preferred: "bottom" });
+    expect(p.placement).toBe("top");
+  });
+
+  it("clamps a left-edge anchor so the tip stays in the viewport", () => {
+    const leftEdge: AnchorRect = { top: 400, left: 0, width: 20, height: 20 };
+    const p = resolveTooltipPosition(leftEdge, tip, VP, { margin: 4 });
+    expect(p.left).toBe(4); // would be 10 - 60 = -50, clamped to margin
+  });
+
+  it("clamps a right-edge anchor so the tip stays in the viewport", () => {
+    const rightEdge: AnchorRect = { top: 400, left: 990, width: 10, height: 20 };
+    const p = resolveTooltipPosition(rightEdge, tip, VP, { margin: 4 });
+    expect(p.left).toBe(VP.width - 4 - tip.width); // 1000 - 4 - 120 = 876
+  });
+
+  it("falls back to the roomier side when neither fits", () => {
+    const tall = { width: 120, height: 700 };
+    const p = resolveTooltipPosition(mid, tall, VP, { preferred: "top" });
+    // anchor.top 400 vs spaceBelow 380 -> above has more room
+    expect(p.placement).toBe("top");
+    expect(p.top).toBeGreaterThanOrEqual(4); // clamped into the viewport
+  });
+});

--- a/src/lib/tooltipPosition.ts
+++ b/src/lib/tooltipPosition.ts
@@ -1,0 +1,71 @@
+// Pure placement math for the portaled Tooltip: flip to the side with room and
+// clamp into the viewport so a tip near an edge (e.g. the top menu bar) is never
+// clipped. Coords are final fixed-position top/left (no CSS transform), so the
+// clamp is exact. Unit-agnostic px.
+
+export interface AnchorRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+export interface Size {
+  width: number;
+  height: number;
+}
+export interface Viewport {
+  width: number;
+  height: number;
+}
+export type Placement = "top" | "bottom";
+export interface PositionedTooltip {
+  top: number;
+  left: number;
+  placement: Placement;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Resolve the tip's fixed top/left and the side it ends up on. Prefers
+ *  `preferred`, flips when it doesn't fit, and falls back to the roomier side
+ *  when neither fits. Horizontal: centred on the anchor, clamped to the
+ *  viewport. `gap` is the anchor-to-tip offset, `margin` the viewport padding. */
+export function resolveTooltipPosition(
+  anchor: AnchorRect,
+  tip: Size,
+  viewport: Viewport,
+  opts: { preferred?: Placement; gap?: number; margin?: number } = {},
+): PositionedTooltip {
+  const preferred = opts.preferred ?? "top";
+  const gap = opts.gap ?? 6;
+  const margin = opts.margin ?? 4;
+
+  const fitsAbove = anchor.top - gap - tip.height >= margin;
+  const fitsBelow = anchor.top + anchor.height + gap + tip.height <= viewport.height - margin;
+  const spaceAbove = anchor.top;
+  const spaceBelow = viewport.height - (anchor.top + anchor.height);
+
+  let placement: Placement;
+  if (preferred === "top") {
+    placement = fitsAbove ? "top" : fitsBelow ? "bottom" : spaceAbove >= spaceBelow ? "top" : "bottom";
+  } else {
+    placement = fitsBelow ? "bottom" : fitsAbove ? "top" : spaceBelow >= spaceAbove ? "bottom" : "top";
+  }
+
+  const rawTop =
+    placement === "top"
+      ? anchor.top - gap - tip.height
+      : anchor.top + anchor.height + gap;
+  const top = clamp(rawTop, margin, Math.max(margin, viewport.height - margin - tip.height));
+
+  const centerX = anchor.left + anchor.width / 2;
+  const left = clamp(
+    centerX - tip.width / 2,
+    margin,
+    Math.max(margin, viewport.width - margin - tip.width),
+  );
+
+  return { top, left, placement };
+}


### PR DESCRIPTION
Position from the measured tip so it flips/clamps into the viewport (no menu-bar clipping) and widen long hints; migrate native-title hints to the component and move printer-font/variables descriptions into focusable info-icon tooltips.