### PR TITLE
feat(canvas): off-label preflight marking + ^LS-direction fix

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -22,12 +22,11 @@ import { Select } from "../ui/Select";
 import type { SnapGuide } from "../../lib/snapGuides";
 import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/align";
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
-import { objectBoundsDots, selectionUnionDots } from "../../lib/objectBounds";
+import { objectBoundsDots, selectionUnionDots, isOutOfBounds, printableRectDots } from "../../lib/objectBounds";
 import { rotateSelectionChanges } from "../../lib/groupRotation";
 import { selectTidyTargets } from "../../lib/tidyClassify";
 import { safeAreaRectDots } from "../../lib/safeArea";
 import { measuredBoundsMap, subscribeMeasuredBounds, getMeasuredSnapshot } from "./measuredBoundsCache";
-import { mmToDots } from "../../lib/coordinates";
 import { isEditableTarget } from "../../lib/dom";
 import { KonvaObject } from "./KonvaObject";
 import { CAPTURE_CHROME } from "./konvaObjectProps";
@@ -155,6 +154,10 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   // (stage space, outside the group).
   const [dragGuides, setDragGuides] = useState<SnapGuide[]>([]);
   const [ghost, setGhost] = useState<LeafObject | null>(null);
+  // While dragging, object positions live on the Konva nodes (the store only
+  // commits on drag-end), so the store-derived off-label outline would freeze at
+  // the start position. Hide it during the drag; it recomputes correctly on drop.
+  const [isDragging, setIsDragging] = useState(false);
 
   // Bypasses @dnd-kit scroll-adjusted delta; palette scroll momentum
   // would otherwise offset touch-device drops.
@@ -328,8 +331,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const usableWidth = containerSize.width - RULER_SIZE;
   const usableHeight = containerSize.height - RULER_SIZE;
 
-  // ^LS shifts all content to the right by labelShift dots. The label rect
-  // grows by that amount so the shifted content is fully visible.
+  // ^LS shifts content LEFT by labelShift (spec/Labelary): model x=0 sits at the
+  // viewport left, the physical label rect sits labelShift dots to its right. The
+  // viewport is widened by labelShift so off-label-left content stays visible.
   const labelShiftMm = (label.labelShift ?? 0) / label.dpmm;
   const effectiveWidthMm = label.widthMm + labelShiftMm;
 
@@ -368,21 +372,34 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
 
   const scale = SCREEN_PX_PER_MM * zoom;
   const labelWidthPx = effectiveWidthMm * scale;
+  const physicalWidthPx = label.widthMm * scale;
   const labelHeightPx = label.heightMm * scale;
   const labelOffsetX = RULER_SIZE + (usableWidth - labelWidthPx) / 2 + panOffset.x;
   const labelShiftPx = labelShiftMm * scale;
-  const objectsOffsetX = labelOffsetX + labelShiftPx;
+  // model x=0 at the viewport left; the physical label rect sits labelShift right.
+  const objectsOffsetX = labelOffsetX;
+  const physicalLabelX = labelOffsetX + labelShiftPx;
   const labelOffsetY = RULER_SIZE + (usableHeight - labelHeightPx) / 2 + panOffset.y;
 
   // Visual label geometry after view rotation (axes swap at 90°/270°).
   // The Konva Group rotates around the label center, so the visual size
-  // swaps width/height while the center stays put.
+  // swaps width/height while the center stays put. Uses the effective (model)
+  // width so the ruler stays aligned to model x=0 under ^LS; the white paper
+  // rect inside it is the physical label (physicalLabelX/physicalWidthPx).
   const labelCenterX = labelOffsetX + labelWidthPx / 2;
   const labelCenterY = labelOffsetY + labelHeightPx / 2;
   const visualLabelWidthPx = axisSwapped ? labelHeightPx : labelWidthPx;
   const visualLabelHeightPx = axisSwapped ? labelWidthPx : labelHeightPx;
   const visualLabelX = labelCenterX - visualLabelWidthPx / 2;
   const visualLabelY = labelCenterY - visualLabelHeightPx / 2;
+  // Resize / line-endpoint snap targets the PHYSICAL paper (model x=labelShift),
+  // matching move-snap and the out-of-bounds rect, so every "snap to label edge"
+  // agrees under ^LS. Rotation-aware like visualLabel*; identical when labelShift=0.
+  const physicalCenterX = physicalLabelX + physicalWidthPx / 2;
+  const physicalVisualWidthPx = axisSwapped ? labelHeightPx : physicalWidthPx;
+  const physicalVisualHeightPx = axisSwapped ? physicalWidthPx : labelHeightPx;
+  const physicalVisualX = physicalCenterX - physicalVisualWidthPx / 2;
+  const physicalVisualY = labelCenterY - physicalVisualHeightPx / 2;
   const rulerWidthMm = axisSwapped ? label.heightMm : effectiveWidthMm;
   const rulerHeightMm = axisSwapped ? effectiveWidthMm : label.heightMm;
   const rulerReversal = axisReversal(viewRotation);
@@ -429,12 +446,12 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const transformerSnapLabelRect = useMemo(
     () => ({
       id: "_lbl",
-      x: visualLabelX,
-      y: visualLabelY,
-      width: visualLabelWidthPx,
-      height: visualLabelHeightPx,
+      x: physicalVisualX,
+      y: physicalVisualY,
+      width: physicalVisualWidthPx,
+      height: physicalVisualHeightPx,
     }),
-    [visualLabelX, visualLabelY, visualLabelWidthPx, visualLabelHeightPx],
+    [physicalVisualX, physicalVisualY, physicalVisualWidthPx, physicalVisualHeightPx],
   );
 
   // Group frame from selectionUnionDots so it matches the snap borders.
@@ -473,6 +490,15 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const selectionFrameBase = isMultiFrame ? toFramePx(selectionUnionDots(objects, visibleSelIds, frameCtx)) : null;
   const movableFrameBase = hasSelection ? toFramePx(selectionUnionDots(objects, movableSelIds, frameCtx)) : null;
   const staticFrameBase = hasSelection ? toFramePx(selectionUnionDots(objects, staticSelIds, frameCtx)) : null;
+  // Objects whose bbox exceeds the printable label rect: the printer clips
+  // off-label content (^PW/^LL), so outline them red as a preflight warning.
+  const outOfBoundsMarks = previewLocks || isDragging
+    ? []
+    : visibleLeaves.flatMap((l) => {
+        if (!isOutOfBounds(l, frameCtx)) return [];
+        const rect = toFramePx(objectBoundsDots(l, frameCtx));
+        return rect ? [{ id: l.id, rect }] : [];
+      });
   // Sub-outlines mark group members; per group, split visible leaves
   // movable/static (mirrors the main frame).
   const movableGroupRects: { x: number; y: number; width: number; height: number }[] = [];
@@ -625,8 +651,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
           .filter((o): o is LabelObject => o !== undefined && !o.locked && o.visible !== false);
         if (movable.length === 0) return null;
 
-        const labelWDots = mmToDots(state.label.widthMm, state.label.dpmm);
-        const labelHDots = mmToDots(state.label.heightMm, state.label.dpmm);
+        const printable = printableRectDots(state.label);
         // Exclude structural primitives (full-label frame, spanning dividers) so
         // they neither inflate the reference nor get rearranged; content only,
         // consistent with tidy. Falls back to all when fewer than 2 content.
@@ -635,7 +660,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
           type: isGroup(o) ? "group" : o.type,
           box: objectBoundsDots(o, ctx),
         }));
-        const contentIds = new Set(selectTidyTargets(items, labelWDots, labelHDots));
+        const contentIds = new Set(selectTidyTargets(items, printable.width, printable.height));
         const content = movable.filter((o) => contentIds.has(o.id));
         const contentIdList = content.map((o) => o.id);
         const boxes: AlignBox[] = items
@@ -643,13 +668,8 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
           .map((it) => ({ id: it.id, ...it.box }));
 
         // Align-to-label pins to the safe-area inset when configured, so the
-        // 6-edge buttons keep a uniform margin; otherwise the full label rect.
-        const labelBox = safeAreaRectDots(state.label) ?? {
-          x: 0,
-          y: 0,
-          width: labelWDots,
-          height: labelHDots,
-        };
+        // 6-edge buttons keep a uniform margin; otherwise the printable rect.
+        const labelBox = safeAreaRectDots(state.label) ?? printable;
         let refBox: ReturnType<typeof selectionUnionDots>;
         // A single unit (one object or one group) has no meaningful "selection"
         // or "key" frame of its own, so it aligns to the label (Figma: a single
@@ -1245,9 +1265,11 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
             // size so onDelta re-measures fresh for this selection.
             dragActiveRef.current = !!id && !!findObjectById(getCurrentObjects(), id);
             barHalfRef.current = { w: 0, h: 0 };
+            setIsDragging(true);
           }}
           onDragEnd={() => {
             dragActiveRef.current = false;
+            setIsDragging(false);
           }}
         >
           {/* Object layer */}
@@ -1263,9 +1285,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
             >
               <Rect
                 ref={labelPaperRef}
-                x={labelOffsetX}
+                x={physicalLabelX}
                 y={labelOffsetY}
-                width={labelWidthPx}
+                width={physicalWidthPx}
                 height={labelHeightPx}
                 fill="white"
                 // Preview: amber glow matches the Labelary-warning palette.
@@ -1309,9 +1331,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
                 previewImg && (
                   <KImage
                     image={previewImg}
-                    x={labelOffsetX}
+                    x={physicalLabelX}
                     y={labelOffsetY}
-                    width={labelWidthPx}
+                    width={physicalWidthPx}
                     height={labelHeightPx}
                     listening={false}
                   />
@@ -1344,6 +1366,22 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
                   />
                 ))
               )}
+
+              {/* Off-label preflight: red outline where an object exceeds the
+                  printable rect (printer clips it). Non-interactive chrome. */}
+              {outOfBoundsMarks.map((m) => (
+                <Rect
+                  key={`oob-${m.id}`}
+                  name={CAPTURE_CHROME}
+                  x={m.rect.x}
+                  y={m.rect.y}
+                  width={m.rect.width}
+                  height={m.rect.height}
+                  stroke={colors.error}
+                  strokeWidth={1.5}
+                  listening={false}
+                />
+              ))}
 
               {!previewLocks && ghost && (
                 <Group opacity={0.5} listening={false}>

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -22,7 +22,7 @@ import { Select } from "../ui/Select";
 import type { SnapGuide } from "../../lib/snapGuides";
 import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/align";
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
-import { objectBoundsDots, selectionUnionDots, isOutOfBounds, printableRectDots } from "../../lib/objectBounds";
+import { objectBoundsDots, selectionUnionDots, isBoxOutOfBounds, printableRectDots } from "../../lib/objectBounds";
 import { rotateSelectionChanges } from "../../lib/groupRotation";
 import { selectTidyTargets } from "../../lib/tidyClassify";
 import { safeAreaRectDots } from "../../lib/safeArea";
@@ -495,8 +495,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const outOfBoundsMarks = previewLocks || isDragging
     ? []
     : visibleLeaves.flatMap((l) => {
-        if (!isOutOfBounds(l, frameCtx)) return [];
-        const rect = toFramePx(objectBoundsDots(l, frameCtx));
+        const box = objectBoundsDots(l, frameCtx);
+        if (!isBoxOutOfBounds(box, frameCtx.label)) return [];
+        const rect = toFramePx(box);
         return rect ? [{ id: l.id, rect }] : [];
       });
   // Sub-outlines mark group members; per group, split visible leaves

--- a/src/components/Canvas/dragGeometry.test.ts
+++ b/src/components/Canvas/dragGeometry.test.ts
@@ -10,9 +10,9 @@ describe("labelSnapRectDots", () => {
     });
   });
 
-  it("accounts for the ^LS shift: starts at -shift and is that much wider", () => {
+  it("accounts for the ^LS shift: content shifts left, window starts at +shift", () => {
     expect(labelSnapRectDots({ widthMm: 10, heightMm: 5, dpmm: 8, labelShift: 12 })).toEqual({
-      id: "_lbl", x: -12, y: 0, width: 92, height: 40,
+      id: "_lbl", x: 12, y: 0, width: 80, height: 40,
     });
   });
 });

--- a/src/components/Canvas/dragGeometry.ts
+++ b/src/components/Canvas/dragGeometry.ts
@@ -3,25 +3,17 @@
 // stage and the controller stays a thin imperative layer.
 
 import { computeSnap, type SnapGuide, type SnapRect } from "../../lib/snapGuides";
-import type { BoundingBoxDots } from "../../lib/objectBounds";
-import { mmToDots } from "../../lib/coordinates";
+import { printableRectDots, type BoundingBoxDots } from "../../lib/objectBounds";
 
-/** Printable-area snap rect (dots). ^LS shifts content right by labelShift, so
- *  the area starts at -labelShift in object space and is that much wider. */
+/** Printable-area snap rect (dots), the {@link printableRectDots} rect tagged
+ *  with the snap id so it shares one source with the out-of-bounds check. */
 export function labelSnapRectDots(label: {
   widthMm: number;
   heightMm: number;
   dpmm: number;
   labelShift?: number;
 }): SnapRect {
-  const shift = label.labelShift ?? 0;
-  return {
-    id: "_lbl",
-    x: shift ? -shift : 0,
-    y: 0,
-    width: mmToDots(label.widthMm, label.dpmm) + shift,
-    height: mmToDots(label.heightMm, label.dpmm),
-  };
+  return { id: "_lbl", ...printableRectDots(label) };
 }
 
 /** Round to the nearest grid multiple; identity when the grid is off. */

--- a/src/components/Palette/ObjectPalette.tsx
+++ b/src/components/Palette/ObjectPalette.tsx
@@ -7,7 +7,7 @@ import { addablesInGroup, resolveAddable, type AddableEntry } from '../../regist
 import { PALETTE_TYPES, variantsOfType } from '../../registry/paletteTypes';
 import { useT } from '../../lib/useT';
 import { useLabelStore } from '../../store/labelStore';
-import { mmToDots } from '../../lib/coordinates';
+import { printableRectDots } from '../../lib/objectBounds';
 import { resolveDefaultSizeDots } from '../../lib/resolveDefaultSize';
 import { DragHandleIcon } from '../ui/DragHandleIcon';
 import { CollapsibleSection } from '../ui/CollapsibleSection';
@@ -27,16 +27,18 @@ function typeLabel(typeId: string, t: Translations): string {
   }
 }
 
-/** Drop an entry centred on the label (double-click / "no drag" path). */
+/** Drop an entry centred on the visible (printable) label area, which ^LS can
+ *  shift off the physical center (double-click / "no drag" path). */
 function spawnCentered(entry: AddableEntry) {
   const addObject = useLabelStore.getState().addObject;
   const { label } = useLabelStore.getState();
   const size = resolveDefaultSizeDots(entry.defaultSize, label);
+  const r = printableRectDots(label);
   addObject(
     entry.type,
     {
-      x: Math.round(mmToDots(label.widthMm, label.dpmm) / 2 - size.width / 2),
-      y: Math.round(mmToDots(label.heightMm, label.dpmm) / 2 - size.height / 2),
+      x: Math.round(r.x + r.width / 2 - size.width / 2),
+      y: Math.round(r.y + r.height / 2 - size.height / 2),
     },
     entry.propsOverride,
   );

--- a/src/lib/objectBounds.test.ts
+++ b/src/lib/objectBounds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { objectBoundsDots, selectionUnionDots, barcodeFtAnchorOffset, type ObjectBoundsCtx } from "./objectBounds";
+import { objectBoundsDots, selectionUnionDots, barcodeFtAnchorOffset, isOutOfBounds, type ObjectBoundsCtx } from "./objectBounds";
 import type { ZplRotation } from "../registry/rotation";
 import { QR_FT_MODULE_OFFSET } from "./bwipConstants";
 import type { LabelConfig } from "../types/LabelConfig";
@@ -355,5 +355,47 @@ describe("barcode ^FT rotation anchor", () => {
     // so x is not stuck at the field origin (would desync from the rendered box).
     expect(fp("I")).toMatchObject({ x: 100, y: 300 }); // x = 400 - 300
     expect(fp("B")).toMatchObject({ x: 300, y: 0 }); // x = 400 - 100, y = 300 - 300
+  });
+});
+
+describe("isOutOfBounds", () => {
+  // label 100x50mm @ 8dpmm = 800x400 dots.
+  const boxAt = (x: number, y: number, width: number, height: number) =>
+    leaf("box", x, y, { width, height, thickness: 3, filled: false, color: "B", rounding: 0 });
+
+  it("fully inside is not out of bounds", () => {
+    expect(isOutOfBounds(boxAt(10, 20, 200, 100), ctx())).toBe(false);
+  });
+
+  it("exact fit to the label rect is not out of bounds", () => {
+    expect(isOutOfBounds(boxAt(0, 0, 800, 400), ctx())).toBe(false);
+  });
+
+  it("crossing the right edge is out of bounds", () => {
+    expect(isOutOfBounds(boxAt(700, 0, 200, 100), ctx())).toBe(true);
+  });
+
+  it("crossing the bottom edge is out of bounds", () => {
+    expect(isOutOfBounds(boxAt(0, 350, 100, 100), ctx())).toBe(true);
+  });
+
+  it("a negative origin is out of bounds (left/top edge)", () => {
+    expect(isOutOfBounds(boxAt(-5, 10, 50, 50), ctx())).toBe(true);
+  });
+
+  it("respects the half-dot epsilon at the edge", () => {
+    expect(isOutOfBounds(boxAt(0, 0, 800.4, 400), ctx())).toBe(false); // 0.4 overhang tolerated
+    expect(isOutOfBounds(boxAt(0, 0, 800.6, 400), ctx())).toBe(true); // 0.6 overhang flagged
+  });
+
+  it("uses the ^LS printable window (^LS shifts content left, window moves right)", () => {
+    const shifted: ObjectBoundsCtx = { label: { ...label, labelShift: 80 } };
+    // ^LS80 shifts content left by 80, so the valid model window is [80, 880].
+    // A box at x=10 now clips off the left edge.
+    expect(isOutOfBounds(boxAt(10, 10, 50, 50), shifted)).toBe(true);
+    expect(isOutOfBounds(boxAt(10, 10, 50, 50), ctx())).toBe(false); // inside without the shift
+    // The right edge extends to 880: a box at 810..860 is now inside.
+    expect(isOutOfBounds(boxAt(810, 0, 50, 50), shifted)).toBe(false);
+    expect(isOutOfBounds(boxAt(810, 0, 50, 50), ctx())).toBe(true); // out without the shift
   });
 });

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -19,6 +19,7 @@ import { isAxisSwapped, objectRotation, type ZplRotation } from "../registry/rot
 import { resolveTextMode } from "../registry/text";
 import { blockBoundsDots, rotatedLineOffset, tbBoundsDots, zebraLineWidthDots } from "./zebraTextLayout";
 import { resolveDefaultSizeDots } from "./resolveDefaultSize";
+import { mmToDots } from "./coordinates";
 import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "./bwipConstants";
 
 export interface BoundingBoxDots {
@@ -297,4 +298,39 @@ export function selectionUnionDots(
     if (node) boxes.push(objectBoundsDots(node, ctx));
   }
   return unionOf(boxes);
+}
+
+/** Printable-area rect (dots) in object space. ^LS shifts content LEFT by
+ *  labelShift (ZPL spec + Labelary-verified): a field at model x prints at
+ *  x-labelShift, so the visible model window is [labelShift, labelShift+width].
+ *  Single source for the drag-snap boundary and the out-of-bounds check. */
+export function printableRectDots(label: {
+  widthMm: number;
+  heightMm: number;
+  dpmm: number;
+  labelShift?: number;
+}): BoundingBoxDots {
+  const shift = label.labelShift ?? 0;
+  return {
+    x: shift,
+    y: 0,
+    width: mmToDots(label.widthMm, label.dpmm),
+    height: mmToDots(label.heightMm, label.dpmm),
+  };
+}
+
+/** True when any edge of the object's bbox falls outside the printable rect.
+ *  Off-label content is clipped by the printer (^PW/^LL), so this flags a
+ *  likely-cut print. A half-dot epsilon avoids flagging an object resting
+ *  exactly on the edge. */
+export function isOutOfBounds(obj: LabelObject, ctx: ObjectBoundsCtx): boolean {
+  const b = objectBoundsDots(obj, ctx);
+  const r = printableRectDots(ctx.label);
+  const eps = 0.5;
+  return (
+    b.x < r.x - eps ||
+    b.y < r.y - eps ||
+    b.x + b.width > r.x + r.width + eps ||
+    b.y + b.height > r.y + r.height + eps
+  );
 }

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -319,18 +319,26 @@ export function printableRectDots(label: {
   };
 }
 
-/** True when any edge of the object's bbox falls outside the printable rect.
- *  Off-label content is clipped by the printer (^PW/^LL), so this flags a
- *  likely-cut print. A half-dot epsilon avoids flagging an object resting
- *  exactly on the edge. */
-export function isOutOfBounds(obj: LabelObject, ctx: ObjectBoundsCtx): boolean {
-  const b = objectBoundsDots(obj, ctx);
-  const r = printableRectDots(ctx.label);
+/** True when any edge of `box` falls outside the printable rect. The predicate
+ *  on a precomputed bbox, so a caller that already has the bounds (e.g. to also
+ *  draw the outline) doesn't recompute them. A half-dot epsilon avoids flagging
+ *  an object resting exactly on the edge. */
+export function isBoxOutOfBounds(
+  box: BoundingBoxDots,
+  label: Parameters<typeof printableRectDots>[0],
+): boolean {
+  const r = printableRectDots(label);
   const eps = 0.5;
   return (
-    b.x < r.x - eps ||
-    b.y < r.y - eps ||
-    b.x + b.width > r.x + r.width + eps ||
-    b.y + b.height > r.y + r.height + eps
+    box.x < r.x - eps ||
+    box.y < r.y - eps ||
+    box.x + box.width > r.x + r.width + eps ||
+    box.y + box.height > r.y + r.height + eps
   );
+}
+
+/** True when the object's bbox falls outside the printable rect. Off-label
+ *  content is clipped by the printer (^PW/^LL), so this flags a likely-cut print. */
+export function isOutOfBounds(obj: LabelObject, ctx: ObjectBoundsCtx): boolean {
+  return isBoxOutOfBounds(objectBoundsDots(obj, ctx), ctx.label);
 }

--- a/src/lib/safeArea.test.ts
+++ b/src/lib/safeArea.test.ts
@@ -27,4 +27,14 @@ describe("safeAreaRectDots", () => {
     // 30mm inset on a 50mm-tall label leaves negative height.
     expect(safeAreaRectDots({ ...base, safeAreaMm: 30 })).toBeNull();
   });
+
+  it("insets the ^LS printable rect (^LS shifts content left, window at +shift)", () => {
+    // labelShift 80: printable rect x=80, width=800; inset 16 each side.
+    expect(safeAreaRectDots({ ...base, safeAreaMm: 2, labelShift: 80 })).toEqual({
+      x: 80 + 16,
+      y: 16,
+      width: 800 - 32,
+      height: 400 - 32,
+    });
+  });
 });

--- a/src/lib/safeArea.ts
+++ b/src/lib/safeArea.ts
@@ -2,19 +2,21 @@
 // margin in mm, converted to dots, that align/pin and the canvas guide use
 // so elements keep a consistent distance to the label edge.
 
-import type { BoundingBoxDots } from "./objectBounds";
+import { printableRectDots, type BoundingBoxDots } from "./objectBounds";
 import type { LabelConfig } from "../types/LabelConfig";
 import { mmToDots } from "./coordinates";
 
 /** Inset rectangle (dots) for the label's safe area, or null when no safe
- *  area applies: unset/zero margin, or an inset so large the rect collapses. */
+ *  area applies: unset/zero margin, or an inset so large the rect collapses.
+ *  Inset from the printable rect so it stays consistent under ^LS. */
 export function safeAreaRectDots(label: LabelConfig): BoundingBoxDots | null {
   const mm = label.safeAreaMm ?? 0;
   if (mm <= 0) return null;
   const inset = mmToDots(mm, label.dpmm);
   if (inset <= 0) return null;
-  const width = mmToDots(label.widthMm, label.dpmm) - 2 * inset;
-  const height = mmToDots(label.heightMm, label.dpmm) - 2 * inset;
+  const r = printableRectDots(label);
+  const width = r.width - 2 * inset;
+  const height = r.height - 2 * inset;
   if (width <= 0 || height <= 0) return null;
-  return { x: inset, y: inset, width, height };
+  return { x: r.x + inset, y: r.y + inset, width, height };
 }


### PR DESCRIPTION
Red outline for objects outside the printable rect (hidden during drag); ^LS now shifts content left per spec/Labelary (window [labelShift, labelShift+PW]).