### PR TITLE
feat(zpl): lossless source-patch overlay for round-tripped ZPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ File menu → **Import ZPL**: paste ZPL code directly, or open a `.zpl` file.
 
 > Import round-trips text, barcodes, shapes, images (including printer-stored and compressed graphics), label-header settings, and template fields (`^FN` slots land in the **Variables** tab; `^FE` inline embeds like `^FD#1#-#2#` import as `«name»` markers in the field content). Anything else the parser doesn't recognize is skipped and listed in the import report.
 
+**Lossless re-export:** edit an imported label and export it again, and the parts you didn't touch come back byte-for-byte. Untouched fields, settings, comments, and even commands the editor doesn't model are preserved exactly; only the objects you edit, add, or remove are regenerated. Setup or device commands that would re-run when the ZPL is sent again are flagged in the import report.
+
 ### Multiple labels (pages)
 
 File menu → **Add page** creates a new page. With multiple pages, the control at the bottom-center of the canvas switches between them and removes them. All pages share the same dimensions; export and import handle each page as a separate label.
@@ -106,6 +108,7 @@ Both `.zpl` and `.json` round-trip cleanly. `.zpl` preserves all printable conte
 
 - Smart alignment and spacing guides
 - Layers panel with reordering
+- Lossless ZPL round-trip: imported ZPL re-exports byte-for-byte, regenerating only the objects you edit and preserving everything else, including comments and commands the editor doesn't model
 - Variables: bind text and barcode fields to named defaults that emit as `^FN` slots (or `^FE` inline embeds when one field references multiple variables), round-tripping with printer-side templates
 - CSV batch printing: import a CSV, map columns to Variables, print or export with efficient printer-side data merge (template ships once, each row sends only its overrides)
 - GS1 content builder: assemble GS1 content from Application Identifiers (DataBar Expanded and GS1 DataMatrix), validated per field and against GS1 combination rules

--- a/src/components/Output/ImportSummary.tsx
+++ b/src/components/Output/ImportSummary.tsx
@@ -10,6 +10,8 @@ const TONE: Record<ImportFindingKind, string> = {
   partial: 'text-amber-400',
   browserLimit: 'text-amber-400',
   unknown: 'text-muted',
+  // Higher severity: a printer-config command that runs on the device.
+  replayRisk: 'text-red-400',
 };
 
 function FindingRow({ finding, showPage }: { finding: ImportFinding; showPage: boolean }) {

--- a/src/lib/designFile.test.ts
+++ b/src/lib/designFile.test.ts
@@ -57,6 +57,49 @@ describe('parseDesignFile', () => {
     expect(result.value.pages[0]?.objects).toHaveLength(1);
   });
 
+  it('round-trips a page overlay through serialize + parse', () => {
+    const source = '^XA^FO10,10^FDx^FS^XZ';
+    const overlay = {
+      segments: [
+        { kind: 'raw' as const, text: '^XA' },
+        { kind: 'object' as const, objectId: 'obj-1', text: '^FO10,10^FDx^FS' },
+        { kind: 'raw' as const, text: '^XZ' },
+      ],
+      v: 3,
+      regenSafe: true,
+    };
+    const json = serializeDesign(
+      { widthMm: 100, heightMm: 60, dpmm: 8 },
+      [{ objects: SAMPLE_OBJECTS, overlay }],
+    );
+    const result = parseDesignFile(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const loaded = result.value.pages[0]?.overlay;
+    expect(loaded?.segments).toHaveLength(3);
+    expect(loaded?.segments.map((s) => s.text).join('')).toBe(source);
+  });
+
+  it('drops a stale-version overlay (keeps the page)', () => {
+    const json = serializeDesign(
+      { widthMm: 100, heightMm: 60, dpmm: 8 },
+      [{
+        objects: SAMPLE_OBJECTS,
+        overlay: {
+          segments: [{ kind: 'raw', text: '^XA^FDx^FS^XZ' }],
+          v: 1,
+          regenSafe: true,
+        },
+      }],
+    );
+    const result = parseDesignFile(json);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Page still loads; only the stale overlay is dropped.
+    expect(result.value.pages).toHaveLength(1);
+    expect(result.value.pages[0]?.overlay).toBeUndefined();
+  });
+
   it('rejects files without a schemaVersion field', () => {
     const json = JSON.stringify({
       label: { widthMm: 100, heightMm: 60, dpmm: 8 },

--- a/src/lib/designFile.ts
+++ b/src/lib/designFile.ts
@@ -8,6 +8,7 @@ import {
   type CsvMapping,
 } from "../types/Variable";
 import type { LabelObject } from "../types/Group";
+import { blockOverlaySchema, type BlockOverlay } from "./zplOverlay/overlay";
 import { visitLeavesInPages } from "./objectTree";
 import { ok, err, type Result } from "./result";
 
@@ -19,7 +20,7 @@ import { ok, err, type Result } from "./result";
 export const CURRENT_DESIGN_SCHEMA_VERSION = 1;
 
 export type DesignFileError = "parse_error" | "invalid_schema";
-export interface DesignFilePage { objects: LabelObject[] }
+export interface DesignFilePage { objects: LabelObject[]; overlay?: BlockOverlay }
 export interface DesignFile {
   label: LabelConfig;
   pages: DesignFilePage[];
@@ -52,7 +53,12 @@ const groupSchema: z.ZodType<unknown> = z.lazy(() =>
 
 const labelObjectSchema: z.ZodType<unknown> = z.union([groupSchema, leafSchema]);
 
-const pageSchema = z.object({ objects: z.array(labelObjectSchema) });
+// A persisted overlay that fails its invariant drops to undefined (the page
+// regenerates) rather than failing the whole design load.
+const pageSchema = z.object({
+  objects: z.array(labelObjectSchema),
+  overlay: blockOverlaySchema.optional().catch(undefined),
+});
 
 const designFileV1Schema = z.object({
   schemaVersion: z.literal(1),

--- a/src/lib/importReport.ts
+++ b/src/lib/importReport.ts
@@ -41,6 +41,12 @@ export function describeFinding(f: ImportFinding): { title: string; detail: stri
       detail: f.command,
     };
   }
+  if (f.kind === 'replayRisk') {
+    return {
+      title: 'Printer setup command: runs on the printer when exported/printed',
+      detail: f.command,
+    };
+  }
   return {
     title: 'Skipped: command not recognised',
     detail: f.command,

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -5,12 +5,29 @@ import { parseZPL } from './zplParser';
 import type { LabelConfig } from '../types/LabelConfig';
 import type { GroupObject, LabelObject } from '../types/Group';
 import { defined, props } from '../test/helpers';
+import { NON_EMITTING_CONFIG_KEYS } from '../store/labelStore.internals';
 
 const BASE_LABEL: LabelConfig = {
   widthMm: 100,
   heightMm: 50,
   dpmm: 8,
 };
+
+describe('NON_EMITTING_CONFIG_KEYS tripwire', () => {
+  // A config key wrongly listed as non-emitting would skip the overlay drop and
+  // export stale config. Lock the membership and prove each member is invariant.
+  it('contains only safeAreaMm', () => {
+    expect([...NON_EMITTING_CONFIG_KEYS]).toEqual(['safeAreaMm']);
+  });
+
+  it('changing safeAreaMm does not change generated ZPL', () => {
+    const objs = [
+      { id: 'a', type: 'text', x: 10, y: 10, rotation: 0,
+        props: { content: 'Hi', fontHeight: 30, fontWidth: 0, rotation: 'N', reverse: false } },
+    ] as unknown as LabelObject[];
+    expect(generateZPL({ ...BASE_LABEL, safeAreaMm: 7 }, objs)).toBe(generateZPL(BASE_LABEL, objs));
+  });
+});
 
 describe('generateZPL — structure', () => {
   it('wraps output in ^XA and ^XZ', () => {

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -16,7 +16,8 @@ import { formatLabelMetaComment } from './zplLabelMeta';
 import type { ClockOffset, CustomFontMapping, LabelConfig } from '../types/LabelConfig';
 import type { ZplEmitContext } from '../types/ZplEmit';
 import type { Variable } from '../types/Variable';
-import { isGroup, walkObjects, type LabelObject, type Page } from '../types/Group';
+import { isGroup, walkObjects, type LabelObject, type LeafObject, type Page } from '../types/Group';
+import { isOverlayConsistent } from './zplOverlay/overlay';
 import { formatFontDownloadFromPath } from './customFonts';
 import type { ImageProps } from '../registry/image';
 import { formatStoragePath } from './storagePath';
@@ -24,6 +25,14 @@ import { formatStoragePath } from './storagePath';
 function formatDownloadObject(m: CustomFontMapping): string | undefined {
   if (!m.embedInZpl || !m.path || !m.previewFontName) return undefined;
   return formatFontDownloadFromPath(m.path, m.previewFontName);
+}
+
+/** Render a leaf to its field bytes, prefixed with its ^FX comment when set.
+ *  Shared by the model generator and the overlay regeneration path so the two
+ *  never drift on comment handling. */
+function emitFieldBody(obj: LeafObject, emitCtx: ZplEmitContext): string {
+  const zpl = getEntry(obj.type)?.toZPL(obj, emitCtx) ?? '';
+  return obj.comment ? `^FX${stripZplCommandChars(obj.comment)}\n${zpl}` : zpl;
 }
 
 function flattenObjects(objects: LabelObject[]): LabelObject[] {
@@ -41,7 +50,7 @@ function flattenObjects(objects: LabelObject[]): LabelObject[] {
 /** Plan `^FE` + header `^FN` declarations for inline-embed templates,
  *  plus the emit context. embedChar is only set when a safe char exists,
  *  which fdFieldFor uses as the "templates allowed" gate. */
-function planTemplateHeader(
+export function planTemplateHeader(
   shifted: LabelObject[],
   label: LabelConfig,
   variables: readonly Variable[],
@@ -144,13 +153,166 @@ function formatGraphicUpload(p: ImageProps): string | undefined {
   return `~DY${formatStoragePath(p.storedAs, false)},${format},G,${total},${bpr},${data}`;
 }
 
-/** Each page becomes its own ^XA..^XZ block (separate labels to the printer). */
+/** Each page becomes its own ^XA..^XZ block (separate labels to the printer).
+ *  A page imported with a source-patch overlay replays its original bytes
+ *  verbatim except for edited/added/removed objects; everything else
+ *  regenerates from the model. Any inconsistency falls back to regeneration. */
 export function generateMultiPageZPL(
   label: LabelConfig,
   pages: Page[],
   variables: readonly Variable[] = [],
 ): string {
-  return pages.map((p) => generateZPL(label, p.objects, variables)).join('\n');
+  let out = '';
+  for (const p of pages) {
+    let block: string;
+    try {
+      block = emitOverlayPage(label, p, variables);
+    } catch (err) {
+      // emitOverlayPage handles expected inconsistencies internally, so a throw
+      // here is an unexpected bug. Surface it (still degrading to regeneration)
+      // rather than silently disabling the overlay.
+      console.warn('emitOverlayPage failed, regenerating page from model', err);
+      block = generateZPL(label, p.objects, variables);
+    }
+    // An overlay page already carries the inter-block separator captured at
+    // import (the splitter folds it into the preceding block). Only insert a
+    // newline when the previous block didn't end with one (a fresh or
+    // fallback page), so multi-page round-trips stay byte-identical and stable.
+    if (out.length > 0 && !out.endsWith('\n')) out += '\n';
+    out += block;
+  }
+  return out;
+}
+
+/** Leaves that would actually export, honouring the `includeInExport=false`
+ *  cascade through groups (mirrors `emitLeaf`). */
+function exportableLeaves(objects: LabelObject[]): LeafObject[] {
+  const out: LeafObject[] = [];
+  const walk = (list: LabelObject[]): void => {
+    for (const o of list) {
+      if (o.includeInExport === false) continue;
+      if (isGroup(o)) walk(o.children);
+      else out.push(o);
+    }
+  };
+  walk(objects);
+  return out;
+}
+
+/** Emit one page from its overlay: verbatim segments for untouched objects,
+ *  in-place regeneration for dirty ones, appended fields for new ones, raw
+ *  segments (config/comments/unmodeled commands/whitespace) replayed as-is.
+ *  Falls back to full regeneration when the overlay is missing/inconsistent,
+ *  or when an edit exists in a block whose running state (^MU/prefix/^CI/^FE)
+ *  would re-interpret a regenerated field. */
+export function emitOverlayPage(
+  label: LabelConfig,
+  page: Page,
+  variables: readonly Variable[] = [],
+): string {
+  const overlay = page.overlay;
+  if (!overlay || !isOverlayConsistent(overlay)) {
+    return generateZPL(label, page.objects, variables);
+  }
+
+  const exportable = exportableLeaves(page.objects);
+  const exportableById = new Map(exportable.map((l) => [l.id, l]));
+  const segmentObjectOrder = overlay.segments.flatMap((s) =>
+    s.kind === 'object' ? [s.objectId] : [],
+  );
+  const segmentIds = new Set(segmentObjectOrder);
+
+  // Order guard: segments are pinned to source order, so a reorder/reparent
+  // (z-order, group, ungroup) that changes the relative order of segment-linked
+  // objects can't be expressed by per-segment patching. Detect it by comparing
+  // the live order of still-present linked objects against their segment order,
+  // and fall back to full regeneration (which emits in model order).
+  const liveLinkedOrder = exportable.filter((l) => segmentIds.has(l.id)).map((l) => l.id);
+  const segmentLiveOrder = segmentObjectOrder.filter((id) => exportableById.has(id));
+  if (liveLinkedOrder.some((id, i) => id !== segmentLiveOrder[i])) {
+    return generateZPL(label, page.objects, variables);
+  }
+  // New objects are appended after all segments, so they must sit at the model
+  // tail. If a segment-linked object follows a new one in model order, appending
+  // would reorder it; fall back to full regeneration (model order).
+  let sawNew = false;
+  for (const l of exportable) {
+    if (!segmentIds.has(l.id)) sawNew = true;
+    else if (sawNew) return generateZPL(label, page.objects, variables);
+  }
+
+  const dirtyLeaves = exportable.filter((l) => segmentIds.has(l.id) && l.dirty);
+  const newLeaves = exportable.filter((l) => !segmentIds.has(l.id));
+
+  // A verbatim 0-edit replay is always byte-safe; a regeneration in a
+  // non-regenSafe block is not, so fall back wholesale the moment an edit
+  // (dirty or new) exists there.
+  if ((dirtyLeaves.length > 0 || newLeaves.length > 0) && !overlay.regenSafe) {
+    return generateZPL(label, page.objects, variables);
+  }
+
+  const fx = overlay.frame?.homeX ?? 0;
+  const fy = overlay.frame?.homeY ?? 0;
+  const ft = overlay.frame?.top ?? 0;
+  // Regenerated objects must be home-relative so they compose with the raw
+  // ^LH/^LT that still execute on replay (no double-shift). One shared emit
+  // context so a picked ^FE/^FC covers dirty and new fields alike.
+  const dirtyShifted = shiftObjectsByHome(dirtyLeaves, fx, fy, ft);
+  const newShifted = shiftObjectsByHome(newLeaves, fx, fy, ft);
+  const { headerLines, emitCtx } = planTemplateHeader(
+    [...dirtyShifted, ...newShifted],
+    label,
+    variables,
+  );
+
+  // No ^A@->^A{alias} rewrite on the regen path: a regenerated direct-path ^A@
+  // is valid and order-independent, whereas aliasing would break when the
+  // block's ^CW sits after the field. Aliasing is a whole-document
+  // normalization that only the model generator needs.
+  const dirtyShiftedById = new Map(dirtyShifted.map((o) => [o.id, o]));
+
+  const out: string[] = [];
+  let headerEmitted = false;
+  const emitHeaderOnce = () => {
+    if (headerEmitted) return;
+    headerEmitted = true;
+    if (headerLines.length > 0) out.push(`${headerLines.join('\n')}\n`);
+  };
+
+  for (const seg of overlay.segments) {
+    if (seg.kind === 'raw' || seg.kind === 'config') {
+      out.push(seg.text);
+      continue;
+    }
+    // object segment
+    const live = exportableById.get(seg.objectId);
+    if (!live) continue; // deleted or hidden
+    if (!live.dirty) {
+      out.push(seg.text); // untouched -> verbatim
+      continue;
+    }
+    emitHeaderOnce(); // template/clock header precedes the first regenerated field
+    const shifted = dirtyShiftedById.get(seg.objectId);
+    if (shifted && !isGroup(shifted)) out.push(emitFieldBody(shifted, emitCtx));
+  }
+
+  let result = out.join('');
+
+  if (newShifted.length > 0) {
+    const appendLines: string[] = [];
+    if (!headerEmitted && headerLines.length > 0) appendLines.push(...headerLines);
+    for (const o of newShifted) if (!isGroup(o)) appendLines.push(emitFieldBody(o, emitCtx));
+    const block = appendLines.join('\n');
+    // New fields go inside the block, just before ^XZ. ZPL command letters are
+    // case-insensitive; check the common uppercase form first and only pay the
+    // full uppercase scan for a rare lowercase terminator on a large payload.
+    let idx = result.lastIndexOf('^XZ');
+    if (idx < 0) idx = result.toUpperCase().lastIndexOf('^XZ');
+    result =
+      idx >= 0 ? `${result.slice(0, idx)}${block}\n${result.slice(idx)}` : `${result}\n${block}`;
+  }
+
+  return result;
 }
 
 /** R: is volatile RAM, matches single-run batch scope. */
@@ -210,6 +372,28 @@ export function generateBatchZpl(
   return [templateStored, ...recallBlocks].join('\n');
 }
 
+/** Subtract label home/top from each object so emit matches the editor, the
+ *  inverse of the parser folding ^LH/^LT into absolute coords. Leaves whose
+ *  shifted origin goes negative are dropped (Zebra rejects negative ^FO and
+ *  clamping would relocate them silently). Identity when no shift applies. */
+function shiftObjectsByHome(
+  objects: LabelObject[],
+  homeX: number,
+  homeY: number,
+  top: number,
+): LabelObject[] {
+  if (homeX === 0 && homeY === 0 && top === 0) return objects;
+  const shiftOrDrop = (obj: LabelObject): LabelObject[] => {
+    if (isGroup(obj)) {
+      return [{ ...obj, children: obj.children.flatMap(shiftOrDrop) }];
+    }
+    const x = obj.x - homeX;
+    const y = obj.y - homeY - top;
+    return x < 0 || y < 0 ? [] : [{ ...obj, x, y }];
+  };
+  return objects.flatMap(shiftOrDrop);
+}
+
 /** Template header lines plus the per-object field bodies, shared by the full
  *  generator and selection copy so the two never drift. Applies the label
  *  home/top shift (dropping negative origins) and the template/clock emit
@@ -222,31 +406,17 @@ export function planFieldEmission(
   const homeX = label.labelHomeX ?? 0;
   const homeY = label.labelHomeY ?? 0;
   const top = label.labelTop ?? 0;
-  // Drop leaves whose shifted origin is negative; Zebra rejects negative
-  // ^FO and clamping would relocate them silently.
-  const shiftOrDrop = (obj: LabelObject): LabelObject[] => {
-    if (isGroup(obj)) {
-      return [{ ...obj, children: obj.children.flatMap(shiftOrDrop) }];
-    }
-    const x = obj.x - homeX;
-    const y = obj.y - homeY - top;
-    return x < 0 || y < 0 ? [] : [{ ...obj, x, y }];
-  };
-  const shifted =
-    homeX !== 0 || homeY !== 0 || top !== 0
-      ? objects.flatMap(shiftOrDrop)
-      : objects;
+  const shifted = shiftObjectsByHome(objects, homeX, homeY, top);
 
   const { headerLines, emitCtx } = planTemplateHeader(shifted, label, variables);
 
   // Groups are structural; includeInExport=false cascades to the subtree.
+  // Byte-identical round-trip lives in the overlay path (emitOverlayPage); this
+  // model generator always regenerates.
   const emitLeaf = (obj: LabelObject): string[] => {
     if (obj.includeInExport === false) return [];
     if (isGroup(obj)) return obj.children.flatMap(emitLeaf);
-    const zpl = getEntry(obj.type)?.toZPL(obj, emitCtx) ?? '';
-    return obj.comment
-      ? [`^FX${stripZplCommandChars(obj.comment)}\n${zpl}`]
-      : [zpl];
+    return [emitFieldBody(obj, emitCtx)];
   };
   return { headerLines, bodyLines: shifted.flatMap(emitLeaf) };
 }
@@ -381,20 +551,24 @@ export function generateZPL(
 
   lines.push('^XZ');
 
-  // Rewrite ^A@...PATH -> ^A{alias} for paths the user registered via ^CW.
+  return aliasFontPaths(lines.join('\n'), label);
+}
+
+/** Rewrite `^A@…PATH` to `^A{alias}` for paths the user registered via `^CW`.
+ *  Used only by the full model generator over its whole output; the overlay
+ *  export deliberately does NOT alias (a regenerated direct-path ^A@ is valid
+ *  and order-independent, avoiding a ^CW forward-reference). */
+function aliasFontPaths(text: string, label: LabelConfig): string {
   const aliasByPath = new Map<string, string>();
   for (const m of label.customFonts ?? []) {
     if (m.alias && m.path) aliasByPath.set(m.path, m.alias);
   }
-  let output = lines.join('\n');
-  if (aliasByPath.size > 0) {
-    output = output.replace(
-      /\^A@([NIRB]),(\d+),(\d+),([A-Z]:[^^\n]+?)(?=\^|\n|$)/g,
-      (full, rot, h, w, path) => {
-        const alias = aliasByPath.get(path);
-        return alias ? `^A${alias}${rot},${h},${w}` : full;
-      },
-    );
-  }
-  return output;
+  if (aliasByPath.size === 0) return text;
+  return text.replace(
+    /\^A@([NIRB]),(\d+),(\d+),([A-Z]:[^^\n]+?)(?=\^|\n|$)/g,
+    (full, rot, h, w, path) => {
+      const alias = aliasByPath.get(path);
+      return alias ? `^A${alias}${rot},${h},${w}` : full;
+    },
+  );
 }

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -304,10 +304,11 @@ export function emitOverlayPage(
     for (const o of newShifted) if (!isGroup(o)) appendLines.push(emitFieldBody(o, emitCtx));
     const block = appendLines.join('\n');
     // New fields go inside the block, just before ^XZ. ZPL command letters are
-    // case-insensitive; check the common uppercase form first and only pay the
-    // full uppercase scan for a rare lowercase terminator on a large payload.
+    // case-insensitive; check the common uppercase form first, then a regex on
+    // the original for a rare lowercase terminator (matching the original keeps
+    // slice indices accurate, unlike toUpperCase which can grow e.g. ß into SS).
     let idx = result.lastIndexOf('^XZ');
-    if (idx < 0) idx = result.toUpperCase().lastIndexOf('^XZ');
+    if (idx < 0) idx = [...result.matchAll(/\^[xX][zZ]/g)].pop()?.index ?? -1;
     result =
       idx >= 0 ? `${result.slice(0, idx)}${block}\n${result.slice(idx)}` : `${result}\n${block}`;
   }

--- a/src/lib/zplImportService.test.ts
+++ b/src/lib/zplImportService.test.ts
@@ -1,7 +1,40 @@
 import { describe, it, expect } from 'vitest';
 import { importZplText } from './zplImportService';
 import { generateSetupScript } from './zplSetupScript';
+import { describeFinding } from './importReport';
 import type { PrinterProfile } from '../types/PrinterProfile';
+
+describe('importZplText - replay-risk findings', () => {
+  it('flags printer setup commands (run on the printer when exported/printed)', () => {
+    const r = importZplText('^XA^KNFOO^FO10,10^A0N,30,30^FDx^FS^XZ', 8);
+    expect(r.report.replayRisk).toContain('^KN');
+    const finding = r.report.findings.find((f) => f.kind === 'replayRisk');
+    expect(finding).toBeDefined();
+    expect(describeFinding(finding!).detail).toBe('^KN');
+  });
+
+  it('does not flag a label without setup commands', () => {
+    const r = importZplText('^XA^FO10,10^A0N,30,30^FDx^FS^XZ', 8);
+    expect(r.report.replayRisk).toEqual([]);
+    expect(r.report.findings.some((f) => f.kind === 'replayRisk')).toBe(false);
+  });
+
+  it('dedupes a setup command repeated across pages', () => {
+    const r = importZplText('^XA^STsome^XZ\n^XA^STmore^XZ', 8);
+    expect(r.report.replayRisk).toEqual(['^ST']);
+  });
+
+  it('flags device-action commands (calibration/reset) that were silently noop-ed', () => {
+    const r = importZplText('^XA~JC~JR^FO10,10^A0N,30,30^FDx^FS^XZ', 8);
+    expect(r.report.replayRisk).toContain('^JC');
+    expect(r.report.replayRisk).toContain('^JR');
+  });
+
+  it('does not flag design noops (^FV/^FM) or visible label settings (^MD/^PR)', () => {
+    const r = importZplText('^XA^MD8^PR4^FV5^FO10,10^A0N,30,30^FDx^FS^XZ', 8);
+    expect(r.report.replayRisk).toEqual([]);
+  });
+});
 
 describe('importZplText - single label', () => {
   it('returns one page with the parsed objects', () => {
@@ -9,6 +42,18 @@ describe('importZplText - single label', () => {
     const result = importZplText(zpl, 8);
     expect(result.pages).toHaveLength(1);
     expect(result.pages[0]?.objects).toHaveLength(1);
+  });
+
+  it('attaches a consistent source-patch overlay to the page', () => {
+    const zpl = '^XA^FO10,20^A0N,30,0^FDHello^FS^XZ';
+    const result = importZplText(zpl, 8);
+    const overlay = result.pages[0]?.overlay;
+    expect(overlay).toBeDefined();
+    // Segments rebuild the full block byte-for-byte.
+    expect(overlay!.segments.map((s) => s.text).join('')).toBe(zpl);
+    // The single field links to the one parsed object.
+    const objId = result.pages[0]!.objects[0]!.id;
+    expect(overlay!.segments.some((s) => s.kind === 'object' && s.objectId === objId)).toBe(true);
   });
 
 });

--- a/src/lib/zplImportService.ts
+++ b/src/lib/zplImportService.ts
@@ -3,7 +3,7 @@ import { pruneUndefined } from "./pruneUndefined";
 import { stripDrivePrefix } from "./customFonts";
 import type { CustomFontMapping, LabelConfig } from "../types/LabelConfig";
 import type { PrinterProfile } from "../types/PrinterProfile";
-import type { LabelObject } from "../types/Group";
+import type { LabelObject, Page } from "../types/Group";
 import { uniqueVariableName, type Variable } from "../types/Variable";
 
 export interface ZplImportResult {
@@ -14,7 +14,7 @@ export interface ZplImportResult {
    *  NOT auto-apply these so a shared `.zpl` can't silently
    *  reconfigure the user's printer. */
   printerProfile: Partial<PrinterProfile>;
-  pages: { objects: LabelObject[] }[];
+  pages: Page[];
   variables: Variable[];
   report: ImportReport;
 }
@@ -56,7 +56,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
       printerProfile: {},
       pages: [],
       variables: [],
-      report: { findings: [], partial: [], browserLimit: [], unknown: [] },
+      report: { findings: [], partial: [], browserLimit: [], unknown: [], replayRisk: [] },
     };
   }
 
@@ -81,7 +81,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
   // the last-seen state (mirrors what the printer would actually end
   // up with after executing the stream).
   const printerProfile: Partial<PrinterProfile> = {};
-  const pages: { objects: LabelObject[] }[] = [];
+  const pages: Page[] = [];
   const findings: ImportFinding[] = [];
   // Variables are document-level, but the parser reconstructs them per
   // block. Merge across blocks by fnNumber (same slot used on multiple
@@ -96,7 +96,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
   // labelConfig replaces all later labelConfigs.
   const aggregatedCustomFonts = new Map<string, CustomFontMapping>();
   parseUnits.forEach((block, i) => {
-    const result = parseZPL(block, dpmm);
+    const result = parseZPL(block, dpmm, { captureOverlay: true });
     uploadedFontPaths.push(...result.uploadedFontPaths);
     for (const m of result.labelConfig.customFonts ?? []) {
       if (m.path) designFontPaths.add(normPath(m.path));
@@ -126,7 +126,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
       rewireBindings(result.objects, idRemap);
     }
     // A preamble-only unit (no ^XA) carries fonts/profile but no page.
-    if (hasLabelBlocks) pages.push({ objects: result.objects });
+    if (hasLabelBlocks) pages.push({ objects: result.objects, overlay: result.overlay });
     if (i === 0) {
       labelConfig = result.labelConfig;
     }
@@ -184,6 +184,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
     partial: dedupBy('partial'),
     browserLimit: dedupBy('browserLimit'),
     unknown: dedupBy('unknown'),
+    replayRisk: dedupBy('replayRisk'),
   };
 
   return { labelConfig, printerProfile, pages, variables, report };
@@ -199,6 +200,10 @@ function rewireBindings(
 ): void {
   for (const obj of objects) {
     if (obj.variableId && idRemap.has(obj.variableId)) {
+      // Cross-block merge is by fnNumber, so the remapped variable keeps the
+      // same ^FN number: the captured bytes stay valid and must NOT be marked
+      // dirty, or an unedited later page would lose its original ^FD default on
+      // export (byte-identity break). The remap only repoints the model binding.
       obj.variableId = idRemap.get(obj.variableId);
     }
     if (obj.type === "group" && "children" in obj) {

--- a/src/lib/zplOverlay/emitOverlayPage.test.ts
+++ b/src/lib/zplOverlay/emitOverlayPage.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { importZplText } from "../zplImportService";
+import { emitOverlayPage, generateMultiPageZPL } from "../zplGenerator";
+import type { LabelConfig } from "../../types/LabelConfig";
+import type { LabelObject, Page } from "../../types/Group";
+
+const LABEL: LabelConfig = { widthMm: 100, heightMm: 60, dpmm: 8 };
+
+/** Import one block and return its single page (with overlay attached). */
+function importedPage(zpl: string): Page {
+  const r = importZplText(zpl, LABEL.dpmm);
+  expect(r.pages).toHaveLength(1);
+  return r.pages[0]!;
+}
+
+/** Mark a leaf edited the way applyObjectChanges would (emit-affecting change). */
+function edit(page: Page, predicate: (o: LabelObject) => boolean, patch: Partial<LabelObject>): LabelObject {
+  const leaf = page.objects.find(predicate)!;
+  Object.assign(leaf, patch, { dirty: true });
+  return leaf;
+}
+
+describe("emitOverlayPage", () => {
+  it("replays an untouched block byte-identically", () => {
+    const src = "^XA\n^PW800\n^LL400\n^FXnote\n^FO50,50^A0N,30,30^FDHello^FS\n^FO50,120^GB200,80,3^FS\n^XZ";
+    const page = importedPage(src);
+    expect(emitOverlayPage(LABEL, page)).toBe(src);
+  });
+
+  it("regenerates only the edited field, neighbours stay verbatim", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHello^FS\n^FO50,120^GB200,80,3^FS\n^XZ";
+    const page = importedPage(src);
+    edit(page, (o) => o.type === "text", { x: 99 });
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).not.toContain("^FO50,50^A0N,30,30^FDHello^FS");
+    expect(out).toContain("^FO99,");
+    expect(out).toContain("^FO50,120^GB200,80,3^FS"); // box untouched
+  });
+
+  it("drops a deleted object's segment, leaving neighbours intact", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHello^FS\n^FO50,120^GB200,80,3^FS\n^XZ";
+    const page = importedPage(src);
+    page.objects = page.objects.filter((o) => o.type !== "text");
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).not.toContain("^FDHello");
+    expect(out).toContain("^FO50,120^GB200,80,3^FS");
+    expect(out.endsWith("^XZ")).toBe(true);
+  });
+
+  it("appends a new object before ^XZ, leaving existing segments verbatim", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHello^FS\n^XZ";
+    const page = importedPage(src);
+    const added: LabelObject = {
+      id: "new-1",
+      type: "text",
+      x: 10,
+      y: 200,
+      rotation: 0,
+      props: { content: "NEW", fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as unknown as LabelObject;
+    page.objects = [...page.objects, added];
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).toContain("^FO50,50^A0N,30,30^FDHello^FS"); // original verbatim
+    expect(out).toContain("^FDNEW");
+    expect(out.indexOf("^FDNEW")).toBeLessThan(out.lastIndexOf("^XZ"));
+  });
+
+  it("appends a new object before a lowercase ^xz terminator", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHi^FS\n^xz";
+    const page = importedPage(src);
+    const added: LabelObject = {
+      id: "new-2",
+      type: "text",
+      x: 10,
+      y: 200,
+      rotation: 0,
+      props: { content: "NEW", fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as unknown as LabelObject;
+    page.objects = [...page.objects, added];
+    const out = emitOverlayPage(LABEL, page);
+    // The new field must land inside the block, before the lowercase terminator.
+    expect(out.indexOf("^FDNEW")).toBeLessThan(out.toUpperCase().lastIndexOf("^XZ"));
+  });
+
+  it("emits a dirty field home-relative under ^LH (no double-shift)", () => {
+    const src = "^XA^LH50,20^FO10,10^A0N,30,30^FDx^FS^XZ";
+    const page = importedPage(src);
+    expect(page.overlay?.frame).toEqual({ homeX: 50, homeY: 20, top: 0 });
+    // Model coords are absolute (home folded); editing y forces regen.
+    const text = page.objects.find((o) => o.type === "text")!;
+    Object.assign(text, { y: text.y + 5, dirty: true });
+    const out = emitOverlayPage(LABEL, page);
+    // The regenerated ^FO stays home-relative (x back near 10, not 60).
+    expect(out).toContain("^LH50,20"); // raw ^LH preserved
+    expect(out).toMatch(/\^FO10,/);
+  });
+
+  it("skips a hidden object segment (includeInExport=false)", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHello^FS\n^FO50,120^GB200,80,3^FS\n^XZ";
+    const page = importedPage(src);
+    edit(page, (o) => o.type === "text", { includeInExport: false });
+    // includeInExport is not emit-affecting, so undo the dirty the helper set.
+    page.objects.find((o) => o.type === "text")!.dirty = undefined;
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).not.toContain("^FDHello");
+    expect(out).toContain("^FO50,120^GB200,80,3^FS");
+  });
+
+  it("regenerates a direct-path ^A@ font without aliasing (no ^CW forward-ref)", () => {
+    // ^CW declared AFTER the field: aliasing the regen to ^AQ would reference
+    // the alias before its ^CW defines it. The overlay keeps the direct path.
+    const src = "^XA\n^FO20,20^A@N,30,30,E:MYFONT.TTF^FDhi^FS\n^CWQ,E:MYFONT.TTF\n^XZ";
+    const r = importZplText(src, LABEL.dpmm);
+    const page = r.pages[0]!;
+    const label = { ...LABEL, ...r.labelConfig }; // carries the ^CWQ alias
+    const text = page.objects.find((o) => o.type === "text")!;
+    Object.assign(text, { x: 40, dirty: true });
+    const out = emitOverlayPage(label, page);
+    expect(out).toContain("^A@N,30,30,E:MYFONT.TTF"); // direct path kept
+    expect(out).not.toContain("^AQ"); // not aliased (would be a forward reference)
+  });
+
+  it("falls back to full regeneration when the overlay is a stale version", () => {
+    const page = importedPage("^XA^FO10,10^A0N,30,30^FDx^FS^XZ");
+    page.overlay!.v = 1; // older schema version, no longer trusted
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).toContain("^XA");
+    expect(out).toContain("^FDx");
+  });
+
+  it("falls back when an edit lands in a non-regenSafe (^MU) block", () => {
+    const page = importedPage("^XA^MUi^FO10,10^A0N,30,30^FDx^FS^MUd^XZ");
+    expect(page.overlay?.regenSafe).toBe(false);
+    edit(page, (o) => o.type === "text", { x: 99 });
+    const out = emitOverlayPage(LABEL, page);
+    // Full regeneration path: model-canonical block, not the raw ^MU replay.
+    expect(out).not.toContain("^MUi");
+  });
+
+  it("falls back when a new object is interleaved among imported ones", () => {
+    const src = "^XA\n^FO10,10^A0N,30,30^FDaa^FS\n^FO10,60^A0N,30,30^FDbb^FS\n^XZ";
+    const page = importedPage(src);
+    const added: LabelObject = {
+      id: "mid",
+      type: "text",
+      x: 10,
+      y: 35,
+      rotation: 0,
+      props: { content: "MID", fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as unknown as LabelObject;
+    // Model order: aa, MID(new), bb. The new object sits BETWEEN imported ones,
+    // so appending at ^XZ would misplace it -> must fall back to model order.
+    page.objects = [page.objects[0]!, added, page.objects[1]!];
+    const out = emitOverlayPage(LABEL, page);
+    expect(out.indexOf("FDaa")).toBeLessThan(out.indexOf("MID"));
+    expect(out.indexOf("MID")).toBeLessThan(out.indexOf("FDbb"));
+  });
+
+  it("falls back to model order when objects are reordered", () => {
+    const src = "^XA\n^FO10,10^A0N,30,30^FDfirst^FS\n^FO10,60^A0N,30,30^FDsecond^FS\n^XZ";
+    const page = importedPage(src);
+    // Reverse z-order; the overlay pins source order, so this must fall back.
+    page.objects = [...page.objects].reverse();
+    const out = emitOverlayPage(LABEL, page);
+    expect(out.indexOf("second")).toBeLessThan(out.indexOf("first"));
+  });
+
+  it("works through generateMultiPageZPL across multiple pages", () => {
+    const p1 = "^XA\n^FO10,10^A0N,30,30^FDone^FS\n^XZ";
+    const p2 = "^XA\n^FO10,10^A0N,30,30^FDtwo^FS\n^XZ";
+    const r = importZplText(`${p1}\n${p2}`, LABEL.dpmm);
+    // Edit page 2 only.
+    Object.assign(r.pages[1]!.objects.find((o) => o.type === "text")!, { x: 77, dirty: true });
+    const out = generateMultiPageZPL(LABEL, r.pages, r.variables);
+    expect(out).toContain("^FO10,10^A0N,30,30^FDone^FS"); // page 1 verbatim
+    expect(out).toContain("^FO77,"); // page 2 patched
+    expect(out).not.toContain("^FO10,10^A0N,30,30^FDtwo^FS");
+  });
+});

--- a/src/lib/zplOverlay/emitOverlayPage.test.ts
+++ b/src/lib/zplOverlay/emitOverlayPage.test.ts
@@ -82,6 +82,26 @@ describe("emitOverlayPage", () => {
     expect(out.indexOf("^FDNEW")).toBeLessThan(out.toUpperCase().lastIndexOf("^XZ"));
   });
 
+  it("keeps a lowercase ^xz terminator intact when content has case-growing Unicode", () => {
+    // 'ß'.toUpperCase() is 'SS' (1->2 chars): a toUpperCase-based terminator
+    // search would shift the slice index and corrupt the ^xz on append.
+    const src = "^XA\n^FO50,50^A0N,30,30^FDStraße^FS\n^xz";
+    const page = importedPage(src);
+    const added: LabelObject = {
+      id: "new-u",
+      type: "text",
+      x: 10,
+      y: 200,
+      rotation: 0,
+      props: { content: "NEW", fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as unknown as LabelObject;
+    page.objects = [...page.objects, added];
+    const out = emitOverlayPage(LABEL, page);
+    expect(out).toContain("^FDStraße^FS"); // original verbatim, not mangled
+    expect(out.trimEnd().endsWith("^xz")).toBe(true); // terminator intact
+    expect(out.indexOf("^FDNEW")).toBeLessThan(out.lastIndexOf("^xz"));
+  });
+
   it("emits a dirty field home-relative under ^LH (no double-shift)", () => {
     const src = "^XA^LH50,20^FO10,10^A0N,30,30^FDx^FS^XZ";
     const page = importedPage(src);

--- a/src/lib/zplOverlay/overlay.test.ts
+++ b/src/lib/zplOverlay/overlay.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildBlockOverlay, overlayText, type LinkedSpan } from "./overlay";
+
+describe("buildBlockOverlay", () => {
+  const src = "^XA\n^FO10,10^FDa^FS\n^FO10,50^FDb^FS\n^XZ";
+  const f1s = src.indexOf("^FO10,10");
+  const f1e = src.indexOf("^FS") + 3;
+  const f2s = src.indexOf("^FO10,50");
+  const f2e = src.indexOf("^FS", f2s) + 3;
+  const spans: LinkedSpan[] = [
+    { start: f1s, end: f1e, link: { kind: "object", objectId: "a" } },
+    { start: f2s, end: f2e, link: { kind: "object", objectId: "b" } },
+  ];
+
+  const opts = { regenSafe: true } as const;
+
+  it("fills gaps with raw and preserves the concat invariant", () => {
+    const o = buildBlockOverlay(src, spans, opts);
+    expect(overlayText(o)).toBe(src);
+    expect(o.segments.map((s) => s.kind)).toEqual(["raw", "object", "raw", "object", "raw"]);
+    expect(o.segments[1]).toMatchObject({ kind: "object", objectId: "a", text: "^FO10,10^FDa^FS" });
+  });
+
+  it("sorts unordered spans", () => {
+    const o = buildBlockOverlay(src, [spans[1]!, spans[0]!], opts);
+    expect(overlayText(o)).toBe(src);
+  });
+
+  it("carries regenSafe and an optional frame", () => {
+    const o = buildBlockOverlay(src, spans, { regenSafe: false, frame: { homeX: 50, homeY: 10, top: 5 } });
+    expect(o.regenSafe).toBe(false);
+    expect(o.frame).toEqual({ homeX: 50, homeY: 10, top: 5 });
+    const o2 = buildBlockOverlay(src, spans, opts);
+    expect(o2.regenSafe).toBe(true);
+    expect(o2.frame).toBeUndefined();
+  });
+
+  it("links a config span and keeps leading/trailing raw", () => {
+    const s2 = "^XA^PW800^FO0,0^FDx^FS^XZ";
+    const cs = s2.indexOf("^PW800");
+    const fs = s2.indexOf("^FO0,0");
+    const o = buildBlockOverlay(s2, [
+      { start: cs, end: cs + "^PW800".length, link: { kind: "config", field: "widthMm" } },
+      { start: fs, end: s2.indexOf("^FS") + 3, link: { kind: "object", objectId: "x" } },
+    ], opts);
+    expect(overlayText(o)).toBe(s2);
+    expect(o.segments.find((s) => s.kind === "config")).toMatchObject({ field: "widthMm", text: "^PW800" });
+  });
+
+  it("throws on overlapping spans", () => {
+    expect(() =>
+      buildBlockOverlay("^XA^FDa^FS^XZ", [
+        { start: 0, end: 6, link: { kind: "object", objectId: "a" } },
+        { start: 3, end: 9, link: { kind: "object", objectId: "b" } },
+      ], opts),
+    ).toThrow();
+  });
+});

--- a/src/lib/zplOverlay/overlay.ts
+++ b/src/lib/zplOverlay/overlay.ts
@@ -1,0 +1,115 @@
+// Round-trip overlay: one ^XA…^XZ block sliced into ordered segments whose
+// texts concatenate back to the original source. On export, segments re-emit
+// verbatim unless their linked model entity was edited/removed, so everything
+// untouched (fields, config, comments, unmodeled commands, whitespace, order)
+// stays byte-identical. The source is not stored: it equals the segment texts
+// joined (see overlayText), so keeping it would duplicate every byte (including
+// large ^GF/~DY graphic payloads) in persistence and every undo snapshot.
+
+import { z } from "zod";
+
+/** Key identifying a labelConfig/printerProfile field a config command sets.
+ *  Refined to a union as config linkage lands (later stage); string for now. */
+export type ConfigFieldKey = string;
+
+export type OverlaySegment =
+  | { kind: "raw"; text: string }
+  | { kind: "object"; objectId: string; text: string }
+  | { kind: "config"; field: ConfigFieldKey; text: string };
+
+/** Folded label-home/top (^LH/^LT) of the block. Regenerated objects must be
+ *  emitted relative to this, because the raw ^LH/^LT commands still execute on
+ *  replay and would otherwise double-shift a model-absolute coordinate. */
+export interface OverlayFrame {
+  homeX: number;
+  homeY: number;
+  top: number;
+}
+
+export interface BlockOverlay {
+  /** Ordered segments covering the whole block; their texts joined reproduce
+   *  the original source byte-for-byte (incl. ^XA/^XZ and whitespace). */
+  segments: OverlaySegment[];
+  v: number;
+  /** When false, a dirty/new object in this block cannot be regenerated in
+   *  place because a surviving raw command would re-interpret its bytes
+   *  (^MU unit scale, non-default ^CC/^CT/^CD prefix, non-UTF-8 ^CI with ^FH,
+   *  non-default ^FE embed). Export then falls back to full regeneration the
+   *  moment any edit exists; a zero-edit verbatim replay stays safe regardless. */
+  regenSafe: boolean;
+  /** Present only when ^LH/^LT moved the origin; absent means no shift. */
+  frame?: OverlayFrame;
+}
+
+/** Overlay schema version; bump when segmentation changes so a stale persisted
+ *  overlay can be detected and rebuilt instead of mis-replayed. */
+export const OVERLAY_VERSION = 3;
+
+/** A model-linked source span `[start, end)` within a block. */
+export interface LinkedSpan {
+  start: number;
+  end: number;
+  link: { kind: "object"; objectId: string } | { kind: "config"; field: ConfigFieldKey };
+}
+
+/** Slice `source` into segments: each linked span becomes an object/config
+ *  segment and the gaps between them raw segments. Spans are sorted here; they
+ *  must be in-bounds and non-overlapping. `regenSafe`/`frame` describe the
+ *  block's running state for the export-time regeneration path. */
+export function buildBlockOverlay(
+  source: string,
+  spans: readonly LinkedSpan[],
+  opts: { regenSafe: boolean; frame?: OverlayFrame },
+): BlockOverlay {
+  const sorted = [...spans].sort((a, b) => a.start - b.start);
+  const segments: OverlaySegment[] = [];
+  let cursor = 0;
+  for (const span of sorted) {
+    if (span.start < 0 || span.end > source.length || span.end < span.start)
+      throw new Error(`overlay span out of bounds [${span.start},${span.end})`);
+    if (span.start < cursor) throw new Error(`overlapping overlay span at ${span.start}`);
+    if (span.start > cursor) segments.push({ kind: "raw", text: source.slice(cursor, span.start) });
+    const text = source.slice(span.start, span.end);
+    segments.push(
+      span.link.kind === "object"
+        ? { kind: "object", objectId: span.link.objectId, text }
+        : { kind: "config", field: span.link.field, text },
+    );
+    cursor = span.end;
+  }
+  if (cursor < source.length) segments.push({ kind: "raw", text: source.slice(cursor) });
+  const overlay: BlockOverlay = { segments, v: OVERLAY_VERSION, regenSafe: opts.regenSafe };
+  if (opts.frame) overlay.frame = opts.frame;
+  return overlay;
+}
+
+/** The block source, reconstructed by concatenating segment texts. */
+export function overlayText(overlay: BlockOverlay): string {
+  return overlay.segments.map((s) => s.text).join("");
+}
+
+/** True when the overlay's segmentation matches the current schema. A persisted
+ *  overlay from an older version is rejected (consumers fall back to model
+ *  regeneration) since its segment shape may no longer replay correctly. */
+export function isOverlayConsistent(overlay: BlockOverlay): boolean {
+  return overlay.v === OVERLAY_VERSION;
+}
+
+const overlaySegmentSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("raw"), text: z.string() }),
+  z.object({ kind: z.literal("object"), objectId: z.string(), text: z.string() }),
+  z.object({ kind: z.literal("config"), field: z.string(), text: z.string() }),
+]);
+
+/** Validates a persisted overlay. A stale-version or malformed value is rejected
+ *  so it drops to regeneration instead of replaying mis-segmented bytes. */
+export const blockOverlaySchema = z
+  .object({
+    segments: z.array(overlaySegmentSchema),
+    v: z.number(),
+    regenSafe: z.boolean(),
+    frame: z
+      .object({ homeX: z.number(), homeY: z.number(), top: z.number() })
+      .optional(),
+  })
+  .refine(isOverlayConsistent);

--- a/src/lib/zplOverlay/overlayCapture.test.ts
+++ b/src/lib/zplOverlay/overlayCapture.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { parseZPL } from "../zplParser";
+import { generateZPL } from "../zplGenerator";
+import { overlayText, type BlockOverlay } from "./overlay";
+
+/** Parse with overlay capture and assert the load-bearing invariant:
+ *  segment texts always concatenate back to the source. */
+function captured(zpl: string): BlockOverlay {
+  const { overlay } = parseZPL(zpl, 8, { captureOverlay: true });
+  expect(overlay, "expected an overlay to be captured").toBeDefined();
+  expect(overlayText(overlay!)).toBe(zpl);
+  return overlay!;
+}
+
+/** Segment linked to the object at `objectId`, or undefined. */
+function objSeg(o: BlockOverlay, objectId: string) {
+  return o.segments.find((s) => s.kind === "object" && s.objectId === objectId);
+}
+
+describe("parseZPL overlay capture", () => {
+  it("links a clean single text field, gaps stay raw", () => {
+    const zpl = "^XA\n^FO10,10^A0N,30,30^FDHello^FS\n^XZ";
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    expect(objects).toHaveLength(1);
+    const seg = objSeg(overlay!, objects[0]!.id);
+    expect(seg?.text).toBe("^FO10,10^A0N,30,30^FDHello^FS");
+    // Leading and trailing raw segments wrap the field.
+    expect(overlay!.segments[0]).toMatchObject({ kind: "raw" });
+    expect(overlay!.segments.at(-1)).toMatchObject({ kind: "raw" });
+  });
+
+  it("links a barcode field with inline ^BY", () => {
+    const zpl = "^XA^FO20,20^BY2^BCN,100,Y,N,N^FD12345^FS^XZ";
+    const o = captured(zpl);
+    const objSegs = o.segments.filter((s) => s.kind === "object");
+    expect(objSegs).toHaveLength(1);
+    expect(objSegs[0]!.text).toBe("^FO20,20^BY2^BCN,100,Y,N,N^FD12345^FS");
+  });
+
+  it("links a ^GB box field (object pushed mid-field)", () => {
+    const zpl = "^XA^FO5,5^GB100,50,3^FS^XZ";
+    const o = captured(zpl);
+    const objSegs = o.segments.filter((s) => s.kind === "object");
+    expect(objSegs).toHaveLength(1);
+    expect(objSegs[0]!.text).toBe("^FO5,5^GB100,50,3^FS");
+  });
+
+  it("links a ^GD diagonal line field", () => {
+    const zpl = "^XA^FO5,5^GD100,50,3,B,L^FS^XZ";
+    const o = captured(zpl);
+    expect(o.segments.filter((s) => s.kind === "object")).toHaveLength(1);
+  });
+
+  it("links two consecutive fields independently", () => {
+    const zpl = "^XA\n^FO10,10^A0N,30,30^FDa^FS\n^FO10,60^A0N,30,30^FDb^FS\n^XZ";
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    expect(objSeg(overlay!, objects[0]!.id)?.text).toBe("^FO10,10^A0N,30,30^FDa^FS");
+    expect(objSeg(overlay!, objects[1]!.id)?.text).toBe("^FO10,60^A0N,30,30^FDb^FS");
+  });
+
+  it("links a deferred reverse-bg box that commits standalone at ^XZ", () => {
+    // Filled black ^GB with no ^FR is stashed; nothing follows to collapse it,
+    // so it commits as a normal box at ^XZ. Its span must still link.
+    const zpl = "^XA^FO5,5^GB80,80,80,B^FS^XZ";
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    expect(objects).toHaveLength(1);
+    expect(objSeg(overlay!, objects[0]!.id)?.text).toBe("^FO5,5^GB80,80,80,B^FS");
+  });
+
+  it("links a reverse-collapse (^GB + ^FR text) into one merged span", () => {
+    // Use the generator so the ^GB bbox is guaranteed to match the text ink and
+    // the parser actually collapses the pair into one reverse-text object.
+    const reverseText = [
+      { id: "r", type: "text", x: 50, y: 50, rotation: 0,
+        props: { content: "Hi", fontHeight: 30, fontWidth: 0, rotation: "N", reverse: true } },
+    ] as unknown as Parameters<typeof generateZPL>[1];
+    const zpl = generateZPL({ widthMm: 50, heightMm: 30, dpmm: 8 }, reverseText);
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    // Collapse yields a single reverse-text object spanning the ^GB and ^FR fields.
+    expect(objects).toHaveLength(1);
+    const seg = objSeg(overlay!, objects[0]!.id);
+    expect(seg?.text).toContain("^GB");
+    expect(seg?.text).toContain("^FR^FD");
+  });
+
+  it("links the standalone box and the following field when bg does not collapse", () => {
+    // Reverse-bg followed by a non-matching text field: the box commits
+    // standalone during the text flush; both objects must link.
+    const zpl =
+      "^XA^FO5,5^GB200,200,200,B^FS\n^FO300,300^A0N,30,30^FDx^FS^XZ";
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    expect(objects).toHaveLength(2);
+    expect(objSeg(overlay!, objects[0]!.id)?.text).toBe("^FO5,5^GB200,200,200,B^FS");
+    expect(objSeg(overlay!, objects[1]!.id)?.text).toBe("^FO300,300^A0N,30,30^FDx^FS");
+  });
+
+  it("does not link a bare ^FN variable declaration, keeps it raw", () => {
+    const zpl = "^XA^FN1^FDdefault^FS^FO10,10^A0N,30,30^FDx^FS^XZ";
+    const { overlay, objects } = parseZPL(zpl, 8, { captureOverlay: true });
+    expect(overlay).toBeDefined();
+    expect(overlayText(overlay!)).toBe(zpl);
+    // The declaration produces a Variable but no object; the real field links.
+    expect(objects).toHaveLength(1);
+    expect(objSeg(overlay!, objects[0]!.id)).toBeDefined();
+    const raw = overlay!.segments.filter((s) => s.kind === "raw").map((s) => s.text).join("");
+    expect(raw).toContain("^FN1^FDdefault^FS");
+  });
+
+  it("marks a plain block regenSafe with no frame", () => {
+    const o = captured("^XA^FO10,10^A0N,30,30^FDx^FS^XZ");
+    expect(o.regenSafe).toBe(true);
+    expect(o.frame).toBeUndefined();
+  });
+
+  it("flags a ^MU block as not regenSafe (raw ^MU would rescale a regen)", () => {
+    const o = captured("^XA^MUi^FO10,10^A0N,30,30^FDx^FS^MUd^XZ");
+    expect(o.regenSafe).toBe(false);
+  });
+
+  it("flags a ^LR block as not regenSafe (raw ^LR would double-reverse a regen)", () => {
+    const o = captured("^XA^LRY^FO10,10^A0N,30,30^FDx^FS^XZ");
+    expect(o.regenSafe).toBe(false);
+  });
+
+  it("flags a bare barcode (^BY outside the field) as not regenSafe", () => {
+    const o = captured("^XA^BY3^FO10,10^BCN,100,Y,N,N^FD12345^FS^XZ");
+    expect(o.regenSafe).toBe(false);
+  });
+
+  it("flags any non-UTF-8 ^CI block as not regenSafe (regen would mis-encode)", () => {
+    expect(captured("^XA^CI13^FO10,10^A0N,30,30^FDx^FS^XZ").regenSafe).toBe(false);
+  });
+
+  it("keeps a UTF-8 (^CI28) block regenSafe", () => {
+    expect(captured("^XA^CI28^FO10,10^A0N,30,30^FDx^FS^XZ").regenSafe).toBe(true);
+  });
+
+  it("keeps a barcode with inline ^BY regenSafe", () => {
+    const o = captured("^XA^FO10,10^BY3^BCN,100,Y,N,N^FD12345^FS^XZ");
+    expect(o.regenSafe).toBe(true);
+  });
+
+  it("keeps a 2D code (QR) regenSafe even without ^BY (it ignores ^BY)", () => {
+    expect(captured("^XA^FO10,10^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(true);
+  });
+
+  it("keeps a DataMatrix regenSafe without ^BY", () => {
+    expect(captured("^XA^FO10,10^BXN,5,200^FDhello^FS^XZ").regenSafe).toBe(true);
+  });
+
+  it("flags a non-default ^FC block as not regenSafe (raw ^FC would mis-clock a regen)", () => {
+    const o = captured("^XA^FC$,{,#^FO50,50^A0N,30,30^FD$m/$d^FS^XZ");
+    expect(o.regenSafe).toBe(false);
+  });
+
+  it("flags a block with a bare ^FN declaration as not regenSafe (would duplicate it)", () => {
+    const o = captured("^XA^FN7^FDACME^FS^FO50,50^A0N,30,30^FDx^FS^XZ");
+    expect(o.regenSafe).toBe(false);
+  });
+
+  it("captures the ^LH frame so a regen can be home-relative", () => {
+    const o = captured("^XA^LH50,20^FO10,10^A0N,30,30^FDx^FS^XZ");
+    expect(o.frame).toEqual({ homeX: 50, homeY: 20, top: 0 });
+  });
+
+  it("is undefined when capture is off", () => {
+    const { overlay } = parseZPL("^XA^FO0,0^FDx^FS^XZ", 8);
+    expect(overlay).toBeUndefined();
+  });
+
+  it("preserves comments and unmodeled commands as raw", () => {
+    const zpl = "^XA^FX banner^FS^FO10,10^A0N,30,30^FDx^FS^PQ3^XZ";
+    const o = captured(zpl);
+    const raw = o.segments.filter((s) => s.kind === "raw").map((s) => s.text).join("");
+    expect(raw).toContain("^FX banner^FS");
+    expect(raw).toContain("^PQ3");
+  });
+});

--- a/src/lib/zplOverlay/overlayCapture.test.ts
+++ b/src/lib/zplOverlay/overlayCapture.test.ts
@@ -150,6 +150,11 @@ describe("parseZPL overlay capture", () => {
     expect(o.regenSafe).toBe(true);
   });
 
+  it("keeps a barcode with lowercase inline ^by regenSafe (ZPL is case-insensitive)", () => {
+    const o = captured("^XA^FO10,10^by3^BCN,100,Y,N,N^FD12345^FS^XZ");
+    expect(o.regenSafe).toBe(true);
+  });
+
   it("keeps a 2D code (QR) regenSafe even without ^BY (it ignores ^BY)", () => {
     expect(captured("^XA^FO10,10^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(true);
   });

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1,8 +1,37 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { zlibSync } from 'fflate';
-import { parseZPL } from './zplParser';
+import { parseZPL, BY_CONSUMING_BARCODE_TYPES } from './zplParser';
 import { formatLabelMetaComment } from './zplLabelMeta';
+import { ObjectRegistry } from '../registry';
 import { props } from '../test/helpers';
+
+// Drift guard for the bare-^BY hazard set. Every 1D and postal barcode emits a
+// ^BY on regen, so it must be classified ^BY-consuming; a forgotten new one
+// would silently let a neighbour's ^BY leak. 2D mag-codes must stay excluded.
+describe('BY_CONSUMING_BARCODE_TYPES drift guard', () => {
+  it('includes every code-1d and code-postal type', () => {
+    for (const [type, entry] of Object.entries(ObjectRegistry)) {
+      if (entry.group === 'code-1d' || entry.group === 'code-postal') {
+        expect(BY_CONSUMING_BARCODE_TYPES.has(type), `${type} (${entry.group})`).toBe(true);
+      }
+    }
+  });
+
+  it('excludes 2D mag-codes and includes the ^BY-using stacked 2D codes', () => {
+    for (const t of ['qrcode', 'datamatrix', 'aztec', 'maxicode']) {
+      expect(BY_CONSUMING_BARCODE_TYPES.has(t), t).toBe(false);
+    }
+    for (const t of ['pdf417', 'micropdf417', 'codablock', 'tlc39']) {
+      expect(BY_CONSUMING_BARCODE_TYPES.has(t), t).toBe(true);
+    }
+  });
+
+  it('lists only real registry leaf types', () => {
+    for (const t of BY_CONSUMING_BARCODE_TYPES) {
+      expect(Object.prototype.hasOwnProperty.call(ObjectRegistry, t), t).toBe(true);
+    }
+  });
+});
 
 /** CRC-16/XMODEM; same variant used by the parser to validate
  *  :B64:/:Z64: wrappers (poly 0x1021, init 0x0000). Duplicated here so

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CLOCK_CHARS } from "./fcTemplate";
+import { DEFAULT_CLOCK_CHARS, isDefaultClockChars } from "./fcTemplate";
 import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
 import { tokenize } from "./zplParser/helpers";
 import { createParserState } from "./zplParser/context";
@@ -10,6 +10,7 @@ import { createLabelConfigHandlers } from "./zplParser/handlers/labelConfig";
 import { createSetupScriptHandlers } from "./zplParser/handlers/setupScript";
 import { createUnitsHandler } from "./zplParser/handlers/units";
 import { createUnsupportedHandlers } from "./zplParser/handlers/unsupported";
+import { buildBlockOverlay, type LinkedSpan } from "./zplOverlay/overlay";
 import type {
   Handler,
   ImportFinding,
@@ -23,13 +24,30 @@ export type {
   ParsedZPL,
 } from "./zplParser/types";
 
-/** Parse a ZPL II byte stream into an editable design model. */
-export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
+/** Barcode object types whose module width comes from ^BY (mirrors the
+ *  `s.defaults.byModuleWidth` consumers in flushField). 2D codes that carry
+ *  their own magnification (qrcode/datamatrix/aztec/maxicode) are excluded, so
+ *  editing a 2D-code label stays regenSafe. */
+export const BY_CONSUMING_BARCODE_TYPES = new Set<string>([
+  "code128", "code39", "ean13", "upce", "upca", "ean8", "interleaved2of5",
+  "code93", "code11", "industrial2of5", "standard2of5", "codabar", "logmars",
+  "msi", "plessey", "planet", "postal", "upcEanExtension", "gs1databar",
+  "pdf417", "code49", "micropdf417", "codablock", "tlc39",
+]);
+
+/** Parse a ZPL II byte stream into an editable design model. `captureOverlay`
+ *  builds a source-patch overlay (segments linking each object to its bytes;
+ *  gaps preserved as raw) for byte-identical re-export. Off by default. */
+export function parseZPL(
+  zpl: string,
+  dpmm = 8,
+  opts: { captureOverlay?: boolean } = {},
+): ParsedZPL {
   const s = createParserState();
   const tokens = tokenize(zpl, s.format);
   const {
     objects, labelConfig, printerProfile, variables,
-    skipped, partialCmds, browserLimit, unknown,
+    skipped, partialCmds, browserLimit, unknown, replayRisk,
   } = s.result;
 
   const takeComment = (): string | undefined => {
@@ -83,7 +101,20 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
   Object.assign(handlers, createBarcodeHandlers(s));
   Object.assign(handlers, createFieldHandlers(s, { flushField, appendComment }));
   Object.assign(handlers, graphicsFamily.handlers);
-  Object.assign(handlers, createSetupScriptHandlers(s));
+  // Replay-risk = printer-config (Setup-Script) commands PLUS device-action
+  // commands (calibration/reset/diagnostics/ZBI/pause) that change device or
+  // queue state when the lossless overlay re-emits them on export. Setup keys
+  // derive from the handler set; device actions are listed explicitly because
+  // their noop handlers are mixed with design noops (^FV/^FM) that are NOT
+  // replay-risk. Visible label settings (labelConfig: ^MD/^PR/^MM...) and ^DY
+  // font uploads are intentionally excluded (the former are shown in the label
+  // panel; a non-font ^DY surfaces as a browserLimit finding).
+  const setupScriptHandlers = createSetupScriptHandlers(s);
+  const replayRiskCodes = new Set([
+    ...Object.keys(setupScriptHandlers),
+    "JA", "JM", "JC", "JD", "JE", "JI", "JR", "PP",
+  ]);
+  Object.assign(handlers, setupScriptHandlers);
   Object.assign(handlers, createLabelConfigHandlers(s, dpmm));
   Object.assign(handlers, createUnitsHandler(s, dpmm));
   Object.assign(handlers, createUnsupportedHandlers(s.result));
@@ -92,11 +123,134 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
   // so a handler-table entry always wins over a pattern-match.
   const wildcards: Wildcard[] = [createDynamicFontAWildcard(s)];
 
-  for (const { cmd, rest } of tokens) {
+  // Overlay capture: a field runs ^FO/^FT … ^FS. `ovStart` is the field's source
+  // start (^FO/^FT), `ovBase` the object count when the field opened; a deferred
+  // reverse-bg that commits mid-field bumps `ovBase` so the field's own object is
+  // still found at `ovBase`. Linking is intentionally conservative: only clean
+  // single-object fields, deferred reverse-bg boxes, and reverse-collapse merges
+  // are linked. Any other shape leaves an object unlinked, which trips the
+  // all-linked gate below and drops the overlay so the block regenerates.
+  const overlaySpans: LinkedSpan[] = [];
+  const linkedIds = new Set<string>();
+  let ovStart: number | null = null;
+  let ovBase = 0;
+  const linkObject = (start: number, end: number, objectId: string) => {
+    overlaySpans.push({ start, end, link: { kind: "object", objectId } });
+    linkedIds.add(objectId);
+  };
+  // Running state that would re-interpret a regenerated object's bytes on
+  // replay (the raw command persists in a raw segment). Verbatim replay is
+  // unaffected; only the dirty/new regeneration path cares. Tracked once per
+  // block; drives the overlay's regenSafe flag.
+  let regenHostileFormat = false;
+  let sawNonUtf8Ci = false;
+  let sawBareBarcode = false;
+  let sawFnDeclaration = false;
+  // Start of a contiguous leading-comment (^FX) run immediately before a field,
+  // so the field's span can own its ^FX bytes (uniform verbatim/regen, and a
+  // comment edit regenerates without leaving a stale ^FX in a raw segment).
+  let commentStart: number | null = null;
+
+  for (const { cmd, rest, start } of tokens) {
     const p = rest.split(s.format.delimiterChar);
+    // Flag printer-config commands: lossless replay re-emits them, so they run
+    // on the user's printer at print/export. Recorded by code (deduped later).
+    if (replayRiskCodes.has(cmd)) replayRisk.push(`^${cmd}`);
     const handler = handlers[cmd] ?? wildcards.find((w) => w.matches(cmd))?.handle;
     if (handler) {
+      const reverseBefore = s.reverseBg;
+      const beforeLen = objects.length;
       handler(p, rest, cmd);
+      if (opts.captureOverlay) {
+        if (
+          s.format.caretChar !== "^" ||
+          s.format.tildeChar !== "~" ||
+          s.format.delimiterChar !== "," ||
+          s.format.unitScale !== 1 ||
+          s.format.embedChar !== "#" ||
+          // ^LR reverses every following field and is never re-emitted, so a
+          // regenerated field under a surviving raw ^LR would double-reverse.
+          s.label.lrActive ||
+          // A non-default ^FC sets the active clock chars; a regenerated clock
+          // field re-derives default chars and would mis-clock under the raw ^FC.
+          !isDefaultClockChars(s.format.clockChars)
+        ) {
+          regenHostileFormat = true;
+        }
+        // Any non-UTF-8 ^CI makes regen unsafe: a regenerated field emits UTF-8
+        // bytes that the surviving raw ^CI would mis-decode (the generator emits
+        // ^CI28 only on the full-regen fallback, not in the overlay path).
+        if (s.format.fhDecoder.encoding !== "utf-8") sawNonUtf8Ci = true;
+        // A bare ^FN declaration (^FN outside an ^FO…^FS field) becomes a raw
+        // segment; the scoped header would re-emit it on regen and duplicate it.
+        if (cmd === "FN" && ovStart === null) sawFnDeclaration = true;
+        // Track the leading-comment run; a non-^FX command (other than the field
+        // opener) breaks contiguity so the span won't swallow intervening config.
+        // Known limitation: when a command separates a ^FX from its field, the
+        // ^FX stays in a raw segment; editing that field re-emits the comment,
+        // producing a duplicate ^FX in the output. Harmless (comments do not
+        // print) and rare, so accepted rather than tracked per-object.
+        if (cmd === "FX") {
+          if (commentStart === null) commentStart = start;
+        } else if (cmd !== "FO" && cmd !== "FT") {
+          commentStart = null;
+        }
+        // A prior stashed reverse-bg committed standalone on this (non-^FS)
+        // token (graphics command, ^XA/^XZ): commitPendingReverseBg pushes the
+        // box first, so objects[beforeLen] is it. ^FS is handled below instead.
+        if (
+          cmd !== "FS" &&
+          reverseBefore?.span &&
+          s.reverseBg !== reverseBefore &&
+          objects.length > beforeLen
+        ) {
+          const box = objects[beforeLen];
+          if (box) linkObject(reverseBefore.span.start, reverseBefore.span.end, box.id);
+          if (ovStart !== null) ovBase++;
+        }
+        if (cmd === "FO" || cmd === "FT") {
+          ovStart = commentStart ?? start;
+          ovBase = objects.length;
+          commentStart = null;
+        } else if (cmd === "FS" && ovStart !== null) {
+          const fieldEnd = start + 3;
+          // A ^BY-consuming barcode whose ^BY sits outside its own field would
+          // inherit a regenerated neighbour's inline ^BY on replay; mark the
+          // block unsafe. Classify by the parsed object type (not a regex) so
+          // 2D codes that ignore ^BY (QR/DataMatrix/Aztec/MaxiCode) stay
+          // regenSafe. The field's own object is the last one pushed.
+          const own = objects.length > ovBase ? objects[objects.length - 1] : undefined;
+          if (
+            own &&
+            BY_CONSUMING_BARCODE_TYPES.has(own.type) &&
+            !zpl.slice(ovStart, fieldEnd).includes("^BY")
+          ) {
+            sawBareBarcode = true;
+          }
+          if (s.reverseBg && s.reverseBg.span === undefined && objects.length === ovBase) {
+            // This field stashed a reverse-bg (no object yet); record its span
+            // so the box can be linked when it commits later.
+            s.reverseBg.span = { start: ovStart, end: fieldEnd };
+          } else if (reverseBefore?.span && s.reverseBg === null && objects.length === ovBase + 1) {
+            // Reverse-collapse: stashed box + this ^FR text merged into one
+            // object spanning both fields (the gap rides along in the segment).
+            const merged = objects[ovBase];
+            if (merged) linkObject(reverseBefore.span.start, fieldEnd, merged.id);
+          } else if (reverseBefore?.span && s.reverseBg === null && objects.length === ovBase + 2) {
+            // Stashed box committed standalone during this flush (box at ovBase),
+            // then the field's own object (text/barcode) at ovBase+1.
+            const box = objects[ovBase];
+            const own = objects[ovBase + 1];
+            if (box) linkObject(reverseBefore.span.start, reverseBefore.span.end, box.id);
+            if (own) linkObject(ovStart, fieldEnd, own.id);
+          } else if (objects.length === ovBase + 1) {
+            // Clean single-object field.
+            const obj = objects[ovBase];
+            if (obj) linkObject(ovStart, fieldEnd, obj.id);
+          }
+          ovStart = null;
+        }
+      }
       continue;
     }
 
@@ -104,6 +258,28 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
       const token = `^${cmd}${rest}`;
       skipped.push(token);
       unknown.push(token);
+    }
+  }
+
+  // Build the overlay only when every parsed object linked to a source span;
+  // an unlinked object would double-emit (raw replay + model regenerate), so a
+  // partial capture is unsafe. Falls back to model regeneration for the block.
+  const allLinked = objects.every((o) => linkedIds.has(o.id));
+  const regenSafe =
+    !regenHostileFormat && !sawNonUtf8Ci && !sawBareBarcode && !sawFnDeclaration;
+  const frame =
+    s.label.lhX !== 0 || s.label.lhY !== 0 || s.label.ltY !== 0
+      ? { homeX: s.label.lhX, homeY: s.label.lhY, top: s.label.ltY }
+      : undefined;
+  // buildBlockOverlay throws on overlapping/out-of-bounds spans (a broken span
+  // invariant). Today that is unreachable, but catching keeps the contract
+  // total: any capture problem drops the overlay rather than crashing import.
+  let overlay: ParsedZPL["overlay"];
+  if (opts.captureOverlay && allLinked) {
+    try {
+      overlay = buildBlockOverlay(zpl, overlaySpans, { regenSafe, frame });
+    } catch {
+      overlay = undefined;
     }
   }
 
@@ -130,6 +306,9 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
     ...unknown.map(
       (command): ImportFinding => ({ kind: "unknown", command, pageIndex: 0 }),
     ),
+    ...replayRisk.map(
+      (command): ImportFinding => ({ kind: "replayRisk", command, pageIndex: 0 }),
+    ),
   ];
 
   return {
@@ -145,6 +324,8 @@ export function parseZPL(zpl: string, dpmm = 8): ParsedZPL {
       partial: [...partialCmds],
       browserLimit,
       unknown,
+      replayRisk,
     },
+    overlay,
   };
 }

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -272,13 +272,15 @@ export function parseZPL(
       ? { homeX: s.label.lhX, homeY: s.label.lhY, top: s.label.ltY }
       : undefined;
   // buildBlockOverlay throws on overlapping/out-of-bounds spans (a broken span
-  // invariant). Today that is unreachable, but catching keeps the contract
-  // total: any capture problem drops the overlay rather than crashing import.
+  // invariant). Today that is unreachable; catching keeps the contract total
+  // (any capture problem drops the overlay rather than crashing import) and the
+  // warn surfaces the parser bug should a future change ever make it reachable.
   let overlay: ParsedZPL["overlay"];
   if (opts.captureOverlay && allLinked) {
     try {
       overlay = buildBlockOverlay(zpl, overlaySpans, { regenSafe, frame });
-    } catch {
+    } catch (err) {
+      console.warn("buildBlockOverlay failed, dropping overlay for this block", err);
       overlay = undefined;
     }
   }

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -223,7 +223,7 @@ export function parseZPL(
           if (
             own &&
             BY_CONSUMING_BARCODE_TYPES.has(own.type) &&
-            !zpl.slice(ovStart, fieldEnd).includes("^BY")
+            !/\^BY/i.test(zpl.slice(ovStart, fieldEnd))
           ) {
             sawBareBarcode = true;
           }

--- a/src/lib/zplParser/context.ts
+++ b/src/lib/zplParser/context.ts
@@ -25,6 +25,10 @@ export interface PendingReverseBg {
   rounding: number;
   reverseFlag: boolean | undefined;
   comment?: string;
+  /** Overlay capture only: source span of the ^GB field, recorded at its ^FS so
+   *  the object it later produces (deferred commit, or reverse-collapse merge)
+   *  can be linked to its original bytes. */
+  span?: { start: number; end: number };
 }
 
 /** Public output accumulators handed back via `ParsedZPL`. */
@@ -37,6 +41,9 @@ export interface ParserResult {
   partialCmds: Set<string>;
   browserLimit: string[];
   unknown: string[];
+  /** Setup-Script / printer-config commands seen (persist/change device state
+   *  on print/export); surfaced as a replay-risk import finding. */
+  replayRisk: string[];
 }
 
 /** Label-frame state from ^LH / ^LT / ^LR; per spec these are persistent
@@ -220,6 +227,7 @@ export function createParserState(): ParserState {
       partialCmds: new Set<string>(),
       browserLimit: [],
       unknown: [],
+      replayRisk: [],
     },
     label: {
       lhX: 0,

--- a/src/lib/zplParser/helpers.ts
+++ b/src/lib/zplParser/helpers.ts
@@ -33,7 +33,7 @@ export interface TokenizerChars {
 export function* tokenize(
   zpl: string,
   chars: TokenizerChars,
-): Generator<{ cmd: string; rest: string }> {
+): Generator<{ cmd: string; rest: string; start: number; end: number }> {
   let pos = 0;
   while (pos < zpl.length) {
     let cmdStart = -1;
@@ -52,7 +52,7 @@ export function* tokenize(
     if (cmd === "CC" || cmd === "CT" || cmd === "CD") {
       const argChar = zpl[cmdStart + 3] ?? "";
       pos = cmdStart + 4;
-      yield { cmd, rest: argChar };
+      yield { cmd, rest: argChar, start: cmdStart, end: pos };
       continue;
     }
     let endPos = zpl.length;
@@ -64,7 +64,9 @@ export function* tokenize(
       }
     }
     pos = endPos;
-    yield { cmd, rest: zpl.slice(cmdStart + 3, endPos) };
+    // `end` is exclusive: the index where the next command's prefix begins (or
+    // end of input), so source.slice(start, end) is this token's verbatim text.
+    yield { cmd, rest: zpl.slice(cmdStart + 3, endPos), start: cmdStart, end: endPos };
   }
 }
 

--- a/src/lib/zplParser/types.ts
+++ b/src/lib/zplParser/types.ts
@@ -2,8 +2,9 @@ import type { LabelConfig } from "../../types/LabelConfig";
 import type { LabelObject } from "../../types/Group";
 import type { Variable } from "../../types/Variable";
 import type { PrinterProfile } from "../../types/PrinterProfile";
+import type { BlockOverlay } from "../zplOverlay/overlay";
 
-export type ImportFindingKind = "partial" | "browserLimit" | "unknown";
+export type ImportFindingKind = "partial" | "browserLimit" | "unknown" | "replayRisk";
 
 /**
  * One import finding. Created per-occurrence so each entry can be navigated
@@ -30,6 +31,10 @@ export interface ImportReport {
   browserLimit: string[];
   /** Commands not recognised at all. */
   unknown: string[];
+  /** Setup-Script / printer-configuration commands that persist or change
+   *  device state when the design is printed or exported (e.g. ^ST, ^KN, ^KP,
+   *  ^JU, ^SE). Lossless replay re-emits them, so the user is warned. */
+  replayRisk: string[];
 }
 
 export interface ParsedZPL {
@@ -55,6 +60,12 @@ export interface ParsedZPL {
    *  importReport for categorised access. */
   skipped: string[];
   importReport: ImportReport;
+  /** Source-patch overlay for the parsed block, present only when
+   *  `captureOverlay` is set and every parsed object linked to a source
+   *  span. Lets export replay untouched fields/config/comments/whitespace
+   *  byte-identically. `undefined` when capture was off or a field shape
+   *  couldn't be linked (the block then regenerates from the model). */
+  overlay?: BlockOverlay;
 }
 
 export type Handler = (p: string[], rest: string, cmd: string) => void;

--- a/src/lib/zplRoundtrip.integration.test.ts
+++ b/src/lib/zplRoundtrip.integration.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useLabelStore } from "../store/labelStore";
+import { importZplText } from "./zplImportService";
+import { generateMultiPageZPL } from "./zplGenerator";
+
+// Integration: drive the REAL user paths (importZplText -> loadDesign -> store ->
+// generateMultiPageZPL), not parseZPL/generate in isolation. Asserts the actual
+// overlay contract: an untouched block re-exports byte-identically (config,
+// comments, and fields that depend on running ^CF all ride along in the
+// overlay), an edited field regenerates self-contained in place, and the cycle
+// is a fixpoint. Per-gate rules are unit-tested in zplRoundtrip.test.ts.
+
+const store = () => useLabelStore.getState();
+
+// Reset the shared store so config/variable edits in one test can't bleed into
+// the next (importInto reads store().label as its base).
+beforeEach(() => {
+  useLabelStore.setState({
+    label: { widthMm: 100, heightMm: 60, dpmm: 8 },
+    pages: [{ objects: [] }],
+    currentPageIndex: 0,
+    selectedIds: [],
+    variables: [],
+    csvMapping: null,
+    csvDataset: null,
+  });
+});
+
+function importInto(zpl: string): void {
+  const label = store().label;
+  const r = importZplText(zpl, label.dpmm);
+  store().loadDesign({ ...label, ...r.labelConfig }, r.pages, r.variables);
+}
+const exportZpl = (): string => {
+  const s = store();
+  return generateMultiPageZPL(s.label, s.pages, s.variables);
+};
+
+// Representative document: a verbatim-eligible text (inline ^A), a shape, a
+// barcode with inline ^BY, a comment, and config that always regenerates.
+const TEXT = "^FO50,50^A0N,30,30^FDHello^FS";
+const BOX = "^FO50,120^GB200,80,3^FS";
+const BARCODE = "^FO50,220^BY3^BCN,100,Y,N,N^FD12345^FS";
+const DOC = `^XA\n^PW800\n^LL400\n^FXheader note\n${TEXT}\n${BOX}\n${BARCODE}\n^XZ`;
+
+// A realistic foreign shipping label: encoding, comments, mixed fonts, a
+// barcode with inline ^BY, a rule, and a print quantity. No geometry sidecar
+// (foreign ZPL never has one), so it exercises the real import path.
+const REAL_LABEL = [
+  "^XA",
+  "^CI28",
+  "^FO40,40^A0N,40,40^FDACME Logistics^FS",
+  "^FXship-to block",
+  "^FO40,110^A0N,28,28^FDJohn Doe^FS",
+  "^FO40,150^A0N,28,28^FD123 Main Street^FS",
+  "^FO40,260^BY3^BCN,120,Y,N,N^FD1Z9999W99^FS",
+  "^FO40,420^GB720,3,3^FS",
+  "^PQ2",
+  "^XZ",
+].join("\n");
+
+describe("round-trip integration (real import -> store -> export)", () => {
+  it("a realistic foreign label re-exports byte-identically with zero edits", () => {
+    importInto(REAL_LABEL);
+    expect(exportZpl()).toBe(REAL_LABEL);
+  });
+
+  it("a realistic foreign label: edit one field, the rest stays byte-identical", () => {
+    importInto(REAL_LABEL);
+    const addr = store().pages[0]!.objects.find(
+      (o) => "props" in o && (o.props as { content?: string }).content === "123 Main Street",
+    )!;
+    store().updateObject(addr.id, { x: 60 });
+    const out = exportZpl();
+    expect(out).toContain("^FO40,40^A0N,40,40^FDACME Logistics^FS"); // untouched verbatim
+    expect(out).toContain("^FO40,260^BY3^BCN,120,Y,N,N^FD1Z9999W99^FS");
+    expect(out).toContain("^FO40,420^GB720,3,3^FS");
+    expect(out).toContain("^FXship-to block"); // comment once, not duplicated
+    expect(out.split("ship-to block").length - 1).toBe(1);
+    expect(out).not.toContain("^FO40,150^A0N,28,28^FD123 Main Street^FS"); // moved -> regenerated
+    expect(out).toContain("^FO60,"); // new x
+  });
+
+
+  it("re-exports every untouched field byte-verbatim, with its comment", () => {
+    importInto(DOC);
+    const out = exportZpl();
+    expect(out).toContain(TEXT);
+    expect(out).toContain(BOX);
+    expect(out).toContain(BARCODE);
+    expect(out).toContain("^FXheader note");
+  });
+
+  it("edits one field: it regenerates, the rest stay verbatim", () => {
+    importInto(DOC);
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    store().updateObject(text.id, { x: 99 });
+    const out = exportZpl();
+    expect(out).not.toContain(TEXT); // edited -> regenerated
+    expect(out).toContain("^FO99,"); // proves the new coordinate
+    expect(out).toContain(BOX); // untouched -> still verbatim
+    expect(out).toContain(BARCODE);
+  });
+
+  it("a two-page label round-trips byte-identically and is a fixpoint", () => {
+    const two =
+      "^XA\n^FO10,10^A0N,30,30^FDa^FS\n^XZ\n^XA\n^FO10,10^A0N,30,30^FDb^FS\n^XZ";
+    importInto(two);
+    const out1 = exportZpl();
+    expect(out1).toBe(two); // no inter-block separator doubling
+    importInto(out1);
+    expect(exportZpl()).toBe(out1); // fixpoint
+  });
+
+  it("editing a commented object does not duplicate its ^FX comment", () => {
+    importInto(DOC);
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    expect(text.comment).toBe("header note"); // ^FX attached to the text field
+    store().updateObject(text.id, { x: 77 });
+    const out = exportZpl();
+    const count = out.split("header note").length - 1;
+    expect(count).toBe(1); // exactly one ^FX, not the raw + regenerated pair
+  });
+
+  it("editing an object's comment is reflected on export (not stale)", () => {
+    importInto(DOC);
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    store().updateObject(text.id, { comment: "revised note" });
+    const out = exportZpl();
+    expect(out).toContain("^FXrevised note");
+    expect(out).not.toContain("header note"); // old comment gone, not duplicated
+  });
+
+  it("adding a comment to an imported object emits one ^FX", () => {
+    importInto(DOC);
+    const box = store().pages[0]!.objects.find((o) => o.type === "box")!;
+    expect(box.comment).toBeUndefined();
+    store().updateObject(box.id, { comment: "the box" });
+    const out = exportZpl();
+    expect(out.split("the box").length - 1).toBe(1);
+    expect(out).toContain("^FXthe box");
+  });
+
+  it("undo of an edit clears dirty so the block replays verbatim again", () => {
+    const src = "^XA^FO10,10^A0N,30,30^FDHi^FS^XZ";
+    importInto(src);
+    expect(exportZpl()).toBe(src);
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    store().updateObject(text.id, { x: 99 });
+    expect(exportZpl()).not.toBe(src); // edited -> regenerated
+    useLabelStore.temporal.getState().undo();
+    // The dirty-tracking middleware must NOT re-stamp on a temporal restore.
+    expect(store().pages[0]!.objects.find((o) => o.type === "text")!.dirty).toBeFalsy();
+    expect(exportZpl()).toBe(src); // back to verbatim
+  });
+
+  it("import -> export -> reimport -> export is a fixpoint (no drift)", () => {
+    importInto(DOC);
+    const out1 = exportZpl();
+    importInto(out1);
+    const out2 = exportZpl();
+    expect(out2).toBe(out1);
+  });
+
+  it("duplicating a page does not carry the overlay (clone regenerates)", () => {
+    importInto("^XA^FO10,10^A0N,30,30^FDx^FS^XZ");
+    expect(store().pages[0]!.overlay).toBeDefined();
+    store().duplicatePage(0);
+    expect(store().pages).toHaveLength(2);
+    expect(store().pages[1]!.overlay).toBeUndefined(); // clone is net-new
+  });
+
+  it("reordering objects falls back to full regeneration (model order)", () => {
+    importInto(DOC);
+    expect(exportZpl()).not.toContain("^CI28"); // overlay replay: no synthesized header
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    store().reorderObject(text.id, 2); // move text to the top of the z-order
+    const out = exportZpl();
+    expect(out).toContain("^CI28"); // fell back to generateZPL (full header)
+  });
+
+  it("a shared ^FN slot across pages round-trips byte-identically (no merge-dirty)", () => {
+    const src =
+      "^XA^FO10,10^A0N,30,30^FN1^FDpageA^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDpageB^FS^XZ";
+    importInto(src);
+    // The cross-block merge must not dirty page 2; its original ^FD default
+    // replays verbatim instead of regenerating with the merged variable's value.
+    expect(exportZpl()).toBe(src);
+  });
+
+  it("setBoundDefault drops page overlays so the new default exports", () => {
+    importInto("^XA^FO10,10^A0N,30,30^FN1^FDold^FS^XZ");
+    expect(store().pages[0]!.overlay).toBeDefined();
+    const v = store().variables[0]!;
+    const obj = store().pages[0]!.objects[0]!;
+    const props = (obj as unknown as { props: object }).props;
+    store().setBoundDefault(v.id, "new", obj.id, { props: { ...props, content: "new" } });
+    expect(store().pages[0]!.overlay).toBeUndefined();
+  });
+
+  it("changing a variable default drops page overlays (stale ^FN header)", () => {
+    importInto("^XA^FO10,10^A0N,30,30^FN1^FDold^FS^XZ");
+    expect(store().pages[0]!.overlay).toBeDefined();
+    store().updateVariable(store().variables[0]!.id, { defaultValue: "new" });
+    expect(store().pages[0]!.overlay).toBeUndefined();
+  });
+
+  it("removing a variable drops page overlays (orphan ^FN declaration)", () => {
+    importInto("^XA^FO10,10^A0N,30,30^FN1^FDold^FS^XZ");
+    expect(store().pages[0]!.overlay).toBeDefined();
+    store().removeVariable(store().variables[0]!.id);
+    expect(store().pages[0]!.overlay).toBeUndefined();
+  });
+
+  it("append-mode strips overlays from appended pages (current config wins)", () => {
+    importInto("^XA^FO10,10^A0N,30,30^FDbase^FS^XZ");
+    const r = importZplText("^XA^PW999^FO20,20^A0N,30,30^FDapp^FS^XZ", store().label.dpmm);
+    expect(r.pages[0]!.overlay).toBeDefined();
+    store().appendPages(r.pages);
+    const appended = store().pages[store().pages.length - 1]!;
+    expect(appended.overlay).toBeUndefined();
+  });
+
+  it("an emit-affecting config edit drops the overlay and reflects the new value", () => {
+    importInto(DOC);
+    expect(store().pages[0]!.overlay).toBeDefined();
+    store().setLabelConfig({ widthMm: 50 });
+    expect(store().pages[0]!.overlay).toBeUndefined(); // dropped -> full regen
+    const out = exportZpl();
+    expect(out).toContain(`^PW${50 * 8}`); // new width emitted
+  });
+
+  it("an editor-only config edit (safeAreaMm) keeps the overlay byte-identical", () => {
+    const src = "^XA\n^FO50,50^A0N,30,30^FDHello^FS\n^XZ";
+    importInto(src);
+    store().setLabelConfig({ safeAreaMm: 3 });
+    expect(store().pages[0]!.overlay).toBeDefined();
+    expect(exportZpl()).toBe(src);
+  });
+
+  it("preserves a fontless-^CF field verbatim, regenerates self-contained on edit", () => {
+    const src = "^XA^CF0,40^FO10,10^FDhi^FS^XZ";
+    importInto(src);
+    // The overlay replays the ^CF in a raw segment, so the fontless field is
+    // preserved byte-identically (the old per-object raw path could not).
+    expect(exportZpl()).toBe(src);
+    // Editing it forces in-place regeneration with an explicit ^A at the ^CF
+    // height, so the patched field is self-contained.
+    const text = store().pages[0]!.objects.find((o) => o.type === "text")!;
+    store().updateObject(text.id, { x: 20 });
+    const out = exportZpl();
+    expect(out).toContain("^FDhi");
+    expect(out).toMatch(/\^A0N,40,/);
+    expect(out).toContain("^FO20,");
+  });
+});

--- a/src/lib/zplRoundtrip.test.ts
+++ b/src/lib/zplRoundtrip.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { cloneShifted, EMIT_AFFECTING_KEYS } from "../store/labelStore.internals";
+import { stampDirtyLeaves } from "../store/dirtyTracking";
+import type { LabelObject, Page } from "../types/Group";
+import { labelObjectBaseSchema } from "../types/LabelObject";
+
+// Byte-identical round-trip lives in zplOverlay/* (capture + emitOverlayPage).
+// This file guards the `dirty` model that drives it. Dirty is stamped centrally
+// by the dirtyTracking middleware (stampDirtyLeaves), not by individual mutators,
+// so an emit-affecting object change flips dirty and the overlay regenerates it.
+
+const leaf = (over: object = {}): LabelObject =>
+  ({
+    id: "o",
+    type: "text",
+    x: 10,
+    y: 10,
+    rotation: 0,
+    props: { content: "hi", fontHeight: 20, fontWidth: 0, rotation: "N" },
+    ...over,
+  }) as unknown as LabelObject;
+const page = (objs: LabelObject[]): Page[] => [{ objects: objs }];
+
+// Real mutators are identity-preserving (a changed object spreads from the
+// prior one, keeping the same `props` ref when props didn't change), so the
+// fixtures derive `next` from a shared `prev` rather than rebuilding leaves.
+const edit = (o: LabelObject, over: object): LabelObject => ({ ...o, ...over });
+
+describe("stampDirtyLeaves (central dirty model)", () => {
+  it("stamps dirty when an emit-affecting field changes", () => {
+    const o = leaf();
+    const out = stampDirtyLeaves(page([o]), page([edit(o, { x: 99 })]));
+    expect(out[0]!.objects[0]!.dirty).toBe(true);
+  });
+
+  it("does not stamp a metadata-only change", () => {
+    const o = leaf();
+    const out = stampDirtyLeaves(page([o]), page([edit(o, { name: "Header" })]));
+    expect(out[0]!.objects[0]!.dirty).toBeFalsy();
+  });
+
+  it("stamps a type change even when props are preserved (convertObjectType guard)", () => {
+    const o = leaf();
+    const out = stampDirtyLeaves(page([o]), page([edit(o, { type: "box" })]));
+    expect(out[0]!.objects[0]!.dirty).toBe(true);
+  });
+
+  it("does not stamp a reorder (same object reference, new position)", () => {
+    const a = leaf({ id: "a" });
+    const b = leaf({ id: "b", x: 50 });
+    const out = stampDirtyLeaves(page([a, b]), page([b, a]));
+    expect(out[0]!.objects.every((o) => !o.dirty)).toBe(true);
+  });
+
+  it("does not stamp a net-new object (no prior counterpart)", () => {
+    const out = stampDirtyLeaves(page([]), page([leaf({ id: "new" })]));
+    expect(out[0]!.objects[0]!.dirty).toBeFalsy();
+  });
+
+  it("keeps an already-dirty object dirty", () => {
+    const o = leaf();
+    const out = stampDirtyLeaves(page([o]), page([edit(o, { dirty: true, x: 99 })]));
+    expect(out[0]!.objects[0]!.dirty).toBe(true);
+  });
+
+  it("stamps a leaf nested inside a group", () => {
+    const o = leaf();
+    const grp = (child: LabelObject): LabelObject =>
+      ({ id: "g", type: "group", x: 0, y: 0, rotation: 0, children: [child] }) as unknown as LabelObject;
+    const out = stampDirtyLeaves(page([grp(o)]), page([grp(edit(o, { x: 99 }))]));
+    const child = (out[0]!.objects[0] as unknown as { children: LabelObject[] }).children[0]!;
+    expect(child.dirty).toBe(true);
+  });
+
+  it("is identity-preserving when nothing emit-affecting changed", () => {
+    const o = leaf();
+    const next = page([edit(o, { name: "x" })]);
+    expect(stampDirtyLeaves(page([o]), next)).toBe(next);
+  });
+});
+
+describe("round-trip dirty guardrails", () => {
+  it("clones drop provenance (a copy is a net-new object)", () => {
+    expect(cloneShifted(leaf({ dirty: true }), 20, 20).dirty).toBeUndefined();
+  });
+
+  it("every base field is classified emit-affecting or metadata", () => {
+    const META = new Set(["locked", "visible", "includeInExport", "name"]);
+    const ignore = new Set(["id", "type", "dirty"]);
+    for (const k of Object.keys(labelObjectBaseSchema.shape)) {
+      if (ignore.has(k)) continue;
+      expect(EMIT_AFFECTING_KEYS.has(k) || META.has(k), `unclassified base field: ${k}`).toBe(true);
+    }
+  });
+});

--- a/src/store/dirtyTracking.ts
+++ b/src/store/dirtyTracking.ts
@@ -1,0 +1,99 @@
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand';
+import { isGroup, type LabelObject, type Page } from '../types/Group';
+import { EMIT_AFFECTING_KEYS } from './labelStore.internals';
+
+// Centralizes round-trip dirty-tracking that was otherwise scattered across every
+// object mutator (the chokepoint plus each wholesale-rewrite bypass). A single
+// state-diff stamps `dirty` whenever an object's emitted ZPL bytes change, so the
+// overlay regenerates it instead of replaying stale source. Wired as
+// temporal(dirtyTracking(persist(...))): it wraps persist and is wrapped by
+// temporal, so zundo's restore path (which replays via the original setState,
+// outside this wrapper) does not re-stamp on undo/redo.
+
+/** True when any emit-affecting field differs. Scalars compare by value; `props`
+ *  compares by reference. Given the store's identity-preserving mutators (which
+ *  keep the same `props` object when nothing changed and produce a fresh one on
+ *  an edit), this never UNDER-stamps; it can only over-stamp on a no-op props
+ *  rebuild, which merely regenerates a byte-identical field. Reuses the single
+ *  EMIT_AFFECTING_KEYS source. */
+function emitAffectingChanged(a: LabelObject, b: LabelObject): boolean {
+  for (const k of EMIT_AFFECTING_KEYS) {
+    if ((a as Record<string, unknown>)[k] !== (b as Record<string, unknown>)[k]) return true;
+  }
+  return false;
+}
+
+function indexLeaves(objects: LabelObject[], out: Map<string, LabelObject>): void {
+  for (const o of objects) {
+    if (isGroup(o)) indexLeaves(o.children, out);
+    else out.set(o.id, o);
+  }
+}
+
+/** Return `nextPages` with `dirty` stamped on any leaf whose emit-affecting
+ *  fields changed versus its same-id counterpart in `prevPages`. Identity-
+ *  preserving: untouched subtrees keep their references. */
+export function stampDirtyLeaves(prevPages: Page[], nextPages: Page[]): Page[] {
+  const prev = new Map<string, LabelObject>();
+  for (const p of prevPages) indexLeaves(p.objects, prev);
+
+  const stamp = (objects: LabelObject[]): LabelObject[] => {
+    let changed = false;
+    const next = objects.map((o) => {
+      if (isGroup(o)) {
+        const kids = stamp(o.children);
+        if (kids === o.children) return o;
+        changed = true;
+        return { ...o, children: kids };
+      }
+      if (o.dirty) return o;
+      const before = prev.get(o.id);
+      // New object (no prior) or untouched reference: nothing to stamp.
+      if (!before || before === o) return o;
+      if (!emitAffectingChanged(before, o)) return o;
+      changed = true;
+      return { ...o, dirty: true };
+    });
+    return changed ? next : objects;
+  };
+
+  let pagesChanged = false;
+  const stamped = nextPages.map((p) => {
+    const objs = stamp(p.objects);
+    if (objs === p.objects) return p;
+    pagesChanged = true;
+    return { ...p, objects: objs };
+  });
+  return pagesChanged ? stamped : nextPages;
+}
+
+/** zustand middleware: stamp dirty on emit-affecting object changes in one place.
+ *  Mutator-preserving pass-through (adds no store type). Only the `set` injected
+ *  into slices is wrapped; a direct `useLabelStore.setState` would bypass
+ *  stamping, but all production mutations go through slice actions. */
+export const dirtyTracking = (<T extends { pages: Page[] }>(
+  initializer: StateCreator<T, [], []>,
+): StateCreator<T, [], []> =>
+  (set, get, api) => {
+    // The `set` casts below are standard middleware boilerplate (the mutated
+    // partial is opaque to the wrapped set's overloads). `stamped` is still
+    // statically Page[] from stampDirtyLeaves' return type, so the page payload
+    // stays type-checked.
+    const stampingSet: typeof set = (partial, replace?: boolean) => {
+      const prevPages = get().pages;
+      const patch = typeof partial === 'function' ? (partial as (s: T) => Partial<T>)(get()) : partial;
+      if (patch && typeof patch === 'object' && 'pages' in patch) {
+        const nextPages = (patch as { pages?: Page[] }).pages;
+        if (nextPages && nextPages !== prevPages) {
+          const stamped = stampDirtyLeaves(prevPages, nextPages);
+          if (stamped !== nextPages) {
+            return (set as (p: unknown, r?: boolean) => void)({ ...patch, pages: stamped }, replace);
+          }
+        }
+      }
+      return (set as (p: unknown, r?: boolean) => void)(patch, replace);
+    };
+    return initializer(stampingSet, get, api);
+  }) as <T extends { pages: Page[] }, Mps extends [StoreMutatorIdentifier, unknown][] = [], Mcs extends [StoreMutatorIdentifier, unknown][] = []>(
+    initializer: StateCreator<T, Mps, Mcs>,
+  ) => StateCreator<T, Mps, Mcs>;

--- a/src/store/labelStore.internals.ts
+++ b/src/store/labelStore.internals.ts
@@ -16,6 +16,53 @@ export function isLockBypass(changes: ObjectChanges): boolean {
   return keys.length > 0 && keys.every((k) => LOCK_BYPASS_KEYS.has(k));
 }
 
+/** Object keys whose change alters emitted ZPL bytes, invalidating the
+ *  overlay's verbatim replay for that object. `comment` is included because it
+ *  emits as a leading `^FX`. Pure metadata (lock/visible/name/includeInExport)
+ *  keeps the replay valid. The `dirtyTracking` middleware reads this to stamp
+ *  `dirty` centrally; mutators no longer set it themselves. */
+export const EMIT_AFFECTING_KEYS = new Set(['x', 'y', 'rotation', 'positionType', 'variableId', 'props', 'comment', 'type']);
+
+/** Label-config keys that never reach emitted ZPL (design-time editor aids
+ *  only). Everything else maps to a config command, so changing it would make
+ *  a page overlay's raw config bytes stale. Exported for a tripwire test: a key
+ *  wrongly added here would silently skip the overlay drop and emit stale config. */
+export const NON_EMITTING_CONFIG_KEYS = new Set(['safeAreaMm']);
+
+/** True when a config patch changes a field that reaches emitted ZPL. Used to
+ *  drop page overlays: until config-segment linkage lands, an overlay replays
+ *  config verbatim, so an emit-affecting edit must force full regeneration. */
+export function configPatchAffectsEmit(
+  prev: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): boolean {
+  return Object.keys(patch).some(
+    (k) => !NON_EMITTING_CONFIG_KEYS.has(k) && prev[k] !== patch[k],
+  );
+}
+
+/** Strip overlays from every page (identity-preserving when none carry one).
+ *  A page with no overlay regenerates from the model, the safe fallback when
+ *  config edits would otherwise replay stale raw config bytes. */
+export function dropPageOverlays(pages: Page[]): Page[] {
+  if (!pages.some((p) => p.overlay)) return pages;
+  return pages.map((p) => {
+    if (!p.overlay) return p;
+    const next = { ...p };
+    delete next.overlay;
+    return next;
+  });
+}
+
+/** Drop round-trip provenance from a leaf: a clone/copy is a net-new object with
+ *  a new id, so it has no overlay segment and must regenerate from the model. */
+function dropProvenance<T extends LabelObject>(node: T): T {
+  if (node.dirty === undefined) return node;
+  const next = { ...node };
+  delete next.dirty;
+  return next;
+}
+
 /** Apply `renameTemplateMarker` to every leaf's `content` in a subtree.
  *  Identity-preserving: returns the same array (and same node refs)
  *  when no markers needed rewriting, so React memoisation downstream
@@ -93,11 +140,14 @@ export function applyObjectChanges(
   }
   const normalize = getEntry(obj.type)?.normalizeChanges;
   const normalized = normalize ? normalize(obj, changes) : changes;
-  return {
+  const next = {
     ...obj,
     ...normalized,
     props: normalized.props ? Object.assign({}, obj.props, normalized.props) : obj.props,
   } as LabelObject;
+  // Dirty-tracking is centralized in the dirtyTracking middleware (a state diff),
+  // so this mutator no longer stamps dirty itself.
+  return next;
 }
 
 /** Immutable insert-at-index that clamps `idx` into the array's bounds.
@@ -144,11 +194,11 @@ export function cloneChildrenFresh(children: LabelObject[]): LabelObject[] {
         children: cloneChildrenFresh(c.children),
       };
     }
-    return {
+    return dropProvenance({
       ...c,
       id: crypto.randomUUID(),
       props: { ...c.props },
-    } as LabelObject;
+    } as LabelObject);
   });
 }
 
@@ -165,13 +215,13 @@ export function cloneShifted(src: LabelObject, dx: number, dy: number): LabelObj
       children: src.children.map((c) => cloneShifted(c, dx, dy)),
     };
   }
-  return {
+  return dropProvenance({
     ...src,
     id: crypto.randomUUID(),
     x: src.x + dx,
     y: src.y + dy,
     props: { ...src.props },
-  } as LabelObject;
+  } as LabelObject);
 }
 
 /** Clone clipboard entries with fresh ids, shifted by (dx, dy). Fresh ids per

--- a/src/store/labelStore.ts
+++ b/src/store/labelStore.ts
@@ -1,6 +1,7 @@
 import { create, useStore } from 'zustand';
 import { temporal } from 'zundo';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { dirtyTracking } from './dirtyTracking';
 import type { ObjectChanges } from '../types/LabelObject';
 import { PRINTER_PROFILE_FIELDS, printerProfileSchema } from '../types/PrinterProfile';
 import { visitLeavesInPages } from '../lib/objectTree';
@@ -297,6 +298,7 @@ export const temporalPartialize = (state: LabelState) => ({
 
 export const useLabelStore = create<LabelState>()(
   temporal(
+    dirtyTracking(
     persist(
     (set, get, store) => ({
       ...createObjectSlice(set, get, store),
@@ -315,6 +317,7 @@ export const useLabelStore = create<LabelState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: persistPartialize,
     }
+    )
     ),
     {
       partialize: temporalPartialize,

--- a/src/store/slices/labelConfigSlice.ts
+++ b/src/store/slices/labelConfigSlice.ts
@@ -5,6 +5,7 @@ import type { Variable, CsvMapping } from '../../types/Variable';
 import { forgetImport } from '../../lib/csvImport';
 import { dropLegacyFontBindings } from '../../lib/customFonts';
 import { selectPreviewLocksEditor } from '../labelStore.selectors';
+import { configPatchAffectsEmit, dropPageOverlays } from '../labelStore.internals';
 import type { LabelState } from '../labelStore';
 
 export interface LabelConfigSlice {
@@ -33,7 +34,12 @@ export const createLabelConfigSlice: StateCreator<LabelState, [], [], LabelConfi
   setLabelConfig: (config) =>
     set((state) => {
       if (selectPreviewLocksEditor(state)) return {};
-      return { label: { ...state.label, ...config } };
+      const label = { ...state.label, ...config };
+      // An emit-affecting config edit invalidates each page overlay's verbatim
+      // config bytes; drop overlays so those pages regenerate with the new
+      // value (config-segment patching is a later stage).
+      if (!configPatchAffectsEmit(state.label, config)) return { label };
+      return { label, pages: dropPageOverlays(state.pages) };
     }),
 
   loadDesign: (label, pages, variables, csvMapping) => {
@@ -58,7 +64,10 @@ export const createLabelConfigSlice: StateCreator<LabelState, [], [], LabelConfi
     set((state) => {
       if (selectPreviewLocksEditor(state)) return {};
       if (pages.length === 0) return {};
-      const newPages = [...state.pages, ...pages];
+      // Strip overlays from appended pages: they are recontextualized into the
+      // current design (whose label config replaces the imported one), so their
+      // captured source config/^FN bytes no longer apply and must regenerate.
+      const newPages = [...state.pages, ...dropPageOverlays(pages)];
       return {
         pages: newPages,
         currentPageIndex: state.pages.length,

--- a/src/store/slices/objectSlice.ts
+++ b/src/store/slices/objectSlice.ts
@@ -128,7 +128,11 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
       if (findAncestors(objs, id).some((g) => !!g.locked)) return {};
       // Wholesale node replacement, so registry normalizeChanges is bypassed by
       // design; the mapper owns the result's validity (line/box have no hook).
-      return updateCurrentObjects(state, (curr) => mapObjectById(curr, id, mapper));
+      // The type/props change is stamped dirty centrally by the dirtyTracking
+      // middleware.
+      return updateCurrentObjects(state, (curr) =>
+        mapObjectById(curr, id, (o) => mapper(o)),
+      );
     }),
 
   updateObjects: (updates) =>
@@ -486,22 +490,9 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
       if (index < 0 || index >= state.pages.length) return {};
       const source = state.pages[index];
       if (!source) return {};
-      const cloned: Page = {
-        objects: source.objects.map((o) => {
-          if (isGroup(o)) {
-            return {
-              ...o,
-              id: crypto.randomUUID(),
-              children: cloneChildrenFresh(o.children),
-            };
-          }
-          return {
-            ...o,
-            id: crypto.randomUUID(),
-            props: { ...o.props },
-          } as LabelObject;
-        }),
-      };
+      // Fresh ids + dropped provenance: the clone is net-new (no overlay), so
+      // it regenerates from the model. Omitting `overlay` keeps it that way.
+      const cloned: Page = { objects: cloneChildrenFresh(source.objects) };
       const insertPos = index + 1;
       const newPages = [
         ...state.pages.slice(0, insertPos),

--- a/src/store/slices/variablesSlice.ts
+++ b/src/store/slices/variablesSlice.ts
@@ -14,6 +14,7 @@ import {
   substituteTemplateMarkers,
   applyObjectChanges,
   updateCurrentObjects,
+  dropPageOverlays,
 } from '../labelStore.internals';
 import { selectPreviewLocksEditor, currentObjects } from '../labelStore.selectors';
 import type { LabelState } from '../labelStore';
@@ -102,16 +103,26 @@ export const createVariablesSlice: StateCreator<LabelState, [], [], VariablesSli
       const next: Partial<LabelState> = {
         variables: state.variables.map((v) => (v.id === id ? { ...v, ...patched } : v)),
       };
+      let pages = state.pages;
       // Rename ripple: every `«oldName»` marker in any object's content
       // needs to point at the new name, otherwise the templates dangle.
       if (patched.name !== undefined && patched.name !== existing.name) {
         const oldName = existing.name;
         const newName = patched.name;
-        next.pages = state.pages.map((page) => ({
+        pages = pages.map((page) => ({
           ...page,
           objects: rewriteTemplateMarkers(page.objects, oldName, newName),
         }));
       }
+      // fnNumber / defaultValue feed both inline ^FN{n}^FD{default} (single-bind)
+      // and the header ^FN declarations of marker-based template fields, the
+      // latter living in raw overlay segments. Drop overlays so those pages
+      // regenerate the headers instead of replaying stale ones.
+      const fnChanged = patched.fnNumber !== undefined && patched.fnNumber !== existing.fnNumber;
+      const defChanged =
+        patched.defaultValue !== undefined && patched.defaultValue !== existing.defaultValue;
+      if (fnChanged || defChanged) pages = dropPageOverlays(pages);
+      if (pages !== state.pages) next.pages = pages;
       return next;
     }),
 
@@ -130,12 +141,15 @@ export const createVariablesSlice: StateCreator<LabelState, [], [], VariablesSli
       const ancestorLocked = findAncestors(currentObjects(state), objectId).some(
         (g) => !!g.locked,
       );
-      const pages = updateCurrentObjects(state, (curr) =>
+      const updated = updateCurrentObjects(state, (curr) =>
         mapObjectById(curr, objectId, (obj) =>
           applyObjectChanges(obj, objectChanges, ancestorLocked),
         ),
       );
-      return { variables, ...pages };
+      // The new default feeds every field reading this variable (other binds and
+      // «name» template headers, some in raw overlay segments), so drop overlays
+      // for a full regen, matching updateVariable's default-change path.
+      return { variables, pages: dropPageOverlays(updated.pages) };
     }),
 
   setVariables: (variables) =>
@@ -174,9 +188,13 @@ export const createVariablesSlice: StateCreator<LabelState, [], [], VariablesSli
         );
         nextMapping = { ...state.csvMapping, bindings: rest };
       }
+      // Drop overlays too: a deleted variable's ^FN declaration may sit in a raw
+      // overlay segment with no bound object to dirty, so a full regen is the
+      // only way to remove it from export.
+      const finalPages = dropPageOverlays(pagesChanged ? nextPages : state.pages);
       return {
         variables: state.variables.filter((v) => v.id !== id),
-        ...(pagesChanged ? { pages: nextPages } : {}),
+        ...(finalPages !== state.pages ? { pages: finalPages } : {}),
         ...(nextMapping !== state.csvMapping ? { csvMapping: nextMapping } : {}),
       };
     }),

--- a/src/types/Group.ts
+++ b/src/types/Group.ts
@@ -1,5 +1,6 @@
 import type { LeafObject } from '../registry/leafObject';
 import type { LabelObjectBase } from './LabelObject';
+import type { BlockOverlay } from '../lib/zplOverlay/overlay';
 export type { LeafObject };
 /** Non-leaf container; cascades lock/visibility/inclusion. Intentionally
  *  outside the registry (no toZPL/defaultSize/PropertiesPanel). */
@@ -14,6 +15,11 @@ export type LabelObject = LeafObject | GroupObject;
 
 export interface Page {
   objects: LabelObject[];
+  /** Source-patch overlay of the ^XA…^XZ block this page was imported from,
+   *  letting export replay untouched bytes verbatim. Absent on fresh designs
+   *  and on pages the parser couldn't fully link; those regenerate from the
+   *  model. Rides persist + zundo as part of the page. */
+  overlay?: BlockOverlay;
 }
 
 export function isGroup(obj: LabelObject): obj is GroupObject {
@@ -116,6 +122,8 @@ export function stripVariableIdFromObjects(
     }
     if (o.variableId !== variableId) return o;
     changed = true;
+    // Unbinding switches ^FN→^FD output; the dirtyTracking middleware stamps
+    // dirty centrally from the variableId change.
     const cleared: LabelObject = { ...o };
     delete cleared.variableId;
     return cleared;

--- a/src/types/LabelObject.ts
+++ b/src/types/LabelObject.ts
@@ -33,6 +33,13 @@ export const labelObjectBaseSchema = z.object({
    *  prop is kept as fallback when the binding is removed. Exported
    *  as `^FN{n}^FD{default}^FS` instead of plain `^FD{content}^FS`. */
   variableId: z.string().optional(),
+  /** Lossless round-trip provenance: set once an imported object diverges from
+   *  its source bytes, so the page overlay regenerates it instead of replaying
+   *  the original segment verbatim. Absent for net-new and untouched objects.
+   *  Stamped centrally by the dirtyTracking store middleware. Transient state,
+   *  so a corrupt persisted value drops to undefined rather than failing the
+   *  whole design-file load. */
+  dirty: z.boolean().optional().catch(undefined),
 });
 
 export type LabelObjectBase = z.infer<typeof labelObjectBaseSchema>;


### PR DESCRIPTION
Imported ZPL is sliced into ordered source segments per block; export replays untouched fields, config, comments and whitespace byte-identically and only regenerates edited, added or removed objects. Dirty-tracking is centralized in a store middleware, and setup/device-action commands that run on the printer when re-emitted are surfaced as a replay-risk finding.