### PR TITLE
fix(import): renumber shared ^FN slots with divergent defaults

### DIFF
--- a/src/components/Output/ImportSummary.tsx
+++ b/src/components/Output/ImportSummary.tsx
@@ -14,6 +14,10 @@ const TONE: Record<ImportFindingKind, string> = {
   replayRisk: 'text-red-400',
   // Round-trip caveat: byte-exact replay ends at the first edit.
   lossyEdit: 'text-amber-400',
+  // Informational: the field kept its data, only the slot number moved.
+  fnRenumbered: 'text-muted',
+  // Higher severity: a page's divergent default was discarded (99 slots full).
+  fnDefaultDropped: 'text-red-400',
 };
 
 function FindingRow({ finding, showPage }: { finding: ImportFinding; showPage: boolean }) {

--- a/src/lib/importReport.ts
+++ b/src/lib/importReport.ts
@@ -53,6 +53,18 @@ export function describeFinding(f: ImportFinding): { title: string; detail: stri
       detail: f.command,
     };
   }
+  if (f.kind === 'fnRenumbered') {
+    return {
+      title: 'Shared ^FN slot with a different default: field moved to a free slot',
+      detail: f.command,
+    };
+  }
+  if (f.kind === 'fnDefaultDropped') {
+    return {
+      title: "All ^FN slots taken: this field keeps the first page's default",
+      detail: f.command,
+    };
+  }
   return {
     title: 'Skipped: command not recognised',
     detail: f.command,

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -59,11 +59,12 @@ export function planTemplateHeader(
 ): { headerLines: string[]; emitCtx: ZplEmitContext } {
   // O(N+V) vs O(N*V) per-marker re-scan.
   const varsByName = new Map(variables.map((v) => [v.name, v]));
-  const varsByFn = new Map(variables.map((v) => [v.fnNumber, v]));
 
   const templatePayloads: string[] = [];
   const clockPayloads: string[] = [];
-  const templateFns = new Set<number>();
+  // Referenced Variable per fn, so the header declares exactly what this
+  // page's templates use.
+  const templateVarsByFn = new Map<number, Variable>();
   const singleBindFns = new Set<number>();
   for (const leaf of flattenObjects(shifted)) {
     if (leaf.includeInExport === false) continue;
@@ -80,7 +81,7 @@ export function planTemplateHeader(
       templatePayloads.push(c);
       for (const name of extractTemplateRefs(c)) {
         const v = varsByName.get(name);
-        if (v) templateFns.add(v.fnNumber);
+        if (v) templateVarsByFn.set(v.fnNumber, v);
       }
     }
     if (hasClockMarkers(c)) clockPayloads.push(c);
@@ -92,10 +93,8 @@ export function planTemplateHeader(
 
   if (pickedEmbedChar !== null) {
     if (pickedEmbedChar !== '#') headerLines.push(`^FE${pickedEmbedChar}`);
-    for (const fn of [...templateFns].sort((a, b) => a - b)) {
+    for (const [fn, v] of [...templateVarsByFn].sort(([a], [b]) => a - b)) {
       if (singleBindFns.has(fn)) continue;
-      const v = varsByFn.get(fn);
-      if (!v) continue;
       headerLines.push(`^FN${fn}${fdField(v.defaultValue)}`);
     }
     emitCtx.embedChar = pickedEmbedChar;

--- a/src/lib/zplImportService.test.ts
+++ b/src/lib/zplImportService.test.ts
@@ -298,10 +298,10 @@ describe('importZplText - ~DY font scope (setup vs design)', () => {
 });
 
 describe('importZplText - cross-block variable merge (content markers)', () => {
-  it('merges ^FN1 across blocks and renames the second block marker to the kept name', () => {
+  it('merges ^FN1 across blocks when the defaults agree', () => {
     const zpl =
       '^XA^FXField: GTIN^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ\n' +
-      '^XA^FO10,10^A0N,30,30^FN1^FDBob^FS^XZ';
+      '^XA^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ';
     const r = importZplText(zpl, 8);
     expect(r.variables).toHaveLength(1);
     const name = r.variables[0]?.name;
@@ -310,5 +310,91 @@ describe('importZplText - cross-block variable merge (content markers)', () => {
     // Both pages reference the single kept variable by the same content marker.
     expect(p0.props.content).toBe(`«${name}»`);
     expect(p1.props.content).toBe(`«${name}»`);
+  });
+
+  it('keeps separate variables for a shared ^FN slot with divergent defaults', () => {
+    // ^FN is scoped per ^XA format; merging Bob onto Alice would lose page 2's
+    // default (regeneration would then emit page 1's). The second Variable
+    // moves to the next free slot so fnNumber stays document-unique.
+    const zpl =
+      '^XA^FXField: GTIN^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ\n' +
+      '^XA^FO10,10^A0N,30,30^FN1^FDBob^FS^XZ';
+    const r = importZplText(zpl, 8);
+    expect(r.variables).toHaveLength(2);
+    expect(r.variables.map((v) => v.fnNumber)).toEqual([1, 2]);
+    expect(r.variables.map((v) => v.defaultValue)).toEqual(['Alice', 'Bob']);
+    const [v0, v1] = r.variables;
+    expect(v0!.name).not.toBe(v1!.name);
+    const p0 = r.pages[0]?.objects[0] as unknown as { props: { content: string } };
+    const p1 = r.pages[1]?.objects[0] as unknown as { props: { content: string } };
+    expect(p0.props.content).toBe(`«${v0!.name}»`);
+    expect(p1.props.content).toBe(`«${v1!.name}»`);
+  });
+
+  it('renumbers around every source ^FN in the document (overlay bytes keep them)', () => {
+    // Page 2's divergent ^FN1 must not land on fn 2: page 3's genuine ^FN2
+    // stays in overlays/replay, so the renumbering skips to fn 3.
+    const zpl =
+      '^XA^FO10,10^A0N,30,30^FN1^FDa^FS^XZ\n' +
+      '^XA^FO10,10^A0N,30,30^FN1^FDb^FS^XZ\n' +
+      '^XA^FO10,10^A0N,30,30^FN2^FDz^FS^XZ';
+    const r = importZplText(zpl, 8);
+    expect(r.variables.map((v) => v.fnNumber)).toEqual([1, 3, 2]);
+    expect(r.variables.map((v) => v.defaultValue)).toEqual(['a', 'b', 'z']);
+    expect(r.report.findings.some((f) => f.kind === 'fnRenumbered')).toBe(true);
+  });
+
+  it('reserves lowercase source ^fn slots too (parser is case-insensitive)', () => {
+    // A raw case-sensitive scan would miss ^fn2 and renumber page 2 onto it.
+    const zpl =
+      '^XA^FO10,10^A0N,30,30^FN1^FDa^FS^XZ\n' +
+      '^XA^FO10,10^A0N,30,30^FN1^FDb^FS^XZ\n' +
+      '^XA^FO10,10^A0N,30,30^fn2^FDz^FS^XZ';
+    const r = importZplText(zpl, 8);
+    expect(r.variables.map((v) => v.fnNumber)).toEqual([1, 3, 2]);
+    expect(r.variables.map((v) => v.defaultValue)).toEqual(['a', 'b', 'z']);
+  });
+
+  it('treats an empty ^FD default as a bare declaration, not a divergent value', () => {
+    // Declaration-first: the valued page backfills the shared Variable.
+    const first = importZplText(
+      '^XA^FO10,10^A0N,30,30^FN1^FD^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ',
+      8,
+    );
+    expect(first.variables).toHaveLength(1);
+    expect(first.variables[0]?.defaultValue).toBe('Alice');
+    // Value-first: the bare declaration merges onto the valued Variable.
+    const second = importZplText(
+      '^XA^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FD^FS^XZ',
+      8,
+    );
+    expect(second.variables).toHaveLength(1);
+    expect(second.variables[0]?.defaultValue).toBe('Alice');
+  });
+
+  it('renames the ^FX-hinted marker when a divergent slot renumbers (GTIN -> GTIN_2)', () => {
+    const zpl =
+      '^XA^FXField: GTIN^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ\n' +
+      '^XA^FXField: GTIN^FO10,10^A0N,30,30^FN1^FDBob^FS^XZ';
+    const r = importZplText(zpl, 8);
+    expect(r.variables.map((v) => v.name)).toEqual(['GTIN', 'GTIN_2']);
+    const p1 = r.pages[1]?.objects[0] as unknown as { props: { content: string } };
+    expect(p1.props.content).toBe('«GTIN_2»');
+  });
+
+  it('falls back to the lossy merge with a finding when all 99 slots are taken', () => {
+    // One block occupying every fn slot, then a divergent reuse of ^FN1.
+    const fields = Array.from({ length: 99 }, (_, k) =>
+      `^FO10,${10 + k}^A0N,10,10^FN${k + 1}^FDv${k + 1}^FS`,
+    ).join('');
+    const zpl = `^XA${fields}^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDdivergent^FS^XZ`;
+    const r = importZplText(zpl, 8);
+    expect(r.variables).toHaveLength(99);
+    // fn-unique invariant holds even in the exhaustion fallback.
+    expect(new Set(r.variables.map((v) => v.fnNumber)).size).toBe(99);
+    expect(r.report.findings.some((f) => f.kind === 'fnDefaultDropped')).toBe(true);
+    // Page 2's marker is rewired onto the first page's Variable (lossy).
+    const p1 = r.pages[1]?.objects[0] as unknown as { props: { content: string } };
+    expect(p1.props.content).toBe(`«${r.variables[0]?.name}»`);
   });
 });

--- a/src/lib/zplImportService.ts
+++ b/src/lib/zplImportService.ts
@@ -5,7 +5,7 @@ import { renameTemplateMarkers } from "./fnTemplate";
 import type { CustomFontMapping, LabelConfig } from "../types/LabelConfig";
 import type { PrinterProfile } from "../types/PrinterProfile";
 import type { LabelObject, Page } from "../types/Group";
-import { uniqueVariableName, type Variable } from "../types/Variable";
+import { nextFreeFnNumber, uniqueVariableName, type Variable } from "../types/Variable";
 
 export interface ZplImportResult {
   labelConfig: Partial<LabelConfig>;
@@ -84,20 +84,26 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
   const printerProfile: Partial<PrinterProfile> = {};
   const pages: Page[] = [];
   const findings: ImportFinding[] = [];
-  // Variables are document-level, but the parser reconstructs them per
-  // block. Merge across blocks by fnNumber (same slot used on multiple
-  // pages → one Variable) and rewire later blocks' object references
-  // onto the first block's Variable so the binding survives the merge.
+  // Variables are document-level; blocks merge by source fnNumber only when
+  // the ^FD defaults agree (^FN is scoped per ^XA format, so a shared slot
+  // with a different default is a distinct field). A divergent default
+  // becomes a separate Variable on a free fnNumber, keeping fn
+  // document-unique for mapping/batch/header.
   const variables: Variable[] = [];
-  const variablesByFn = new Map<number, Variable>();
+  const variablesBySourceFn = new Map<number, Variable[]>();
+  // Parse all blocks up front: renumbering must avoid every source ^FN in
+  // the document (overlays replay original bytes, so a partial regeneration
+  // would otherwise collide with a verbatim same-numbered field).
+  const parsedBlocks = parseUnits.map((block) => parseZPL(block, dpmm, { captureOverlay: true }));
+  const usedFns = new Set<number>();
+  for (const r of parsedBlocks) for (const fn of r.sourceFnNumbers) usedFns.add(fn);
 
   // Cross-block customFonts merge by alias. Foreign ZPL can split a font
   // upload from its ^CW alias (~DY in preamble, ^CW in a later block),
   // and the per-block parser would otherwise lose the entry when block 0's
   // labelConfig replaces all later labelConfigs.
   const aggregatedCustomFonts = new Map<string, CustomFontMapping>();
-  parseUnits.forEach((block, i) => {
-    const result = parseZPL(block, dpmm, { captureOverlay: true });
+  parsedBlocks.forEach((result, i) => {
     uploadedFontPaths.push(...result.uploadedFontPaths);
     for (const m of result.labelConfig.customFonts ?? []) {
       if (m.path) designFontPaths.add(normPath(m.path));
@@ -110,18 +116,39 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
     // markers must be renamed to the kept variable's name.
     const nameRemap = new Map<string, string>();
     for (const v of result.variables) {
-      const existing = variablesByFn.get(v.fnNumber);
-      if (existing) {
-        if (v.name !== existing.name) nameRemap.set(v.name, existing.name);
-      } else {
-        // New fnNumber: keep the entry but disambiguate the name if a prior
-        // block has the same (e.g. two `field_1` from different blocks).
-        const uniqueName = uniqueVariableName(v.name, variables);
-        if (uniqueName !== v.name) nameRemap.set(v.name, uniqueName);
-        const kept: Variable = { ...v, name: uniqueName };
-        variables.push(kept);
-        variablesByFn.set(kept.fnNumber, kept);
+      const slotMates = variablesBySourceFn.get(v.fnNumber) ?? [];
+      // An empty default is a bare slot declaration, not a divergent value
+      // (mirrors the parser's in-block backfill semantics).
+      const mate = slotMates.find(
+        (m) => m.defaultValue === v.defaultValue || m.defaultValue === "" || v.defaultValue === "",
+      );
+      if (mate) {
+        if (mate.defaultValue === "" && v.defaultValue !== "") mate.defaultValue = v.defaultValue;
+        if (v.name !== mate.name) nameRemap.set(v.name, mate.name);
+        continue;
       }
+      let fnNumber = v.fnNumber;
+      if (slotMates.length > 0) {
+        const free = nextFreeFnNumber([...usedFns]);
+        if (free === null) {
+          // All 99 slots taken: fall back to the lossy merge rather than drop
+          // the field's binding entirely.
+          const first = slotMates[0];
+          if (first && v.name !== first.name) nameRemap.set(v.name, first.name);
+          findings.push({ kind: "fnDefaultDropped", command: `^FN${v.fnNumber}`, pageIndex: i });
+          continue;
+        }
+        fnNumber = free;
+        findings.push({ kind: "fnRenumbered", command: `^FN${v.fnNumber} → ^FN${free}`, pageIndex: i });
+      }
+      // Disambiguate the name if a prior block took it (e.g. two `field_1`
+      // from different blocks).
+      const uniqueName = uniqueVariableName(v.name, variables);
+      if (uniqueName !== v.name) nameRemap.set(v.name, uniqueName);
+      const kept: Variable = { ...v, name: uniqueName, fnNumber };
+      variables.push(kept);
+      usedFns.add(fnNumber);
+      variablesBySourceFn.set(v.fnNumber, [...slotMates, kept]);
     }
     // Rename this block's content markers onto the kept variable names.
     // Defensive walk into groups; the parser does not produce groups, but the
@@ -207,10 +234,9 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
 
 /** In-place rewrite of cross-block variable references on freshly-parsed objects
  *  (not yet in the store, so mutation is safe). Renames `«name»` content markers
- *  to the merged variable's name. The merge is by ^FN number, so the kept
- *  variable keeps the same number: captured bytes stay valid and must NOT be
- *  marked dirty (an unedited later page would lose its original ^FD default on
- *  export otherwise). */
+ *  to the kept (merged or renumbered) variable's name. The pages must NOT be
+ *  marked dirty: their captured bytes stay valid as-is, and an unedited later
+ *  page would otherwise lose its original ^FD default on export. */
 function rewireBindings(
   objects: LabelObject[],
   nameRemap: ReadonlyMap<string, string>,

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -331,6 +331,7 @@ export function parseZPL(
     variables,
     uploadedFontPaths: [...s.fonts.downloadedFontPaths],
     referencedFontPaths: [...s.fonts.referencedFontPaths],
+    sourceFnNumbers: s.result.sourceFnNumbers,
     skipped,
     importReport: {
       findings,

--- a/src/lib/zplParser/context.ts
+++ b/src/lib/zplParser/context.ts
@@ -49,6 +49,10 @@ export interface ParserResult {
   /** Setup-Script / printer-config commands seen (persist/change device state
    *  on print/export); surfaced as a replay-risk import finding. */
   replayRisk: string[];
+  /** Every in-range ^FN slot the tokenizer saw, including on fields that end
+   *  up passthrough-only (no Variable). Import renumbering must avoid these:
+   *  overlays replay the original bytes. */
+  sourceFnNumbers: Set<number>;
 }
 
 /** Label-frame state from ^LH / ^LT / ^LR; per spec these are persistent
@@ -234,6 +238,7 @@ export function createParserState(): ParserState {
       browserLimit: [],
       unknown: [],
       replayRisk: [],
+      sourceFnNumbers: new Set<number>(),
     },
     label: {
       lhX: 0,

--- a/src/lib/zplParser/handlers/fields.ts
+++ b/src/lib/zplParser/handlers/fields.ts
@@ -333,6 +333,7 @@ export function createFieldHandlers(
         s.result.partialCmds.add("^FN");
         return;
       }
+      s.result.sourceFnNumbers.add(n);
       s.comment.fnNumber = n;
       s.comment.fnComment = s.comment.pending;
     },

--- a/src/lib/zplParser/types.ts
+++ b/src/lib/zplParser/types.ts
@@ -4,7 +4,14 @@ import type { Variable } from "../../types/Variable";
 import type { PrinterProfile } from "../../types/PrinterProfile";
 import type { BlockOverlay } from "../zplOverlay/overlay";
 
-export type ImportFindingKind = "partial" | "browserLimit" | "unknown" | "replayRisk" | "lossyEdit";
+export type ImportFindingKind =
+  | "partial"
+  | "browserLimit"
+  | "unknown"
+  | "replayRisk"
+  | "lossyEdit"
+  | "fnRenumbered"
+  | "fnDefaultDropped";
 
 /**
  * One import finding. Created per-occurrence so each entry can be navigated
@@ -25,9 +32,9 @@ export interface ImportFinding {
 
 export interface ImportReport {
   findings: ImportFinding[];
-  // The buckets below are command-code dedup views for the command-based kinds
-  // only. Block-level kinds without a command (e.g. 'lossyEdit') live solely in
-  // `findings`; iterate `findings` (not the buckets) for a kind-complete view.
+  // The buckets below are command-code dedup views for these four kinds only.
+  // Every other kind (lossyEdit, fnRenumbered, fnDefaultDropped) lives solely
+  // in `findings`; iterate `findings` for a kind-complete view.
   /** Commands imported with known loss. Deduplicated by command code. */
   partial: string[];
   /** Commands skipped because they require printer hardware or file storage. */
@@ -59,6 +66,9 @@ export interface ParsedZPL {
    *  service treats these as design fonts so an uploaded font used
    *  without a `^CW` alias is not misclassified as a Setup-Script font. */
   referencedFontPaths: string[];
+  /** Every in-range ^FN slot the tokenizer saw, including on passthrough-only
+   *  fields; import renumbering must avoid these (overlays replay the bytes). */
+  sourceFnNumbers: ReadonlySet<number>;
   /** Commands not fully imported (browserLimit + unknown). Prefer
    *  importReport for categorised access. */
   skipped: string[];

--- a/src/lib/zplRoundtrip.integration.test.ts
+++ b/src/lib/zplRoundtrip.integration.test.ts
@@ -184,9 +184,65 @@ describe("round-trip integration (real import -> store -> export)", () => {
     const src =
       "^XA^FO10,10^A0N,30,30^FN1^FDpageA^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDpageB^FS^XZ";
     importInto(src);
-    // The cross-block merge must not dirty page 2; its original ^FD default
-    // replays verbatim instead of regenerating with the merged variable's value.
+    // The import must not dirty page 2; its original ^FN1^FD bytes replay
+    // verbatim even though its Variable was renumbered to a free slot.
     expect(exportZpl()).toBe(src);
+  });
+
+  it("a shared ^FN slot with divergent defaults keeps each page's default after an edit", () => {
+    importInto(
+      "^XA^FO10,10^A0N,30,30^FN1^FDpageA^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDpageB^FS^XZ",
+    );
+    // Divergent defaults must not merge: page 2 gets its own Variable on the
+    // next free slot (fn stays document-unique for mapping/batch).
+    expect(store().variables).toHaveLength(2);
+    expect(store().variables.map((v) => v.fnNumber)).toEqual([1, 2]);
+
+    // Edit page 2 so its block regenerates instead of replaying the overlay.
+    const p2obj = store().pages[1]!.objects[0]!;
+    useLabelStore.setState({ currentPageIndex: 1 });
+    store().updateObject(p2obj.id, { x: p2obj.x + 1 });
+
+    const out = exportZpl();
+    const page2Block = out.slice(out.lastIndexOf("^XA"));
+    expect(page2Block).toContain("^FN2");
+    expect(page2Block).toContain("pageB");
+    expect(page2Block).not.toContain("pageA");
+  });
+
+  it("renumbering avoids a sibling source ^FN in the same block (partial regen stays collision-free)", () => {
+    importInto(
+      "^XA^FO10,10^A0N,30,30^FN1^FDAlice^FS^XZ\n" +
+        "^XA^FO10,10^A0N,30,30^FN1^FDBob^FS^FO10,60^A0N,30,30^FN2^FDCharlie^FS^XZ",
+    );
+    expect(store().variables.map((v) => v.fnNumber)).toEqual([1, 3, 2]);
+
+    // Edit only Bob's field: its regenerated ^FN3 must not collide with
+    // Charlie's verbatim ^FN2 bytes in the same format.
+    const bob = store().pages[1]!.objects[0]!;
+    useLabelStore.setState({ currentPageIndex: 1 });
+    store().updateObject(bob.id, { x: bob.x + 1 });
+
+    const out = exportZpl();
+    const page2Block = out.slice(out.lastIndexOf("^XA"));
+    expect(page2Block).toContain("^FN3");
+    expect(page2Block).toContain("Bob");
+    expect(page2Block).toContain("^FN2^FDCharlie");
+    // Exactly one ^FN2 in the format (Charlie's verbatim bytes).
+    expect(page2Block.match(/\^FN2/g)).toHaveLength(1);
+  });
+
+  it("a shared ^FN slot with matching defaults still merges to one Variable", () => {
+    importInto(
+      "^XA^FO10,10^A0N,30,30^FN1^FDsame^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDsame^FS^XZ",
+    );
+    expect(store().variables).toHaveLength(1);
+    // A later page repeating an earlier default merges onto that Variable.
+    importInto(
+      "^XA^FO10,10^A0N,30,30^FN1^FDa^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDb^FS^XZ\n^XA^FO10,10^A0N,30,30^FN1^FDa^FS^XZ",
+    );
+    expect(store().variables).toHaveLength(2);
+    expect(store().variables.map((v) => v.fnNumber)).toEqual([1, 2]);
   });
 
   it("save → edit → reload restores a clean, byte-lossless document", () => {


### PR DESCRIPTION
^FN is scoped per ^XA format; collapsing pages onto the first Variable lost later defaults, so an edited page regenerated with page 1's value. A divergent default becomes its own Variable on a free fnNumber that avoids every source ^FN (overlays replay original bytes, so partial regen must not collide). Empty defaults merge as bare declarations; slot exhaustion falls back to the lossy merge. Both renumbering and the fallback surface as import findings.