### PR TITLE
feat(canvas): single-shape 90deg rotation for box/ellipse/line

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -33,7 +33,7 @@ import { CAPTURE_CHROME } from "./konvaObjectProps";
 import { Grid } from "./Grid";
 import { GuideLines } from "./GuideLines";
 import { Ruler, RULER_SIZE } from "./Ruler";
-import { getEntry } from "../../registry";
+import { getEntry, SHAPE_PRIMITIVE_TYPES } from "../../registry";
 import type { LeafObject } from "../../registry";
 import { PALETTE_GROUPS } from "../Palette/paletteGroups";
 import { addablesInGroup, resolveAddable, type AddableEntry } from "../../registry/palettePresets";
@@ -771,6 +771,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     ? objects.find((o) => o.id === selectedIds[0]) ?? null
     : null;
   const stepRotation = singleSelected ? getStepRotation(singleSelected) : null;
+  // Shape primitives get the single-rotate button too, not only via a group.
+  const singleShapeRotatable =
+    !!singleSelected && !isGroup(singleSelected) && SHAPE_PRIMITIVE_TYPES.has(singleSelected.type);
   const allSelectedLocked = isSelectionLocked(objects, selectedIds);
 
   // Selected leaves whose effective (cascaded) lock is on; each gets an amber
@@ -794,10 +797,18 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   });
 
   const handleRotateStep = () => {
-    if (!singleSelected || !stepRotation) return;
-    updateObject(singleSelected.id, {
-      props: { rotation: nextZplRotation(stepRotation) },
-    });
+    if (!singleSelected || singleSelected.locked) return;
+    if (stepRotation) {
+      // Types with a rotation prop (text/barcode/symbol): step it in place.
+      updateObject(singleSelected.id, {
+        props: { rotation: nextZplRotation(stepRotation) },
+      });
+      return;
+    }
+    // Shapes without a rotation prop (box/ellipse/line): quarter-turn about the
+    // object's own centre via the shared geometry (w/h swap or angle step).
+    const changes = rotateSelectionChanges(objects, [singleSelected.id], frameCtx, 1);
+    if (changes.size > 0) updateObjects([...changes].map(([id, c]) => ({ id, changes: c })));
   };
 
   // Group / multi-select rotate: one clockwise quarter turn about the union
@@ -843,7 +854,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       onClick: () => convertObjectType(singleSelected.id, toggleShapeMode),
     });
   }
-  if (singleSelected && stepRotation && !singleSelected.locked) {
+  if (singleSelected && (stepRotation || singleShapeRotatable) && !singleSelected.locked) {
     actionButtons.push({
       key: "rotate",
       iconPath: ROTATE_ICON,

--- a/src/lib/groupRotation.test.ts
+++ b/src/lib/groupRotation.test.ts
@@ -223,4 +223,16 @@ describe("rotateSelectionChanges", () => {
     expect(m.has(hidden.id)).toBe(false); // off screen, must not rotate or skew pivot
     expect(m.get(vis.id)).toEqual({ x: 0, y: 0, props: { width: 20, height: 20 } });
   });
+
+  it("ellipse 90deg about its own centre swaps w/h (same path as box)", () => {
+    const e = leaf("ellipse", 10, 10, { width: 40, height: 20, thickness: 2, color: "B" }); // centre (30,20)
+    const c = rotateSelectionChanges([e], [e.id], ctx(), 1).get(e.id);
+    expect(c).toEqual({ x: 20, y: 0, props: { width: 20, height: 40 } });
+  });
+
+  it("diagonal line steps its angle by 90deg and re-anchors about its own centre", () => {
+    const ln = leaf("line", 60, 40, { angle: 45, length: 50, thickness: 2, color: "B" });
+    const c = rotateSelectionChanges([ln], [ln.id], ctx(), 1).get(ln.id);
+    expect(c).toEqual({ x: 97, y: 39, props: { angle: 135 } });
+  });
 });

--- a/src/lib/tidyClassify.ts
+++ b/src/lib/tidyClassify.ts
@@ -5,11 +5,9 @@
 // dot bboxes (see objectBounds.ts).
 
 import type { BoundingBoxDots } from "./objectBounds";
+import { SHAPE_PRIMITIVE_TYPES } from "../registry";
 
 export type TidyClass = "frame" | "divider" | "content";
-
-/** Only shape primitives can be structural. */
-const SHAPE_TYPES = new Set(["box", "ellipse", "line"]);
 
 const FRAME_COVERAGE = 0.8;
 const DIVIDER_THIN_DOTS = 8;
@@ -23,7 +21,7 @@ export function classifyForTidy(
   labelWidthDots: number,
   labelHeightDots: number,
 ): TidyClass {
-  if (!SHAPE_TYPES.has(type)) return "content";
+  if (!SHAPE_PRIMITIVE_TYPES.has(type)) return "content";
 
   if (
     (type === "box" || type === "ellipse") &&

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -46,6 +46,15 @@ export const BARCODE_1D_TYPES = new Set([
 
 export const STACKED_2D_TYPES = new Set(['pdf417', 'micropdf417', 'codablock']);
 
+// Graphic shape primitives (no `props.rotation`): box/ellipse/line. They
+// quarter-turn via geometry (w/h swap, or a line's angle), unlike image which
+// shares `group: 'shape'` but cannot turn. Shared by single-object rotation and
+// tidy classification. `satisfies` catches a typo/rename; the Set stays string-
+// keyed so `.has(obj.type)` (a string) type-checks.
+export const SHAPE_PRIMITIVE_TYPES: ReadonlySet<string> = new Set(
+  ['box', 'ellipse', 'line'] as const satisfies readonly LeafType[],
+);
+
 // satisfies = exhaustiveness check; export type stays permissive.
 const _ObjectRegistry = {
   // text


### PR DESCRIPTION
Box/ellipse swap width/height, a line steps its angle, via the shared rotateSelectionChanges geometry. Enables the rotate button for a single shape instead of only groups/multi-select.