### PR TITLE
fix(canvas): correct group rotation of axis-aligned GB bars

### DIFF
--- a/src/lib/groupRotation.test.ts
+++ b/src/lib/groupRotation.test.ts
@@ -53,11 +53,38 @@ describe("rotateSelectionChanges", () => {
     expect(c?.props).toEqual({ rotation: "N" });
   });
 
-  it("line adds 90deg to the angle and rotates the start point", () => {
+  it("line 90deg re-anchors the band so its centre stays put", () => {
     const ln = leaf("line", 10, 10, { angle: 0, length: 50, thickness: 2, color: "B" });
     const c = rotateSelectionChanges([ln], [ln.id], ctx(), 1).get(ln.id);
-    // bbox (10,10,50,2) centre (35,11); start (10,10) -> (36,-14); angle 90
-    expect(c).toEqual({ x: 36, y: -14, props: { angle: 90 } });
+    // horizontal 50x2 (centre 35,11) -> vertical 2x50 still centred at (35,11): TL (34,-14)
+    expect(c).toEqual({ x: 34, y: -14, props: { angle: 90 } });
+  });
+
+  it("axis-aligned bar keeps its centre across 180/270deg (was off by thickness)", () => {
+    // Vertical bar bbox (100,100,20,80), centre (110,140); pivot = its centre.
+    const bar = () => leaf("line", 100, 100, { angle: 90, length: 80, thickness: 20, color: "B" });
+    // 180deg: still vertical (20x80), angle 270; centre stays (110,140) so the
+    // ^GB FO (bottom-left for 270) is (100, 100+80) = (100,180).
+    expect(rotateSelectionChanges([bar()], [bar().id], ctx(), 2).get(bar().id)).toEqual({
+      x: 100, y: 180, props: { angle: 270 },
+    });
+    // 270deg: horizontal (80x20), angle 0; centre (110,140) so top-left = (70,130).
+    expect(rotateSelectionChanges([bar()], [bar().id], ctx(), 3).get(bar().id)).toEqual({
+      x: 70, y: 130, props: { angle: 0 },
+    });
+  });
+
+  it("four quarter turns return a line to integer origin (no trig-float drift)", () => {
+    let ln = leaf("line", 100, 100, { angle: 0, length: 50, thickness: 8, color: "B" });
+    for (let i = 0; i < 4; i++) {
+      const c = rotateSelectionChanges([ln], [ln.id], ctx(), 1).get(ln.id)!;
+      // Every intermediate anchor must stay integer (cos/sin residue not leaked).
+      expect(Number.isInteger(c.x)).toBe(true);
+      expect(Number.isInteger(c.y)).toBe(true);
+      const props = (ln as unknown as { props: object }).props;
+      ln = { ...ln, x: c.x!, y: c.y!, props: { ...props, ...c.props } } as unknown as LabelObject;
+    }
+    expect({ x: ln.x, y: ln.y }).toEqual({ x: 100, y: 100 });
   });
 
   it("multi-select rotates each leaf about the shared union centre", () => {

--- a/src/lib/groupRotation.ts
+++ b/src/lib/groupRotation.ts
@@ -34,6 +34,27 @@ function advanceRotation(r: string, steps: number): string {
   return ZPL_ROTATIONS[(((i + steps) % 4) + 4) % 4] ?? r;
 }
 
+/** Axis-aligned line angles (0/90/180/270) emit ^GB; other angles emit ^GD. */
+function isAxisAligned(angle: number): boolean {
+  return (((angle % 90) + 90) % 90) === 0;
+}
+
+/** A leaf's bbox rotated `steps` quarter turns about `pivot`, dims swapping on
+ *  odd steps. Rounded: box bounds are already integer (round is a no-op), but a
+ *  line's bounds carry trig residue (lineBounds uses cos/sin, e.g. cos(270deg)
+ *  is ~-1e-16), which would otherwise leak a `99.99999` anchor into the model. */
+function rotatedRect(leaf: LeafObject, pivot: Vec, steps: number, ctx: ObjectBoundsCtx) {
+  const b = objectBoundsDots(leaf, ctx);
+  const c1 = rotateAbout({ x: b.x, y: b.y }, pivot, steps);
+  const c2 = rotateAbout({ x: b.x + b.width, y: b.y + b.height }, pivot, steps);
+  return {
+    x: Math.round(Math.min(c1.x, c2.x)),
+    y: Math.round(Math.min(c1.y, c2.y)),
+    width: Math.round(Math.abs(c2.x - c1.x)),
+    height: Math.round(Math.abs(c2.y - c1.y)),
+  };
+}
+
 function leafChanges(
   leaf: LeafObject,
   pivot: Vec,
@@ -42,21 +63,26 @@ function leafChanges(
 ): ObjectChanges {
   if (leaf.type === "line") {
     const p = leaf.props as { angle: number };
-    const a = rotateAbout({ x: leaf.x, y: leaf.y }, pivot, steps);
     const angle = (((p.angle + 90 * steps) % 360) + 360) % 360;
+    // Axis-aligned bars emit ^GB, whose ^FO anchor is NOT the bbox top-left for
+    // every angle: 180 anchors at the top-right, 270 at the bottom-left (see
+    // line.toZPL). Rotating the raw anchor would land off by `thickness` when the
+    // turn changes that convention, so rotate the bbox then re-anchor.
+    if (isAxisAligned(p.angle)) {
+      const r = rotatedRect(leaf, pivot, steps, ctx);
+      const x = angle === 180 ? r.x + r.width : r.x;
+      const y = angle === 270 ? r.y + r.height : r.y;
+      return { x, y, props: { angle } };
+    }
+    // Diagonal (^GD): the anchor is a centreline endpoint, so rotating it about
+    // the pivot keeps the line rigid.
+    const a = rotateAbout({ x: leaf.x, y: leaf.y }, pivot, steps);
     return { x: Math.round(a.x), y: Math.round(a.y), props: { angle } };
   }
 
-  // Box / ellipse: rotate two opposite corners. Integer corners about an integer
-  // pivot stay integer (a quarter turn maps the lattice onto itself), so this is
-  // exact (no rounding drift) and the dims swap for odd steps automatically.
   if (leaf.type === "box" || leaf.type === "ellipse") {
-    const b = objectBoundsDots(leaf, ctx);
-    const c1 = rotateAbout({ x: b.x, y: b.y }, pivot, steps);
-    const c2 = rotateAbout({ x: b.x + b.width, y: b.y + b.height }, pivot, steps);
-    const x = Math.min(c1.x, c2.x);
-    const y = Math.min(c1.y, c2.y);
-    return { x, y, props: { width: Math.abs(c2.x - c1.x), height: Math.abs(c2.y - c1.y) } };
+    const r = rotatedRect(leaf, pivot, steps, ctx);
+    return { x: r.x, y: r.y, props: { width: r.width, height: r.height } };
   }
 
   // Symbol / image: footprint can't turn (Zebra rotates only the symbol glyph,


### PR DESCRIPTION
Re-anchor rotated lines by the new ^GB FO convention; was off by thickness on 180/270 turns.