### PR TITLE
feat(preflight): producer architecture for print-risk badges

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef } from "react";
-import bwipjs from "bwip-js/browser";
 import { Image as KImage, Group, Rect, Text } from "react-konva";
 import type Konva from "konva";
 import { BARCODE_1D_TYPES, ObjectRegistry } from "../../registry";
@@ -10,13 +9,10 @@ import { useFontCacheVersion } from "../../hooks/useFontCacheVersion";
 import { selectionHandlers, type KonvaObjectProps } from "./konvaObjectProps";
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import {
-  buildBwipOptions,
-  cleanBwipError,
   getDisplaySize,
   get1DBwipScale,
   getEanUpcHriFragments,
-  renderEanUpcRawCanvas,
-  renderTlc39Canvas,
+  renderBarcodeCanvas,
   type BarcodeDisplaySize,
   type EanUpcType,
 } from "./bwipHelpers";
@@ -91,48 +87,9 @@ export function BarcodeObject({
     !ObjectRegistry[obj.type]?.interpretationLocked &&
     !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
 
-  let barcodeCanvas: HTMLCanvasElement | null = null;
-  let errorMsg: string | null = null;
-  if (obj.type === "tlc39") {
-    // bwip-js has no native tlc39 encoder, render the Code 39 + MicroPDF417
-    // composite ourselves. Goes straight to canvas, bypassing buildBwipOptions.
-    barcodeCanvas = renderTlc39Canvas(obj.props, scale, dpmm);
-    if (!barcodeCanvas) errorMsg = "TLC39 render failed";
-  } else if (EAN_UPC_TYPES.has(obj.type)) {
-    // EAN/UPC use bwip.raw + own fillRect pass so guard tails extend in
-    // the same canvas as the bars (no overlay seam). The 13-dot text
-    // zone is always reserved on the canvas so the KImage dimensions
-    // stay constant; the tails only get drawn when HRI is on.
-    const eanHeight = (obj.props as { height: number }).height;
-    const modulePxInt = get1DBwipScale(moduleWidth, scale, dpmm);
-    const barHeightPx = dotsToPx(eanHeight, scale, dpmm);
-    const tailHeightPx = dotsToPx(EAN_TEXT_ZONE_DOTS, scale, dpmm);
-    barcodeCanvas = renderEanUpcRawCanvas({
-      type: obj.type as EanUpcType,
-      text: rawContent,
-      modulePxInt,
-      barHeightPx,
-      tailHeightPx,
-      extendGuards: printInterpEnabled,
-    });
-    if (!barcodeCanvas) errorMsg = "EAN/UPC encode failed";
-  } else {
-    const opts = buildBwipOptions(obj, scale, dpmm);
-    if (opts) {
-      const canvas = document.createElement("canvas");
-      try {
-        // buildBwipOptions returns Record<string, unknown> on purpose: the
-        // option fields differ across barcode types (ean13 vs code128 vs …)
-        // and per-type narrowing would duplicate the switch already in
-        // buildBwipOptions. bwip-js' toCanvas signature uses a strict
-        // literal-string union, so the structural cast bridges the two.
-        bwipjs.toCanvas(canvas, opts as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
-        barcodeCanvas = canvas;
-      } catch (e) {
-        errorMsg = cleanBwipError(e);
-      }
-    }
-  }
+  // Shared with the preflight encode check (barcodeEncodeFindings) so the
+  // displayed placeholder and the badge can't disagree on what's codable.
+  const { canvas: barcodeCanvas, error: errorMsg } = renderBarcodeCanvas(obj, scale, dpmm);
 
   // Single object holding the full ZPL footprint (w/h) and the bar
   // sub-rectangle (barW/barH/barLeftPx/barTopPx). Defaults zero out

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -24,6 +24,7 @@ import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/al
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
 import { objectBoundsDots, selectionUnionDots, printableRectDots } from "../../lib/objectBounds";
 import { computePreflight } from "../../lib/preflight";
+import { barcodeEncodeFindings } from "./barcodePreflight";
 import { rotateSelectionChanges } from "../../lib/groupRotation";
 import { selectTidyTargets } from "../../lib/tidyClassify";
 import { safeAreaRectDots } from "../../lib/safeArea";
@@ -503,7 +504,12 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   // during drag/preview-lock like the rest of the chrome.
   const preflightSuppressed = previewLocks || isDragging;
   const preflightLeaves = preflightSuppressed ? [] : exportableLeaves(objects);
-  const preflightFindings = preflightSuppressed ? [] : computePreflight(preflightLeaves, frameCtx);
+  const preflightFindings = preflightSuppressed
+    ? []
+    : [
+        ...computePreflight(preflightLeaves, frameCtx),
+        ...barcodeEncodeFindings(preflightLeaves, scale, label.dpmm),
+      ];
   // Off-label marks pair each off-label finding with its on-screen bbox: a
   // clipped object gets a solid amber outline, a fully-outside one a dashed red
   // outline with a faint fill. Keyed on the off-label kind (not severity) so a

--- a/src/components/Canvas/PreflightOverlay.tsx
+++ b/src/components/Canvas/PreflightOverlay.tsx
@@ -35,6 +35,11 @@ export function PreflightOverlay({ findings, objects, onSelect }: Props) {
   const kindText: Record<PreflightKind, string> = {
     offLabelOutside: t.preflight.offLabelOutside,
     offLabelClipped: t.preflight.offLabelClipped,
+    renderFailed: t.preflight.renderFailed,
+    blockTooNarrow: t.preflight.blockTooNarrow,
+    barcodeTooSmall: t.preflight.barcodeTooSmall,
+    textOverset: t.preflight.textOverset,
+    imageMissing: t.preflight.imageMissing,
   };
   const nameOf = (id: string) => {
     const o = byId.get(id);
@@ -73,6 +78,7 @@ export function PreflightOverlay({ findings, objects, onSelect }: Props) {
                   key={`${f.objectId}-${i}`}
                   type="button"
                   role="menuitem"
+                  title={f.detail || undefined}
                   onClick={() => {
                     onSelect(f.objectId);
                     setOpen(false);
@@ -80,7 +86,10 @@ export function PreflightOverlay({ findings, objects, onSelect }: Props) {
                   className="flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-surface-2 transition-colors"
                 >
                   <Icon className={`w-3.5 h-3.5 shrink-0 ${tone}`} />
-                  <span className="truncate text-text">{nameOf(f.objectId)}</span>
+                  <span className="flex flex-col min-w-0">
+                    <span className="truncate text-text">{nameOf(f.objectId)}</span>
+                    {f.detail && <span className="truncate text-[10px] text-muted">{f.detail}</span>}
+                  </span>
                   <span className="ml-auto shrink-0 text-muted">{kindText[f.kind]}</span>
                 </button>
               );

--- a/src/components/Canvas/barcodePreflight.test.ts
+++ b/src/components/Canvas/barcodePreflight.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { barcodeEncodeFindings } from "./barcodePreflight";
+import type { LabelObject } from "../../types/Group";
+import type { LeafObject } from "../../registry";
+
+const bar = (id: string): LeafObject =>
+  ({ id, type: "code128", x: 0, y: 0, rotation: 0,
+     props: { content: "X", height: 50, moduleWidth: 2, printInterpretation: false, checkDigit: false, rotation: "N" } } as LabelObject as LeafObject);
+
+describe("barcodeEncodeFindings", () => {
+  it("maps an encode error to a renderFailed finding over all given leaves", () => {
+    const leaves = [bar("a"), bar("b")];
+    // Inject the encoder so the mapping is tested without the DOM bwip encoder;
+    // this also proves a hidden-but-exported leaf is checked (no visibility gate).
+    const out = barcodeEncodeFindings(leaves, 1, 8, (l) => (l.id === "a" ? "too much data" : null));
+    expect(out).toEqual([
+      { objectId: "a", kind: "renderFailed", severity: "error", detail: "too much data" },
+    ]);
+  });
+
+  it("returns nothing when every leaf encodes", () => {
+    expect(barcodeEncodeFindings([bar("a")], 1, 8, () => null)).toEqual([]);
+  });
+});

--- a/src/components/Canvas/barcodePreflight.ts
+++ b/src/components/Canvas/barcodePreflight.ts
@@ -1,0 +1,36 @@
+import type { LeafObject } from "../../registry";
+import { PREFLIGHT_SEVERITY, type PreflightFinding } from "../../lib/preflight";
+import { renderBarcodeCanvas } from "./bwipHelpers";
+
+// Cache the encode verdict per object identity. The store is identity-preserving,
+// so an unedited barcode keeps its reference and is not re-encoded when a
+// sibling changes (editing one object would otherwise re-encode the whole page).
+const encodeCache = new WeakMap<LeafObject, { scale: number; dpmm: number; error: string | null }>();
+
+function cachedEncodeError(leaf: LeafObject, scale: number, dpmm: number): string | null {
+  const hit = encodeCache.get(leaf);
+  if (hit && hit.scale === scale && hit.dpmm === dpmm) return hit.error;
+  const error = renderBarcodeCanvas(leaf, scale, dpmm).error;
+  encodeCache.set(leaf, { scale, dpmm, error });
+  return error;
+}
+
+/** Encode check over ALL exportable leaves, not just rendered ones, so a
+ *  hidden-but-exported barcode with an uncodable payload (QR overflow, invalid
+ *  EAN, ...) still badges. Lives at the canvas layer because the encoder does.
+ *  `encodeError` is injectable so the mapping is testable without the encoder. */
+export function barcodeEncodeFindings(
+  leaves: readonly LeafObject[],
+  scale: number,
+  dpmm: number,
+  encodeError: (leaf: LeafObject) => string | null = (leaf) => cachedEncodeError(leaf, scale, dpmm),
+): PreflightFinding[] {
+  const findings: PreflightFinding[] = [];
+  for (const leaf of leaves) {
+    const error = encodeError(leaf);
+    if (error) {
+      findings.push({ objectId: leaf.id, kind: "renderFailed", severity: PREFLIGHT_SEVERITY.renderFailed, detail: error });
+    }
+  }
+  return findings;
+}

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -2,7 +2,7 @@
 // canvas. Per-symbology rationale lives at each case in getUprightDisplaySize.
 
 import bwipjs from "bwip-js/browser";
-import { type LeafObject } from "../../registry";
+import { getEntry, type LeafObject } from "../../registry";
 import { barcodeTextZoneDots, barcodeZoneAbove } from "../../lib/barcodeHri";
 import { upceData6FromFd } from "../../registry/hriFormatters";
 import type { LabelObject } from "../../types/Group";
@@ -20,6 +20,7 @@ import {
   CODE11_QUIET_ZONE_DELTA_MODULES,
   CODE93_QUIET_ZONE_DELTA_MODULES,
   EAN_TEXT_ZONE_DOTS,
+  EAN_UPC_TYPES,
   GS1_DATABAR_PADDING_ROWS,
   GS1_DATABAR_SPEC_HEIGHT_MODULES,
   LOGMARS_TEXT_ZONE_DOTS,
@@ -958,4 +959,43 @@ export function renderTlc39Canvas(
   ctx.drawImage(mpdfSrc, 0, 0, w, mpdfPxH);
   ctx.drawImage(code39Src, 0, mpdfPxH, w, code39PxH);
   return composite;
+}
+
+/** Single source for encoding an object as a barcode at `scale`: used by the
+ *  canvas display AND the preflight encode check. Returns the rendered canvas
+ *  (null on failure) and a cleaned error message (null on success). A
+ *  non-barcode type yields {canvas:null, error:null}. */
+export function renderBarcodeCanvas(
+  obj: LeafObject,
+  scale: number,
+  dpmm: number,
+): { canvas: HTMLCanvasElement | null; error: string | null } {
+  if (obj.type === "tlc39") {
+    const canvas = renderTlc39Canvas(obj.props as Parameters<typeof renderTlc39Canvas>[0], scale, dpmm);
+    return { canvas, error: canvas ? null : "TLC39 render failed" };
+  }
+  if (EAN_UPC_TYPES.has(obj.type)) {
+    const moduleWidth = (obj.props as { moduleWidth?: number }).moduleWidth ?? 2;
+    const printInterpEnabled =
+      !getEntry(obj.type)?.interpretationLocked &&
+      !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
+    const canvas = renderEanUpcRawCanvas({
+      type: obj.type as EanUpcType,
+      text: (obj.props as { content?: string }).content ?? "",
+      modulePxInt: get1DBwipScale(moduleWidth, scale, dpmm),
+      barHeightPx: dotsToPx((obj.props as { height: number }).height, scale, dpmm),
+      tailHeightPx: dotsToPx(EAN_TEXT_ZONE_DOTS, scale, dpmm),
+      extendGuards: printInterpEnabled,
+    });
+    return { canvas, error: canvas ? null : "EAN/UPC encode failed" };
+  }
+  const opts = buildBwipOptions(obj, scale, dpmm);
+  if (!opts) return { canvas: null, error: null };
+  const canvas = document.createElement("canvas");
+  try {
+    bwipjs.toCanvas(canvas, opts as unknown as Parameters<typeof bwipjs.toCanvas>[1]);
+    return { canvas, error: null };
+  } catch (e) {
+    return { canvas: null, error: cleanBwipError(e) };
+  }
 }

--- a/src/lib/barcodeScannability.ts
+++ b/src/lib/barcodeScannability.ts
@@ -1,0 +1,23 @@
+import type { PreflightCtx, PreflightProducerResult } from "../types/preflight";
+
+/** Recommended minimum barcode module / X-dimension in mm for reliable general
+ *  scanning, per GS1/AIM guidance (~0.25 mm). Below this the preflight warns.
+ *  Shared floor for 1D X-dimension and 2D cell size. */
+export const MIN_BARCODE_MODULE_MM = 0.25;
+
+/** A `barcodeTooSmall` finding when the module size (dots) is below the minimum
+ *  scannable X-dimension at the device density. Used by every 1D and 2D type. */
+export function moduleTooSmallFindings(moduleDots: number, dpmm: number): PreflightProducerResult[] {
+  const mm = moduleDots / dpmm;
+  if (!(mm < MIN_BARCODE_MODULE_MM)) return []; // also short-circuits NaN/Infinity
+  return [{ kind: "barcodeTooSmall", detail: `${mm.toFixed(2)} mm (min ${MIN_BARCODE_MODULE_MM} mm)` }];
+}
+
+/** Curried registry `preflight` producer: warns when the named module-size prop
+ *  (e.g. moduleWidth, magnification, dimension) is below the min X-dimension.
+ *  One source for the scannability check every 1D/2D barcode type registers. */
+export function moduleTooSmallPreflight<P extends object>(
+  prop: keyof P & string,
+): (obj: { props: P }, ctx: PreflightCtx) => PreflightProducerResult[] {
+  return (obj, ctx) => moduleTooSmallFindings(obj.props[prop] as number, ctx.label.dpmm);
+}

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computePreflight } from "./preflight";
+import { getEntry } from "../registry";
 import type { ObjectBoundsCtx } from "./objectBounds";
 import type { LabelObject } from "../types/Group";
 import type { LeafObject } from "../registry";
@@ -115,5 +116,79 @@ describe("computePreflight (off-label producer)", () => {
       ["clip", "offLabelClipped"],
       ["out", "offLabelOutside"],
     ]);
+  });
+});
+
+describe("per-type producers (registry preflight capability)", () => {
+  const textLeaf = (props: object): LeafObject =>
+    ({ id: "t", type: "text", x: 0, y: 0, rotation: 0, props } as LabelObject as LeafObject);
+  const bar = (moduleWidth: number): LeafObject =>
+    ({
+      id: "bc", type: "code128", x: 100, y: 100, rotation: 0,
+      props: { content: "X", height: 50, moduleWidth, printInterpretation: false, checkDigit: false, rotation: "N" },
+    } as LabelObject as LeafObject);
+
+  it("text: a block narrower than one glyph cell flags blockTooNarrow", () => {
+    const narrow = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 2 }), { label });
+    expect(narrow).toEqual([{ kind: "blockTooNarrow" }]);
+  });
+
+  it("text: a wide block and a plain (normal) field flag nothing", () => {
+    const wide = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 200 }), { label });
+    const normal = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0 }), { label });
+    expect(wide).toEqual([]);
+    expect(normal).toEqual([]);
+  });
+
+  it("barcode: a module below the min X-dimension flags barcodeTooSmall", () => {
+    // moduleWidth 1 @ 8 dpmm = 0.125 mm < 0.25 mm.
+    const small = getEntry("code128")!.preflight!(bar(1), { label });
+    expect(small).toEqual([{ kind: "barcodeTooSmall", detail: "0.13 mm (min 0.25 mm)" }]);
+  });
+
+  it("barcode: a module at/above the min X-dimension flags nothing", () => {
+    // moduleWidth 2 @ 8 dpmm = 0.25 mm.
+    expect(getEntry("code128")!.preflight!(bar(2), { label })).toEqual([]);
+  });
+
+  it("computePreflight stamps objectId + severity from a producer finding", () => {
+    expect(computePreflight([bar(1)], ctx)).toContainEqual({
+      objectId: "bc", kind: "barcodeTooSmall", severity: "warning", detail: "0.13 mm (min 0.25 mm)",
+    });
+  });
+
+  it("2D: a QR magnification below the min cell size flags barcodeTooSmall", () => {
+    const qr = (magnification: number): LeafObject =>
+      ({ id: "q", type: "qrcode", x: 0, y: 0, rotation: 0,
+         props: { content: "x", magnification, errorCorrection: "Q", model: 2, rotation: "N" } } as LabelObject as LeafObject);
+    // magnification 1 @ 8 dpmm = 0.125 mm < 0.25; magnification 2 = 0.25 mm (ok).
+    expect(getEntry("qrcode")!.preflight!(qr(1), { label })).toEqual([
+      { kind: "barcodeTooSmall", detail: "0.13 mm (min 0.25 mm)" },
+    ]);
+    expect(getEntry("qrcode")!.preflight!(qr(2), { label })).toEqual([]);
+  });
+
+  it("text: ^FB content wrapping past the line cap flags textOverset", () => {
+    const fb = textLeaf({ content: "AAA BBB CCC", fontHeight: 30, fontWidth: 0, blockWidth: 40, blockLines: 1 });
+    expect(getEntry("text")!.preflight!(fb, { label })).toEqual([{ kind: "textOverset" }]);
+  });
+
+  it("text: ^TB content taller than the block height flags textOverset", () => {
+    const tb = textLeaf({ content: "AAA", fontHeight: 30, fontWidth: 0, blockWidth: 200, blockHeight: 10, textMode: "tb" });
+    expect(getEntry("text")!.preflight!(tb, { label })).toEqual([{ kind: "textOverset" }]);
+  });
+
+  it("text: a block with room to spare flags nothing", () => {
+    const ok = textLeaf({ content: "AAA", fontHeight: 30, fontWidth: 0, blockWidth: 400, blockLines: 5 });
+    expect(getEntry("text")!.preflight!(ok, { label })).toEqual([]);
+  });
+
+  it("image: no resolvable bytes flags imageMissing; rawGf resolves", () => {
+    const img = (props: object): LeafObject =>
+      ({ id: "i", type: "image", x: 0, y: 0, rotation: 0, props } as LabelObject as LeafObject);
+    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128 }), { label })).toEqual([
+      { kind: "imageMissing" },
+    ]);
+    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128, rawGf: "^GFA,1,1,1,00" }), { label })).toEqual([]);
   });
 });

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -1,32 +1,21 @@
-import type { LeafObject } from "../registry";
+import { getEntry, type LeafObject } from "../registry";
 import { objectBoundsDots, offLabelPlacement, type ObjectBoundsCtx } from "./objectBounds";
 import { emittedAnchorDots } from "./emittedAnchor";
+import {
+  PREFLIGHT_SEVERITY,
+  type PreflightFinding,
+  type PreflightKind,
+  type PreflightSeverity,
+} from "../types/preflight";
 
-export type PreflightSeverity = "error" | "warning";
-
-/** Distinct preflight problem kinds. Off-label is the first producer; further
- *  producers (approx render, ...) add their own kinds here. */
-export type PreflightKind = "offLabelOutside" | "offLabelClipped";
-
-export interface PreflightFinding {
-  objectId: string;
-  kind: PreflightKind;
-  severity: PreflightSeverity;
-}
-
-/** Single source for kind -> severity so canvas styling and the badge tiering
- *  can't drift apart. */
-export const PREFLIGHT_SEVERITY: Record<PreflightKind, PreflightSeverity> = {
-  offLabelOutside: "error",
-  offLabelClipped: "warning",
-};
+export { PREFLIGHT_SEVERITY };
+export type { PreflightFinding, PreflightKind, PreflightSeverity };
 
 /** Current preflight findings for a page's leaves. Pass the EXPORTABLE leaves
  *  (includeInExport, not editor visibility) so the warnings track what actually
  *  prints. Pure projection of the document, recomputed as geometry and measured
- *  footprints settle. A negative emitted origin maps to the hard
- *  `offLabelOutside`; a right/bottom overflow stays the softer `offLabelClipped`
- *  (see {@link offLabelPlacement}). */
+ *  footprints settle. Runs the geometry (off-label) producer plus each type's
+ *  own `preflight` producer (block-too-narrow, barcode module too small). */
 export function computePreflight(
   leaves: readonly LeafObject[],
   ctx: ObjectBoundsCtx,
@@ -38,6 +27,13 @@ export function computePreflight(
     const kind =
       placement === "outside" ? "offLabelOutside" : placement === "clipped" ? "offLabelClipped" : null;
     if (kind) findings.push({ objectId: leaf.id, kind, severity: PREFLIGHT_SEVERITY[kind] });
+
+    const produce = getEntry(leaf.type)?.preflight;
+    if (produce) {
+      for (const r of produce(leaf, { label: ctx.label })) {
+        findings.push({ objectId: leaf.id, kind: r.kind, severity: PREFLIGHT_SEVERITY[r.kind], detail: r.detail });
+      }
+    }
   }
   return findings;
 }

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -274,6 +274,11 @@ const ar = {
     heading: 'تحذيرات',
     offLabelOutside: 'خارج الملصق',
     offLabelClipped: 'مقصوص عند الحافة',
+    renderFailed: 'تعذّر الترميز',
+    blockTooNarrow: 'الكتلة ضيقة جداً',
+    barcodeTooSmall: 'الوحدة صغيرة جداً',
+    textOverset: 'نص مقتطع',
+    imageMissing: 'الصورة مفقودة',
   },
 
   printerSettings: {

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -274,6 +274,11 @@ const bg = {
     heading: 'Предупреждения',
     offLabelOutside: 'Извън етикета',
     offLabelClipped: 'Отрязано в края',
+    renderFailed: 'Неуспешно кодиране',
+    blockTooNarrow: 'Блокът е твърде тесен',
+    barcodeTooSmall: 'Модулът е твърде малък',
+    textOverset: 'Текст отрязан',
+    imageMissing: 'Липсва изображение',
   },
 
   printerSettings: {

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -274,6 +274,11 @@ const cs = {
     heading: 'Upozornění',
     offLabelOutside: 'Mimo štítek',
     offLabelClipped: 'Oříznuto u okraje',
+    renderFailed: 'Nelze zakódovat',
+    blockTooNarrow: 'Blok příliš úzký',
+    barcodeTooSmall: 'Modul příliš malý',
+    textOverset: 'Text oříznut',
+    imageMissing: 'Chybí obrázek',
   },
 
   printerSettings: {

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -274,6 +274,11 @@ const da = {
     heading: 'Advarsler',
     offLabelOutside: 'Uden for etiketten',
     offLabelClipped: 'Beskåret ved kanten',
+    renderFailed: 'Kan ikke kodes',
+    blockTooNarrow: 'Blok for smal',
+    barcodeTooSmall: 'Modul for lille',
+    textOverset: 'Tekst afskåret',
+    imageMissing: 'Billede mangler',
   },
 
   printerSettings: {

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -274,6 +274,11 @@ const de = {
     heading: 'Warnungen',
     offLabelOutside: 'Außerhalb des Etiketts',
     offLabelClipped: 'Am Rand abgeschnitten',
+    renderFailed: 'Nicht kodierbar',
+    blockTooNarrow: 'Block zu schmal',
+    barcodeTooSmall: 'Modul zu klein',
+    textOverset: 'Text beschnitten',
+    imageMissing: 'Bild fehlt',
   },
 
   printerSettings: {

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -274,6 +274,11 @@ const el = {
     heading: 'Προειδοποιήσεις',
     offLabelOutside: 'Εκτός ετικέτας',
     offLabelClipped: 'Περικομμένο στην άκρη',
+    renderFailed: 'Δεν κωδικοποιείται',
+    blockTooNarrow: 'Πλαίσιο πολύ στενό',
+    barcodeTooSmall: 'Μονάδα πολύ μικρή',
+    textOverset: 'Κείμενο αποκόπηκε',
+    imageMissing: 'Λείπει εικόνα',
   },
 
   printerSettings: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -274,6 +274,11 @@ const en = {
     heading: 'Warnings',
     offLabelOutside: 'Outside label',
     offLabelClipped: 'Clipped at edge',
+    renderFailed: 'Cannot encode',
+    blockTooNarrow: 'Block too narrow',
+    barcodeTooSmall: 'Module too small',
+    textOverset: 'Text clipped',
+    imageMissing: 'Image missing',
   },
 
   printerSettings: {

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -274,6 +274,11 @@ const es = {
     heading: 'Avisos',
     offLabelOutside: 'Fuera de la etiqueta',
     offLabelClipped: 'Recortado en el borde',
+    renderFailed: 'No codificable',
+    blockTooNarrow: 'Bloque demasiado estrecho',
+    barcodeTooSmall: 'Módulo demasiado pequeño',
+    textOverset: 'Texto recortado',
+    imageMissing: 'Falta imagen',
   },
 
   printerSettings: {

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -274,6 +274,11 @@ const et = {
     heading: 'Hoiatused',
     offLabelOutside: 'Sildist väljas',
     offLabelClipped: 'Servast lõigatud',
+    renderFailed: 'Ei kodeeritav',
+    blockTooNarrow: 'Plokk liiga kitsas',
+    barcodeTooSmall: 'Moodul liiga väike',
+    textOverset: 'Tekst lõigatud',
+    imageMissing: 'Pilt puudub',
   },
 
   printerSettings: {

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -274,6 +274,11 @@ const fa = {
     heading: 'هشدارها',
     offLabelOutside: 'خارج از برچسب',
     offLabelClipped: 'بریده‌شده در لبه',
+    renderFailed: 'رمزگذاری ناموفق',
+    blockTooNarrow: 'بلوک خیلی باریک',
+    barcodeTooSmall: 'ماژول خیلی کوچک',
+    textOverset: 'متن برش‌خورده',
+    imageMissing: 'تصویر ناموجود',
   },
 
   printerSettings: {

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -274,6 +274,11 @@ const fi = {
     heading: 'Varoitukset',
     offLabelOutside: 'Etiketin ulkopuolella',
     offLabelClipped: 'Leikkautuu reunasta',
+    renderFailed: 'Ei koodattavissa',
+    blockTooNarrow: 'Lohko liian kapea',
+    barcodeTooSmall: 'Moduuli liian pieni',
+    textOverset: 'Teksti katkaistu',
+    imageMissing: 'Kuva puuttuu',
   },
 
   printerSettings: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -274,6 +274,11 @@ const fr = {
     heading: 'Avertissements',
     offLabelOutside: "Hors de l'étiquette",
     offLabelClipped: 'Coupé au bord',
+    renderFailed: 'Encodage impossible',
+    blockTooNarrow: 'Bloc trop étroit',
+    barcodeTooSmall: 'Module trop petit',
+    textOverset: 'Texte coupé',
+    imageMissing: 'Image absente',
   },
 
   printerSettings: {

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -274,6 +274,11 @@ const he = {
     heading: 'אזהרות',
     offLabelOutside: 'מחוץ לתווית',
     offLabelClipped: 'נחתך בקצה',
+    renderFailed: 'לא ניתן לקודד',
+    blockTooNarrow: 'בלוק צר מדי',
+    barcodeTooSmall: 'מודול קטן מדי',
+    textOverset: 'טקסט חתוך',
+    imageMissing: 'תמונה חסרה',
   },
 
   printerSettings: {

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -274,6 +274,11 @@ const hr = {
     heading: 'Upozorenja',
     offLabelOutside: 'Izvan naljepnice',
     offLabelClipped: 'Odrezano na rubu',
+    renderFailed: 'Nije kodirivo',
+    blockTooNarrow: 'Blok preuzak',
+    barcodeTooSmall: 'Modul premali',
+    textOverset: 'Tekst odrezan',
+    imageMissing: 'Slika nedostaje',
   },
 
   printerSettings: {

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -274,6 +274,11 @@ const hu = {
     heading: 'Figyelmeztetések',
     offLabelOutside: 'Címkén kívül',
     offLabelClipped: 'Szélén levágva',
+    renderFailed: 'Nem kódolható',
+    blockTooNarrow: 'Blokk túl keskeny',
+    barcodeTooSmall: 'Modul túl kicsi',
+    textOverset: 'Szöveg vágva',
+    imageMissing: 'Kép hiányzik',
   },
 
   printerSettings: {

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -274,6 +274,11 @@ const it = {
     heading: 'Avvisi',
     offLabelOutside: "Fuori dall'etichetta",
     offLabelClipped: 'Tagliato al bordo',
+    renderFailed: 'Non codificabile',
+    blockTooNarrow: 'Blocco troppo stretto',
+    barcodeTooSmall: 'Modulo troppo piccolo',
+    textOverset: 'Testo tagliato',
+    imageMissing: 'Immagine assente',
   },
 
   printerSettings: {

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -274,6 +274,11 @@ const ja = {
     heading: '警告',
     offLabelOutside: 'ラベルの外',
     offLabelClipped: '端で切れています',
+    renderFailed: 'エンコード不可',
+    blockTooNarrow: 'ブロックが狭すぎる',
+    barcodeTooSmall: 'モジュールが小さすぎる',
+    textOverset: 'テキスト切れ',
+    imageMissing: '画像なし',
   },
 
   printerSettings: {

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -274,6 +274,11 @@ const ko = {
     heading: '경고',
     offLabelOutside: '라벨 바깥',
     offLabelClipped: '가장자리에서 잘림',
+    renderFailed: '인코딩 불가',
+    blockTooNarrow: '블록이 너무 좁음',
+    barcodeTooSmall: '모듈이 너무 작음',
+    textOverset: '텍스트 잘림',
+    imageMissing: '이미지 없음',
   },
 
   printerSettings: {

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -274,6 +274,11 @@ const lt = {
     heading: 'Įspėjimai',
     offLabelOutside: 'Už etiketės ribų',
     offLabelClipped: 'Nukirpta ties kraštu',
+    renderFailed: 'Negalima koduoti',
+    blockTooNarrow: 'Blokas per siauras',
+    barcodeTooSmall: 'Modulis per mažas',
+    textOverset: 'Tekstas apkarpytas',
+    imageMissing: 'Trūksta vaizdo',
   },
 
   printerSettings: {

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -274,6 +274,11 @@ const lv = {
     heading: 'Brīdinājumi',
     offLabelOutside: 'Ārpus etiķetes',
     offLabelClipped: 'Apgriezts pie malas',
+    renderFailed: 'Nevar kodēt',
+    blockTooNarrow: 'Bloks pārāk šaurs',
+    barcodeTooSmall: 'Modulis pārāk mazs',
+    textOverset: 'Teksts apgriezts',
+    imageMissing: 'Attēls trūkst',
   },
 
   printerSettings: {

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -274,6 +274,11 @@ const nl = {
     heading: 'Waarschuwingen',
     offLabelOutside: 'Buiten het etiket',
     offLabelClipped: 'Afgesneden aan de rand',
+    renderFailed: 'Niet codeerbaar',
+    blockTooNarrow: 'Blok te smal',
+    barcodeTooSmall: 'Module te klein',
+    textOverset: 'Tekst afgesneden',
+    imageMissing: 'Afbeelding ontbreekt',
   },
 
   printerSettings: {

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -274,6 +274,11 @@ const no = {
     heading: 'Advarsler',
     offLabelOutside: 'Utenfor etiketten',
     offLabelClipped: 'Beskåret ved kanten',
+    renderFailed: 'Kan ikke kodes',
+    blockTooNarrow: 'Blokk for smal',
+    barcodeTooSmall: 'Modul for liten',
+    textOverset: 'Tekst avkortet',
+    imageMissing: 'Bilde mangler',
   },
 
   printerSettings: {

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -274,6 +274,11 @@ const pl = {
     heading: 'Ostrzeżenia',
     offLabelOutside: 'Poza etykietą',
     offLabelClipped: 'Przycięte przy krawędzi',
+    renderFailed: 'Błąd kodowania',
+    blockTooNarrow: 'Blok zbyt wąski',
+    barcodeTooSmall: 'Moduł zbyt mały',
+    textOverset: 'Tekst przycięty',
+    imageMissing: 'Brak obrazu',
   },
 
   printerSettings: {

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -274,6 +274,11 @@ const pt = {
     heading: 'Avisos',
     offLabelOutside: 'Fora da etiqueta',
     offLabelClipped: 'Cortado na borda',
+    renderFailed: 'Não codificável',
+    blockTooNarrow: 'Bloco muito estreito',
+    barcodeTooSmall: 'Módulo muito pequeno',
+    textOverset: 'Texto cortado',
+    imageMissing: 'Imagem ausente',
   },
 
   printerSettings: {

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -274,6 +274,11 @@ const ro = {
     heading: 'Avertismente',
     offLabelOutside: 'În afara etichetei',
     offLabelClipped: 'Tăiat la margine',
+    renderFailed: 'Necodificabil',
+    blockTooNarrow: 'Bloc prea îngust',
+    barcodeTooSmall: 'Modul prea mic',
+    textOverset: 'Text trunchiat',
+    imageMissing: 'Imagine lipsă',
   },
 
   printerSettings: {

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -274,6 +274,11 @@ const sk = {
     heading: 'Upozornenia',
     offLabelOutside: 'Mimo štítka',
     offLabelClipped: 'Orezané pri okraji',
+    renderFailed: 'Nekódovateľné',
+    blockTooNarrow: 'Blok príliš úzky',
+    barcodeTooSmall: 'Modul príliš malý',
+    textOverset: 'Text orezaný',
+    imageMissing: 'Chýba obrázok',
   },
 
   printerSettings: {

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -274,6 +274,11 @@ const sl = {
     heading: 'Opozorila',
     offLabelOutside: 'Zunaj etikete',
     offLabelClipped: 'Obrezano na robu',
+    renderFailed: 'Ni kodirljivo',
+    blockTooNarrow: 'Blok preozek',
+    barcodeTooSmall: 'Modul premajhen',
+    textOverset: 'Besedilo odrezano',
+    imageMissing: 'Slika manjka',
   },
 
   printerSettings: {

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -274,6 +274,11 @@ const sr = {
     heading: 'Упозорења',
     offLabelOutside: 'Изван налепнице',
     offLabelClipped: 'Одсечено на ивици',
+    renderFailed: 'Nije kodirljivo',
+    blockTooNarrow: 'Блок превише узак',
+    barcodeTooSmall: 'Модул превише мали',
+    textOverset: 'Tekst odsečen',
+    imageMissing: 'Slika nedostaje',
   },
 
   printerSettings: {

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -274,6 +274,11 @@ const sv = {
     heading: 'Varningar',
     offLabelOutside: 'Utanför etiketten',
     offLabelClipped: 'Beskuren vid kanten',
+    renderFailed: 'Kan inte kodas',
+    blockTooNarrow: 'Block för smalt',
+    barcodeTooSmall: 'Modul för liten',
+    textOverset: 'Text avklippt',
+    imageMissing: 'Bild saknas',
   },
 
   printerSettings: {

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -274,6 +274,11 @@ const tr = {
     heading: 'Uyarılar',
     offLabelOutside: 'Etiketin dışında',
     offLabelClipped: 'Kenarda kırpılmış',
+    renderFailed: 'Kodlanamıyor',
+    blockTooNarrow: 'Blok çok dar',
+    barcodeTooSmall: 'Modül çok küçük',
+    textOverset: 'Metin kesildi',
+    imageMissing: 'Resim eksik',
   },
 
   printerSettings: {

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -274,6 +274,11 @@ const zhHans = {
     heading: '警告',
     offLabelOutside: '标签外',
     offLabelClipped: '边缘被裁切',
+    renderFailed: '无法编码',
+    blockTooNarrow: '块太窄',
+    barcodeTooSmall: '模块太小',
+    textOverset: '文本截断',
+    imageMissing: '图像缺失',
   },
 
   printerSettings: {

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -274,6 +274,11 @@ const zhHant = {
     heading: '警告',
     offLabelOutside: '標籤外',
     offLabelClipped: '邊緣被裁切',
+    renderFailed: '無法編碼',
+    blockTooNarrow: '區塊太窄',
+    barcodeTooSmall: '模組太小',
+    textOverset: '文字截斷',
+    imageMissing: '圖像缺失',
   },
 
   printerSettings: {

--- a/src/registry/aztec.ts
+++ b/src/registry/aztec.ts
@@ -1,5 +1,6 @@
 import type { ObjectTypeCore } from "../types/ObjectType";
 import { fieldPos, fdFieldFor } from "./zplHelpers";
+import { moduleTooSmallPreflight } from "../lib/barcodeScannability";
 import { type ZplRotation } from "./rotation";
 
 export const MAGNIFICATION_MIN = 1;
@@ -31,6 +32,8 @@ export const aztec: ObjectTypeCore<AztecProps> = {
   defaultSize: { width: 200, height: 200 },
 
   uniformScaleProp: { name: 'magnification', min: MAGNIFICATION_MIN, max: MAGNIFICATION_MAX },
+
+  preflight: moduleTooSmallPreflight<AztecProps>('magnification'),
 
   toZPL: (obj, ctx) => {
     const p = obj.props;

--- a/src/registry/barcode1d.ts
+++ b/src/registry/barcode1d.ts
@@ -5,6 +5,7 @@ import { fieldPos, fdFieldFor } from './zplHelpers';
 import { serialFieldData, type SerialMode } from './serialField';
 import { commitBarcodeWidthHeightTransform } from './transformHelpers';
 import { hasTemplateMarkers } from '../lib/fnTemplate';
+import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { isLoneMarker } from '../lib/variableField';
 import { type ZplRotation } from './rotation';
 
@@ -90,6 +91,8 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
     heightLocked: config.heightLocked,
     interpretationLocked: config.interpretationLocked,
     hri: config.hri,
+
+    preflight: moduleTooSmallPreflight<Barcode1DProps>('moduleWidth'),
 
     // heightLocked symbologies disable the transformer entirely; others scale
     // bar height with sy and module width with sx (clamped in the helper).

--- a/src/registry/codablock.ts
+++ b/src/registry/codablock.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from "../types/ObjectType";
 import { fieldPos, fdFieldFor } from "./zplHelpers";
 import { commitStacked2DTransform } from "./transformHelpers";
+import { moduleTooSmallPreflight } from "../lib/barcodeScannability";
 import { type ZplRotation } from "./rotation";
 
 /** CODABLOCK A requires ^BY module width >= 2 (spec). */
@@ -20,6 +21,7 @@ export const codablock: ObjectTypeCore<CodablockProps> = {
   zplCmd: "^BB",
   group: "code-2d",
   bindable: true,
+  preflight: moduleTooSmallPreflight<CodablockProps>('moduleWidth'),
   defaultProps: {
     content: "1234567890",
     moduleWidth: 2,

--- a/src/registry/code49.ts
+++ b/src/registry/code49.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
 import { fieldPos, fdFieldFor } from './zplHelpers';
 import { commitBarcodeWidthHeightTransform } from './transformHelpers';
+import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 
 /** ZPL ^B4 m: 'A' = auto subset. 0-5 force a specific subset. */
@@ -27,6 +28,7 @@ export const code49: ObjectTypeCore<Code49Props> = {
   zplCmd: '^B4',
   group: 'code-1d',
   bindable: true,
+  preflight: moduleTooSmallPreflight<Code49Props>('moduleWidth'),
   defaultProps: {
     content: 'CODE49',
     height: 20,

--- a/src/registry/datamatrix.ts
+++ b/src/registry/datamatrix.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
 import { fieldPos, fdFieldFor } from './zplHelpers';
 import { GS1_DATAMATRIX_ESCAPE, gs1ContentToDataMatrixFd } from '../lib/gs1';
+import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 
 export const DIMENSION_MIN = 1;
@@ -32,6 +33,8 @@ export const datamatrix: ObjectTypeCore<DataMatrixProps> = {
   defaultSize: { width: 150, height: 150 },
 
   uniformScaleProp: { name: 'dimension', min: DIMENSION_MIN, max: DIMENSION_MAX },
+
+  preflight: moduleTooSmallPreflight<DataMatrixProps>('dimension'),
 
   // GS1 mode FNC1-escapes the payload; shared with the CSV batch override.
   fdTransform: (obj) => (obj.props.gs1 ? gs1ContentToDataMatrixFd : undefined),

--- a/src/registry/gs1databar.ts
+++ b/src/registry/gs1databar.ts
@@ -1,6 +1,7 @@
 import type { LabelObjectBase } from '../types/LabelObject';
 import type { ObjectTypeCore } from '../types/ObjectType';
 import { fieldPos, fdFieldFor } from './zplHelpers';
+import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 import { GS1_DATABAR_DEFAULT_SEGMENTS } from '../lib/gs1';
 
@@ -38,6 +39,7 @@ export const gs1databar: ObjectTypeCore<Gs1DatabarProps> = {
   zplCmd: '^BR',
   group: 'code-1d',
   bindable: true,
+  preflight: moduleTooSmallPreflight<Gs1DatabarProps>('magnification'),
   defaultProps: {
     content: '0112345678901',
     magnification: 2,

--- a/src/registry/image.ts
+++ b/src/registry/image.ts
@@ -112,6 +112,15 @@ export const image: ObjectTypeCore<ImageProps> = {
   },
   defaultSize: { width: 200, height: 200 },
 
+  // No resolvable bytes (no opaque ^GF, no recall path, nothing cached) emits a
+  // blank ^FD^FS, so flag the silent empty graphic. Pure (mirrors toZPL), so it
+  // also covers exportable-but-hidden images the canvas never renders.
+  preflight: (obj) => {
+    const p = obj.props;
+    const resolvable = !!p.rawGf || !!p.storedAs || !!getImage(p.imageId);
+    return resolvable ? [] : [{ kind: 'imageMissing' }];
+  },
+
   // Resize via canvas-handle:
   //  - With cached PNG → aspect locked, height re-derives from widthDots.
   //    Pick the dominant scale (largest deviation from 1) so all eight

--- a/src/registry/micropdf417.ts
+++ b/src/registry/micropdf417.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from "../types/ObjectType";
 import { fieldPos, fdFieldFor } from "./zplHelpers";
 import { commitStacked2DTransform } from "./transformHelpers";
+import { moduleTooSmallPreflight } from "../lib/barcodeScannability";
 import { type ZplRotation } from "./rotation";
 
 export interface MicroPdf417Props {
@@ -25,6 +26,8 @@ export const micropdf417: ObjectTypeCore<MicroPdf417Props> = {
     rotation: 'N',
   },
   defaultSize: { width: 200, height: 100 },
+
+  preflight: moduleTooSmallPreflight<MicroPdf417Props>('moduleWidth'),
 
   commitTransform: commitStacked2DTransform,
 

--- a/src/registry/pdf417.ts
+++ b/src/registry/pdf417.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from "../types/ObjectType";
 import { fieldPos, fdFieldFor } from "./zplHelpers";
 import { commitStacked2DTransform } from "./transformHelpers";
+import { moduleTooSmallPreflight } from "../lib/barcodeScannability";
 import { type ZplRotation } from "./rotation";
 
 /** ^BY module width with ^B7 is 2 to 10 (spec p.82), unlike the general 1. */
@@ -32,6 +33,7 @@ export const pdf417: ObjectTypeCore<Pdf417Props> = {
   defaultSize: { width: 300, height: 150 },
 
   moduleWidthMin: PDF417_MODULE_WIDTH_MIN,
+  preflight: moduleTooSmallPreflight<Pdf417Props>('moduleWidth'),
   commitTransform: (obj, ctx) => commitStacked2DTransform(obj, ctx, PDF417_MODULE_WIDTH_MIN),
 
   toZPL: (obj, ctx) => {

--- a/src/registry/qrcode.ts
+++ b/src/registry/qrcode.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
 import type { LabelObjectBase } from '../types/LabelObject';
 import { fieldPos, fdFieldFor } from './zplHelpers';
+import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 
 /** ZPL prefixes the QR payload with `{ec}A,` inside ^FD. Shared by toZPL and
@@ -38,6 +39,8 @@ export const qrcode: ObjectTypeCore<QrCodeProps> = {
   defaultSize: { width: 200, height: 200 },
 
   uniformScaleProp: { name: 'magnification', min: MAGNIFICATION_MIN, max: MAGNIFICATION_MAX },
+
+  preflight: moduleTooSmallPreflight<QrCodeProps>('magnification'),
 
   fdTransform: qrFdTransform,
 

--- a/src/registry/text.ts
+++ b/src/registry/text.ts
@@ -5,7 +5,13 @@ import { encodeFbContent } from "../lib/fbContent";
 import { encodeTbContent } from "../lib/tbContent";
 import { serialFieldData, type SerialMode } from "./serialField";
 import { deriveBlockTextPatch } from "../lib/textBlock";
-import { type ZplRotation } from "../lib/zebraTextLayout";
+import {
+  isBlockTooNarrow,
+  wrapBlockLines,
+  zebraLineWidthDots,
+  tbLineStepDots,
+  type ZplRotation,
+} from "../lib/zebraTextLayout";
 
 /** Text layout mode. 'normal' = plain ^A (no wrap), 'fb' = ^FB field
  *  block (max-lines cap, justify, hanging indent), 'tb' = ^TB text block
@@ -97,6 +103,34 @@ export const text: ObjectTypeCore<TextProps> = {
     rotation: "N",
   },
   defaultSize: { width: 200, height: 40 },
+  // Block modes (^FB/^TB) silently lose data two ways: a block narrower than one
+  // glyph cell prints nothing (error), and content that wraps past the line cap
+  // (^FB) or block height (^TB) is clipped (overset warning). Mirrors the wrap
+  // the panel/canvas already use (Font-0 metrics), so the badge matches them.
+  preflight: (obj) => {
+    const p = obj.props;
+    const mode = resolveTextMode(p);
+    if (mode === "normal") return [];
+    if (isBlockTooNarrow(p.blockWidth ?? 0, p.fontHeight, p.fontWidth ?? 0)) {
+      return [{ kind: "blockTooNarrow" }];
+    }
+    // ^FB honours newlines as hard breaks; ^TB collapses them to spaces (mirrors
+    // encodeTbContent), so wrap the collapsed form there to avoid false overset.
+    const content = mode === "tb" ? (p.content ?? "").replace(/\n/g, " ") : (p.content ?? "");
+    const lines = wrapBlockLines(content, p.blockWidth ?? 0, (line) =>
+      zebraLineWidthDots(line, p.fontHeight, p.fontWidth ?? 0),
+    );
+    // ^TB clips at blockHeight; N lines occupy (N-1) steps plus the last line's
+    // own height, not N steps (the trailing 0.25 line-gap doesn't render).
+    const tbHeight = (p.blockHeight ?? 0) > 0
+      ? (lines.length - 1) * tbLineStepDots(p.fontHeight) + p.fontHeight
+      : 0;
+    const overset =
+      mode === "fb"
+        ? lines.length > (p.blockLines ?? 1)
+        : (p.blockHeight ?? 0) > 0 && tbHeight > (p.blockHeight ?? 0);
+    return overset ? [{ kind: "textOverset" }] : [];
+  },
   // Rectangle resize: corner drag updates fontHeight from sy and
   // fontWidth from sx independently. fontWidth=0 in storage is the
   // Zebra default meaning "match height"; in that case the effective

--- a/src/registry/tlc39.ts
+++ b/src/registry/tlc39.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from "../types/ObjectType";
 import { fieldPos, fdFieldFor } from "./zplHelpers";
 import { commitBarcodeWidthHeightTransform } from "./transformHelpers";
+import { moduleTooSmallPreflight } from "../lib/barcodeScannability";
 import { type ZplRotation } from "./rotation";
 
 export interface Tlc39Props {
@@ -28,6 +29,7 @@ export const tlc39: ObjectTypeCore<Tlc39Props> = {
   zplCmd: "^BT",
   group: "code-2d",
   bindable: true,
+  preflight: moduleTooSmallPreflight<Tlc39Props>('moduleWidth'),
   defaultProps: {
     content: "123456,SERIAL",
     moduleWidth: 2,

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -2,6 +2,7 @@ import type React from 'react';
 import type { LabelObjectBase, ObjectChanges, ObjectGroup } from './LabelObject';
 import type { HriBehavior, TransformContext, ZplEmitContext } from './ZplEmit';
 import type { ContentSpec } from './contentSpec';
+import type { PreflightCtx, PreflightProducerResult } from './preflight';
 
 /** Domain half of a registry entry: emits ZPL, no React deps. */
 export interface ObjectTypeCore<P extends object = object> {
@@ -60,6 +61,13 @@ export interface ObjectTypeCore<P extends object = object> {
   ) => Partial<P>;
   /** Only for 1D barcodes with an HRI overlay; see {@link HriBehavior}. */
   hri?: HriBehavior;
+  /** Pure per-type preflight checks the geometry pass can't see (e.g. block
+   *  text too narrow to print, barcode module too small to scan). Returns
+   *  findings without objectId/severity; computePreflight stamps both. */
+  preflight?: (
+    obj: LabelObjectBase & { props: P },
+    ctx: PreflightCtx,
+  ) => PreflightProducerResult[];
 }
 
 /** Lives in `<type>.panel.tsx` so the domain `.ts` stays React-free. */

--- a/src/types/preflight.ts
+++ b/src/types/preflight.ts
@@ -1,0 +1,52 @@
+import type { LabelConfig } from './LabelConfig';
+
+export type PreflightSeverity = 'error' | 'warning';
+
+/** Distinct preflight problem kinds. Producers: geometry (off-label), render
+ *  (encode failure), and per-type pure checks (block-too-narrow, barcode module
+ *  too small). Each new producer adds its kind here. */
+export type PreflightKind =
+  | 'offLabelOutside'
+  | 'offLabelClipped'
+  | 'renderFailed'
+  | 'blockTooNarrow'
+  | 'barcodeTooSmall'
+  | 'textOverset'
+  | 'imageMissing';
+
+export interface PreflightFinding {
+  objectId: string;
+  kind: PreflightKind;
+  severity: PreflightSeverity;
+  /** Optional human-readable specifics (encoder message, measured value),
+   *  shown after the kind label in the badge list. */
+  detail?: string;
+}
+
+/** Single source for kind -> severity so canvas styling and badge tiering can't
+ *  drift apart. */
+export const PREFLIGHT_SEVERITY: Record<PreflightKind, PreflightSeverity> = {
+  offLabelOutside: 'error',
+  offLabelClipped: 'warning',
+  renderFailed: 'error',
+  blockTooNarrow: 'error',
+  barcodeTooSmall: 'warning',
+  textOverset: 'warning',
+  // Warning, not error like blockTooNarrow, although both print blank: image
+  // bytes may still be hydrating from storage, so the state can self-resolve.
+  imageMissing: 'warning',
+};
+
+/** What a per-type `preflight` producer receives. Minimal on purpose (just the
+ *  label, for dpmm) so the registry capability stays free of the lib-layer
+ *  ObjectBoundsCtx and its import cycle. */
+export interface PreflightCtx {
+  label: LabelConfig;
+}
+
+/** A per-type producer's output: kind plus optional detail. computePreflight
+ *  stamps the objectId and derives severity from PREFLIGHT_SEVERITY. */
+export interface PreflightProducerResult {
+  kind: PreflightKind;
+  detail?: string;
+}


### PR DESCRIPTION
Extend the preflight badge from off-label only to a multi-producer model: per-type registry preflight checks (barcode module too small for scanning, block text too narrow / overset) plus a canvas-layer encode check over all exportable leaves (encode failure incl. QR overflow, image with no bytes). All findings carry an optional detail; localised in all 32 languages.