### PR TITLE
feat(palette): row context menu + categorized add menu in favorites

### DIFF
--- a/src/components/Canvas/CanvasContextMenu.tsx
+++ b/src/components/Canvas/CanvasContextMenu.tsx
@@ -1,8 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { useDismiss } from "../../hooks/useDismiss";
 import {
-  ChevronRightIcon,
   ChevronUpIcon,
   ChevronDownIcon,
   ChevronDoubleUpIcon,
@@ -22,9 +18,9 @@ import {
   PlusIcon,
   Squares2X2Icon,
 } from "@heroicons/react/16/solid";
-import type { MenuAction, MenuSection } from "./canvasActions";
+import { ContextMenu, type MenuAction, type MenuSection } from "../ui/ContextMenu";
 
-type IconType = typeof ChevronRightIcon;
+type IconType = typeof ChevronUpIcon;
 
 // Icons stay in the view, keyed by the action id, so canvasActions stays pure.
 const ICONS: Record<string, IconType> = {
@@ -53,10 +49,6 @@ function iconFor(item: MenuAction): IconType | undefined {
   return ICONS[item.id];
 }
 
-function RowIcon({ icon: Icon }: { icon?: IconType }) {
-  return Icon ? <Icon className="w-4 h-4 shrink-0" /> : null;
-}
-
 interface Props {
   sections: MenuSection[];
   /** Viewport coords of the right-click. */
@@ -67,124 +59,6 @@ interface Props {
   onClose: () => void;
 }
 
-const MENU_BOX =
-  "z-[60] min-w-44 bg-surface border border-border rounded-lg shadow-2xl p-1";
-
-function labelOf(item: MenuAction, labels: Record<string, string>): string {
-  return item.label ?? (item.labelKey ? labels[item.labelKey] ?? item.labelKey : item.id);
-}
-
-function Row({
-  item,
-  labels,
-  onClose,
-}: {
-  item: MenuAction;
-  labels: Record<string, string>;
-  onClose: () => void;
-}) {
-  const [subOpen, setSubOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const subRef = useRef<HTMLDivElement>(null);
-  // Submenus open to the right by default; flip left and/or shift up once the
-  // real size is known so a nested level can't run off the viewport.
-  const [flip, setFlip] = useState<{ left: boolean; up: number }>({ left: false, up: 0 });
-  const cls = `w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs font-mono rounded transition-colors ${
-    item.disabled
-      ? "text-muted/40 cursor-not-allowed"
-      : item.danger
-        ? "text-text hover:bg-error/15 hover:text-error"
-        : "text-text hover:bg-surface-2"
-  }`;
-
-  useLayoutEffect(() => {
-    if (!subOpen) return;
-    const wrap = wrapRef.current;
-    const sub = subRef.current;
-    if (!wrap || !sub) return;
-    const wr = wrap.getBoundingClientRect();
-    const sr = sub.getBoundingClientRect();
-    const overBottom = sr.bottom + 4 - window.innerHeight;
-    setFlip({
-      left: wr.right + sr.width + 4 > window.innerWidth,
-      up: overBottom > 0 ? overBottom : 0,
-    });
-  }, [subOpen]);
-
-  const submenu = item.submenu;
-  if (submenu?.length) {
-    return (
-      <div
-        ref={wrapRef}
-        className="relative"
-        onMouseEnter={() => !item.disabled && setSubOpen(true)}
-        onMouseLeave={() => setSubOpen(false)}
-      >
-        <button disabled={item.disabled} className={cls}>
-          <RowIcon icon={iconFor(item)} />
-          <span className="flex-1">{labelOf(item, labels)}</span>
-          <ChevronRightIcon className="w-3.5 h-3.5 text-muted shrink-0" />
-        </button>
-        {subOpen && (
-          <div
-            ref={subRef}
-            className={`absolute top-0 ${flip.left ? "right-full mr-0.5" : "left-full ml-0.5"} ${MENU_BOX}`}
-            style={flip.up ? { transform: `translateY(-${flip.up}px)` } : undefined}
-          >
-            {submenu.map((s) => (
-              <Row key={s.id} item={s} labels={labels} onClose={onClose} />
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <button
-      disabled={item.disabled}
-      className={cls}
-      onClick={() => {
-        if (item.disabled) return;
-        item.run?.();
-        onClose();
-      }}
-    >
-      <RowIcon icon={iconFor(item)} />
-      <span className="flex-1">{labelOf(item, labels)}</span>
-    </button>
-  );
-}
-
 export function CanvasContextMenu({ sections, x, y, labels, onClose }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ x, y });
-
-  // Clamp into the viewport once the real size is known.
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const r = el.getBoundingClientRect();
-    setPos({
-      x: Math.min(x, window.innerWidth - r.width - 4),
-      y: Math.min(y, window.innerHeight - r.height - 4),
-    });
-  }, [x, y]);
-
-  // Defer so the opening right-click's own pointer events don't self-close.
-  useDismiss(ref, onClose, { defer: true });
-
-  return createPortal(
-    <div ref={ref} className={`fixed ${MENU_BOX}`} style={{ left: pos.x, top: pos.y }} role="menu">
-      {sections.map((section, i) => (
-        <div key={section.id}>
-          {i > 0 && <div className="my-1 border-t border-border" />}
-          {section.items.map((item) => (
-            <Row key={item.id} item={item} labels={labels} onClose={onClose} />
-          ))}
-        </div>
-      ))}
-    </div>,
-    document.body,
-  );
+  return <ContextMenu sections={sections} x={x} y={y} labels={labels} iconFor={iconFor} onClose={onClose} />;
 }

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -38,8 +38,8 @@ import { GuideLines } from "./GuideLines";
 import { Ruler, RULER_SIZE } from "./Ruler";
 import { getEntry, SHAPE_PRIMITIVE_TYPES } from "../../registry";
 import type { LeafObject } from "../../registry";
-import { PALETTE_GROUPS } from "../Palette/paletteGroups";
-import { addablesInGroup, resolveAddable, type AddableEntry } from "../../registry/palettePresets";
+import { addableGroupsFor } from "../Palette/paletteGroups";
+import { resolveAddable, type AddableEntry } from "../../registry/palettePresets";
 import { useColorScheme } from "../../lib/useColorScheme";
 import { useT } from "../../lib/useT";
 import { useCanvasPanZoom } from "./hooks/useCanvasPanZoom";
@@ -1105,7 +1105,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       .map(toAddable);
     const addableGroups = [
       ...(quickTypes.length ? [{ id: "favorites", label: t.palette.favorites, types: quickTypes }] : []),
-      ...PALETTE_GROUPS.map((g) => ({ id: g.key, label: t.palette[g.labelKey], types: addablesInGroup(g.key, t).map(toAddable) })),
+      ...addableGroupsFor(t).map((g) => ({ id: g.key, label: g.label, types: g.entries.map(toAddable) })),
     ].filter((g) => g.types.length > 0);
     const sections = buildContextMenu({
       onObject,

--- a/src/components/Canvas/canvasActions.ts
+++ b/src/components/Canvas/canvasActions.ts
@@ -1,23 +1,7 @@
 import type { ZOrderDir } from "../../lib/zorder";
+import type { MenuAction, MenuSection } from "../ui/ContextMenu";
 
-/** One context-menu entry. `labelKey` resolves against `t.contextMenu`; a raw
- *  `label` overrides it (dynamic entries like the add-object types). A
- *  `submenu` makes it a parent row. */
-export interface MenuAction {
-  id: string;
-  labelKey?: string;
-  label?: string;
-  run?: () => void;
-  disabled?: boolean;
-  danger?: boolean;
-  submenu?: MenuAction[];
-}
-
-/** Actions are grouped into divider-separated sections. */
-export interface MenuSection {
-  id: string;
-  items: MenuAction[];
-}
+export type { MenuAction, MenuSection };
 
 /** What the right-click targeted plus the capabilities + dispatchers needed to
  *  build the menu. Kept data-only (no Konva/React) so the builder is pure and

--- a/src/components/Palette/ObjectPalette.tsx
+++ b/src/components/Palette/ObjectPalette.tsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from 'react';
 import { useDraggable, useDndMonitor, DragOverlay } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { MagnifyingGlassIcon, MinusIcon } from '@heroicons/react/16/solid';
-import { PALETTE_GROUPS } from './paletteGroups';
+import { MagnifyingGlassIcon, MinusIcon, PlusIcon } from '@heroicons/react/16/solid';
+import { addableGroupsFor } from './paletteGroups';
 import { StarGlyph } from './StarGlyph';
-import { addablesInGroup, resolveAddable, type AddableEntry } from '../../registry/palettePresets';
+import { buildFavoritesAddMenu, buildPaletteRowMenu } from './paletteActions';
+import { ContextMenu, type MenuSection } from '../ui/ContextMenu';
+import { resolveAddable, type AddableEntry } from '../../registry/palettePresets';
 import { getEntry } from '../../registry';
 import { useT } from '../../lib/useT';
 import { useLabelStore } from '../../store/labelStore';
@@ -96,7 +98,13 @@ function PinButton({ entryId }: { entryId: string }) {
 
 /** Browse/search row: whole row drags onto the canvas (no grip). Search results
  *  show a pin star (`pinnable`); flat browse stays bare. */
-function BrowseRow({ entry, dragId, cat, pinnable }: { entry: AddableEntry; dragId: string; cat?: string; pinnable?: boolean }) {
+function BrowseRow({ entry, dragId, cat, pinnable, onOpenMenu }: {
+  entry: AddableEntry;
+  dragId: string;
+  cat?: string;
+  pinnable?: boolean;
+  onOpenMenu: (e: React.MouseEvent, entry: AddableEntry) => void;
+}) {
   // Only the pointer `listeners` go on the row, not dnd-kit `attributes`: those
   // set role="button"/tabIndex on the row, which would wrap the nested pin button
   // in a button (invalid) and promise keyboard drag we don't wire (PointerSensor).
@@ -109,6 +117,7 @@ function BrowseRow({ entry, dragId, cat, pinnable }: { entry: AddableEntry; drag
       ref={setNodeRef}
       {...listeners}
       onDoubleClick={() => spawnCentered(entry)}
+      onContextMenu={(e) => onOpenMenu(e, entry)}
       style={{ touchAction: 'pan-y' }}
       className={`${rowBodyCls} ${isDragging ? 'opacity-40' : ''}`}
     >
@@ -124,7 +133,12 @@ function BrowseRow({ entry, dragId, cat, pinnable }: { entry: AddableEntry; drag
 
 /** Favorites row: one concrete object. Normal mode the whole row drags onto the
  *  canvas; edit mode shows a left grip (reorder handle) and a right remove button. */
-function FavoriteRow({ row, index, editing }: { row: PaletteRow; index: number; editing: boolean }) {
+function FavoriteRow({ row, index, editing, onOpenMenu }: {
+  row: PaletteRow;
+  index: number;
+  editing: boolean;
+  onOpenMenu: (e: React.MouseEvent, entry: AddableEntry) => void;
+}) {
   const t = useT();
   const removeRow = useLabelStore((s) => s.removePaletteRow);
   const entry = resolveAddable(row.entryId, t);
@@ -149,6 +163,7 @@ function FavoriteRow({ row, index, editing }: { row: PaletteRow; index: number; 
         ref={setActivatorNodeRef}
         {...listeners}
         onDoubleClick={editing ? undefined : () => spawnCentered(entry)}
+        onContextMenu={editing ? undefined : (e) => onOpenMenu(e, entry)}
         style={{ touchAction: 'pan-y' }}
         className={`${rowBodyCls} ${editing ? 'bg-surface-2 border-border-2 hover:-translate-y-0' : ''}`}
       >
@@ -195,10 +210,45 @@ export function ObjectPalette() {
   const rows = useLabelStore((s) => s.paletteRows);
   const view = useLabelStore((s) => s.paletteView);
   const editing = useLabelStore((s) => s.paletteEditing);
+  const toggleRow = useLabelStore((s) => s.togglePaletteRow);
   const reorderRows = useLabelStore((s) => s.reorderPaletteRows);
   const [activeEntry, setActiveEntry] = useState<AddableEntry | null>(null);
   const [overCanvas, setOverCanvas] = useState(false);
+  const [menu, setMenu] = useState<{ x: number; y: number; sections: MenuSection[] } | null>(null);
   const q = query.trim().toLowerCase();
+
+  const openRowMenu = (e: React.MouseEvent, entry: AddableEntry) => {
+    e.preventDefault();
+    const sections = buildPaletteRowMenu({
+      pinned: rows.some((r) => r.entryId === entry.id),
+      labels: {
+        addToLabel: t.palette.addToLabel,
+        pinToFavorites: t.palette.pinToFavorites,
+        unpinFromFavorites: t.palette.unpinFromFavorites,
+      },
+      dispatch: {
+        addToLabel: () => spawnCentered(entry),
+        togglePin: () => toggleRow(entry.id),
+      },
+    });
+    setMenu({ x: e.clientX, y: e.clientY, sections });
+  };
+
+  const openAddMenu = (e: React.MouseEvent) => {
+    const groups = addableGroupsFor(t).map((g) => ({
+      id: g.key,
+      label: g.label,
+      entries: g.entries.map((entry) => ({
+        id: entry.id,
+        label: entry.label,
+        pinned: rows.some((r) => r.entryId === entry.id),
+      })),
+    }));
+    const sections = buildFavoritesAddMenu(groups, toggleRow);
+    if (!sections.some((s) => s.items.length > 0)) return; // everything already pinned
+    const r = e.currentTarget.getBoundingClientRect();
+    setMenu({ x: r.left, y: r.bottom + 4, sections });
+  };
 
   // Track the dragged entry for the overlay chip, and reorder favorites on drop.
   // Over the canvas the chip is hidden so the canvas's own ghost (the real
@@ -228,10 +278,9 @@ export function ObjectPalette() {
 
   // Flat list across every group (registry types + presets); the basis for both
   // flat mode and search.
-  const flatGroups = PALETTE_GROUPS.map((group) => ({
-    group,
-    entries: addablesInGroup(group.key, t).filter((e) => !q || e.label.toLowerCase().includes(q)),
-  })).filter((g) => g.entries.length > 0);
+  const flatGroups = addableGroupsFor(t)
+    .map((g) => ({ ...g, entries: g.entries.filter((e) => !q || e.label.toLowerCase().includes(q)) }))
+    .filter((g) => g.entries.length > 0);
   const resultCount = flatGroups.reduce((n, g) => n + g.entries.length, 0);
 
   return (
@@ -258,9 +307,9 @@ export function ObjectPalette() {
           ) : (
             <div className="flex flex-col gap-0.5">
               <p className="px-1 pb-0.5 font-mono text-[9px] text-muted">{t.palette.resultsFmt.replace('{n}', String(resultCount))}</p>
-              {flatGroups.flatMap(({ group, entries }) =>
+              {flatGroups.flatMap(({ key, entries }) =>
                 entries.map((e) => (
-                  <BrowseRow key={`${group.key}-${e.id}`} entry={e} dragId={`search-${group.key}-${e.id}`} cat={entryCategory(e, t)} pinnable />
+                  <BrowseRow key={`${key}-${e.id}`} entry={e} dragId={`search-${key}-${e.id}`} cat={entryCategory(e, t)} pinnable onOpenMenu={openRowMenu} />
                 )),
               )}
             </div>
@@ -270,31 +319,32 @@ export function ObjectPalette() {
             <SortableContext items={rows.map((r) => rowDragId(r.id))} strategy={verticalListSortingStrategy}>
               <div className="flex flex-col gap-0.5">
                 {rows.map((r, i) => (
-                  <FavoriteRow key={r.id} row={r} index={i} editing={editing} />
+                  <FavoriteRow key={r.id} row={r} index={i} editing={editing} onOpenMenu={openRowMenu} />
                 ))}
               </div>
             </SortableContext>
-            {/* Shown in edit mode, and when there are no favorites at all so an
-                empty list still tells the user how to add one. */}
+            {/* Edit mode only (plus the empty state, which otherwise has no
+                entry point at all). */}
             {(editing || rows.length === 0) && (
               <button
                 type="button"
-                onClick={() => searchRef.current?.focus()}
+                onClick={openAddMenu}
                 className="flex items-center justify-center gap-1.5 px-2 py-1.5 w-full rounded text-xs font-mono border border-dashed border-border text-muted hover:text-text hover:border-border-2 transition-colors"
               >
-                {t.palette.addViaSearchHint}
+                <PlusIcon className="w-3.5 h-3.5" />
+                {t.palette.addObjectButton}
               </button>
             )}
           </>
         ) : (
-          flatGroups.map(({ group, entries }) => (
+          flatGroups.map(({ key, label, entries }) => (
             <CollapsibleSection
-              key={group.key}
-              id={`palette-${group.key}`}
-              title={<GroupTitle label={t.palette[group.labelKey]} count={entries.length} />}
+              key={key}
+              id={`palette-${key}`}
+              title={<GroupTitle label={label} count={entries.length} />}
             >
               {entries.map((e) => (
-                <BrowseRow key={`${group.key}-${e.id}`} entry={e} dragId={`flat-${group.key}-${e.id}`} />
+                <BrowseRow key={`${key}-${e.id}`} entry={e} dragId={`flat-${key}-${e.id}`} onOpenMenu={openRowMenu} />
               ))}
             </CollapsibleSection>
           ))
@@ -304,6 +354,8 @@ export function ObjectPalette() {
       {/* Drag chip under the cursor, hidden only over the canvas (where the
           canvas renders its own full-size ghost). Shown for favorites reorder. */}
       <DragOverlay>{activeEntry && !overCanvas ? <DragChip icon={activeEntry.icon} label={activeEntry.label} /> : null}</DragOverlay>
+
+      {menu && <ContextMenu sections={menu.sections} x={menu.x} y={menu.y} onClose={() => setMenu(null)} />}
     </div>
   );
 }

--- a/src/components/Palette/paletteActions.test.ts
+++ b/src/components/Palette/paletteActions.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildFavoritesAddMenu, buildPaletteRowMenu } from "./paletteActions";
+
+const LABELS = { addToLabel: "Add", pinToFavorites: "Pin", unpinFromFavorites: "Unpin" };
+
+describe("buildPaletteRowMenu", () => {
+  it("offers add-to-label plus pin, flipping to unpin when already pinned", () => {
+    const dispatch = { addToLabel: vi.fn(), togglePin: vi.fn() };
+    const unpinned = buildPaletteRowMenu({ pinned: false, labels: LABELS, dispatch });
+    expect(unpinned[0]?.items.map((i) => i.label)).toEqual(["Add", "Pin"]);
+    const pinned = buildPaletteRowMenu({ pinned: true, labels: LABELS, dispatch });
+    expect(pinned[0]?.items.map((i) => i.label)).toEqual(["Add", "Unpin"]);
+    pinned[0]?.items[1]?.run?.();
+    expect(dispatch.togglePin).toHaveBeenCalledOnce();
+  });
+});
+
+describe("buildFavoritesAddMenu", () => {
+  const groups = [
+    { id: "text", label: "Text", entries: [{ id: "text-a", label: "A", pinned: false }] },
+    { id: "code", label: "Codes", entries: [{ id: "qr", label: "QR", pinned: true }] },
+    { id: "empty", label: "Empty", entries: [] },
+  ];
+
+  it("maps groups to submenus, disables already-pinned entries, drops empty groups", () => {
+    const onAdd = vi.fn();
+    const [section] = buildFavoritesAddMenu(groups, onAdd);
+    expect(section?.items.map((i) => i.label)).toEqual(["Text", "Codes"]);
+    const textSub = section?.items[0]?.submenu;
+    expect(textSub?.[0]?.disabled).toBe(false);
+    expect(section?.items[1]?.submenu?.[0]?.disabled).toBe(true);
+    textSub?.[0]?.run?.();
+    expect(onAdd).toHaveBeenCalledWith("text-a");
+  });
+});

--- a/src/components/Palette/paletteActions.ts
+++ b/src/components/Palette/paletteActions.ts
@@ -1,0 +1,57 @@
+import type { MenuAction, MenuSection } from "../ui/ContextMenu";
+
+/** Labels arrive resolved so the builders stay pure and locale-free. */
+export interface PaletteRowMenuCtx {
+  pinned: boolean;
+  labels: { addToLabel: string; pinToFavorites: string; unpinFromFavorites: string };
+  dispatch: {
+    addToLabel: () => void;
+    /** Adds or removes the favorites row for this entry (one row per entry). */
+    togglePin: () => void;
+  };
+}
+
+/** Right-click menu for a palette row (browse, search, or favorites). */
+export function buildPaletteRowMenu(ctx: PaletteRowMenuCtx): MenuSection[] {
+  return [
+    {
+      id: "row",
+      items: [
+        { id: "addToLabel", label: ctx.labels.addToLabel, run: ctx.dispatch.addToLabel },
+        {
+          id: "togglePin",
+          label: ctx.pinned ? ctx.labels.unpinFromFavorites : ctx.labels.pinToFavorites,
+          run: ctx.dispatch.togglePin,
+        },
+      ],
+    },
+  ];
+}
+
+export interface AddMenuGroup {
+  id: string;
+  label: string;
+  entries: { id: string; label: string; pinned: boolean }[];
+}
+
+/** Favorites "add object" menu: one level of category submenus (the palette
+ *  groups), entries already pinned are disabled instead of hidden so the
+ *  catalog reads the same regardless of curation state. */
+export function buildFavoritesAddMenu(
+  groups: readonly AddMenuGroup[],
+  onAdd: (entryId: string) => void,
+): MenuSection[] {
+  const items: MenuAction[] = groups
+    .filter((g) => g.entries.length > 0)
+    .map((g) => ({
+      id: `grp:${g.id}`,
+      label: g.label,
+      submenu: g.entries.map((e) => ({
+        id: `add:${e.id}`,
+        label: e.label,
+        disabled: e.pinned,
+        run: () => onAdd(e.id),
+      })),
+    }));
+  return [{ id: "add", items }];
+}

--- a/src/components/Palette/paletteGroups.ts
+++ b/src/components/Palette/paletteGroups.ts
@@ -1,4 +1,7 @@
 import type { ObjectGroup } from '../../types/LabelObject';
+import { addablesInGroup, type AddableEntry } from '../../registry/palettePresets';
+import type { Translations } from '../../locales';
+
 export const PALETTE_GROUPS = [
   { key: 'text' as ObjectGroup, labelKey: 'groupText' },
   { key: 'code-1d' as ObjectGroup, labelKey: 'groupCode1d' },
@@ -8,3 +11,15 @@ export const PALETTE_GROUPS = [
 ] as const;
 
 export type PaletteGroupLabelKey = typeof PALETTE_GROUPS[number]['labelKey'];
+
+/** Single source for the palette groups; each consumer maps entries onto its
+ *  own shape (flat browse, canvas add-here, favorites add). */
+export function addableGroupsFor(
+  t: Translations,
+): { key: ObjectGroup; label: string; entries: AddableEntry[] }[] {
+  return PALETTE_GROUPS.map((g) => ({
+    key: g.key,
+    label: t.palette[g.labelKey],
+    entries: addablesInGroup(g.key, t),
+  }));
+}

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronRightIcon } from "@heroicons/react/16/solid";
+import { useDismiss } from "../../hooks/useDismiss";
+
+/** One context-menu entry. `labelKey` resolves against the caller's `labels`
+ *  map; a raw `label` overrides it (dynamic entries). A `submenu` makes it a
+ *  parent row. */
+export interface MenuAction {
+  id: string;
+  labelKey?: string;
+  label?: string;
+  run?: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+  submenu?: MenuAction[];
+}
+
+/** Actions are grouped into divider-separated sections. */
+export interface MenuSection {
+  id: string;
+  items: MenuAction[];
+}
+
+type IconType = React.ComponentType<{ className?: string }>;
+
+interface Props {
+  sections: MenuSection[];
+  /** Viewport coords to open at (right-click point or an anchor corner). */
+  x: number;
+  y: number;
+  /** Resolved labels for `labelKey` entries; `label` entries need none. */
+  labels?: Record<string, string>;
+  /** Icon per action; consumer-owned so the menu model stays pure data. */
+  iconFor?: (item: MenuAction) => IconType | undefined;
+  onClose: () => void;
+}
+
+const MENU_BOX =
+  "z-[60] min-w-44 bg-surface border border-border rounded-lg shadow-2xl p-1";
+
+function labelOf(item: MenuAction, labels?: Record<string, string>): string {
+  return item.label ?? (item.labelKey ? labels?.[item.labelKey] ?? item.labelKey : item.id);
+}
+
+function RowIcon({ icon: Icon }: { icon?: IconType }) {
+  return Icon ? <Icon className="w-4 h-4 shrink-0" /> : null;
+}
+
+function Row({
+  item,
+  labels,
+  iconFor,
+  onClose,
+}: {
+  item: MenuAction;
+  labels?: Record<string, string>;
+  iconFor?: (item: MenuAction) => IconType | undefined;
+  onClose: () => void;
+}) {
+  const [subOpen, setSubOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const subRef = useRef<HTMLDivElement>(null);
+  // Submenus open to the right by default; flip left and/or shift up once the
+  // real size is known so a nested level can't run off the viewport.
+  const [flip, setFlip] = useState<{ left: boolean; up: number }>({ left: false, up: 0 });
+  const cls = `w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs font-mono rounded transition-colors ${
+    item.disabled
+      ? "text-muted/40 cursor-not-allowed"
+      : item.danger
+        ? "text-text hover:bg-error/15 hover:text-error"
+        : "text-text hover:bg-surface-2"
+  }`;
+
+  useLayoutEffect(() => {
+    if (!subOpen) return;
+    const wrap = wrapRef.current;
+    const sub = subRef.current;
+    if (!wrap || !sub) return;
+    const wr = wrap.getBoundingClientRect();
+    const sr = sub.getBoundingClientRect();
+    const overBottom = sr.bottom + 4 - window.innerHeight;
+    setFlip({
+      left: wr.right + sr.width + 4 > window.innerWidth,
+      up: overBottom > 0 ? overBottom : 0,
+    });
+  }, [subOpen]);
+
+  const submenu = item.submenu;
+  if (submenu?.length) {
+    return (
+      <div
+        ref={wrapRef}
+        className="relative"
+        onMouseEnter={() => !item.disabled && setSubOpen(true)}
+        onMouseLeave={() => setSubOpen(false)}
+      >
+        <button disabled={item.disabled} className={cls}>
+          <RowIcon icon={iconFor?.(item)} />
+          <span className="flex-1">{labelOf(item, labels)}</span>
+          <ChevronRightIcon className="w-3.5 h-3.5 text-muted shrink-0" />
+        </button>
+        {subOpen && (
+          <div
+            ref={subRef}
+            className={`absolute top-0 ${flip.left ? "right-full mr-0.5" : "left-full ml-0.5"} ${MENU_BOX}`}
+            style={flip.up ? { transform: `translateY(-${flip.up}px)` } : undefined}
+          >
+            {submenu.map((s) => (
+              <Row key={s.id} item={s} labels={labels} iconFor={iconFor} onClose={onClose} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      disabled={item.disabled}
+      className={cls}
+      onClick={() => {
+        if (item.disabled) return;
+        item.run?.();
+        onClose();
+      }}
+    >
+      <RowIcon icon={iconFor?.(item)} />
+      <span className="flex-1">{labelOf(item, labels)}</span>
+    </button>
+  );
+}
+
+/** Pure view over `MenuSection[]`; builders stay data-only. */
+export function ContextMenu({ sections, x, y, labels, iconFor, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ x, y });
+
+  // Clamp into the viewport once the real size is known.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setPos({
+      x: Math.min(x, window.innerWidth - r.width - 4),
+      y: Math.min(y, window.innerHeight - r.height - 4),
+    });
+  }, [x, y]);
+
+  // Defer so the opening right-click's own pointer events don't self-close.
+  useDismiss(ref, onClose, { defer: true });
+
+  // Also dismiss on scroll (the fixed menu would detach from its anchor) and on
+  // a context menu elsewhere (keyboard Menu key fires no pointerdown, so two
+  // could otherwise stack). Mounted after the opening event, so it isn't caught.
+  useEffect(() => {
+    const close = (e: Event) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    window.addEventListener("scroll", close, true);
+    window.addEventListener("contextmenu", close, true);
+    return () => {
+      window.removeEventListener("scroll", close, true);
+      window.removeEventListener("contextmenu", close, true);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div ref={ref} className={`fixed ${MENU_BOX}`} style={{ left: pos.x, top: pos.y }} role="menu">
+      {sections.map((section, i) => (
+        <div key={section.id}>
+          {i > 0 && <div className="my-1 border-t border-border" />}
+          {section.items.map((item) => (
+            <Row key={item.id} item={item} labels={labels} iconFor={iconFor} onClose={onClose} />
+          ))}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -17,10 +17,11 @@ const ar = {
     typeForm: 'شكل',
     noResults: 'لا نتائج لـ "{q}"',
     favorites: 'المفضلة',
-    addViaSearchHint: 'إضافة عبر البحث + ☆',
     resultsFmt: '{n} نتائج',
     unpinFromFavorites: 'إزالة من المفضلة',
     pinToFavorites: 'إضافة إلى المفضلة',
+    addToLabel: 'إضافة إلى التسمية',
+    addObjectButton: 'إضافة عنصر…',
   },
   gs1builder: {
     button: 'إنشاء محتوى GS1…',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -17,10 +17,11 @@ const bg = {
     typeForm: 'Форма',
     noResults: 'Няма съвпадения за „{q}“',
     favorites: 'Любими',
-    addViaSearchHint: 'Добавяне чрез търсене + ☆',
     resultsFmt: '{n} резултата',
     unpinFromFavorites: 'Премахване от любими',
     pinToFavorites: 'Добавяне към любими',
+    addToLabel: 'Добавяне към етикета',
+    addObjectButton: 'Добавяне на обект…',
   },
   gs1builder: {
     button: 'Създаване на GS1 съдържание…',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -17,10 +17,11 @@ const cs = {
     typeForm: 'Tvar',
     noResults: 'Žádné výsledky pro „{q}“',
     favorites: 'Oblíbené',
-    addViaSearchHint: 'Přidat vyhledáváním + ☆',
     resultsFmt: '{n} shod',
     unpinFromFavorites: 'Odebrat z oblíbených',
     pinToFavorites: 'Přidat do oblíbených',
+    addToLabel: 'Přidat na štítek',
+    addObjectButton: 'Přidat objekt…',
   },
   gs1builder: {
     button: 'Vytvořit obsah GS1…',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -17,10 +17,11 @@ const da = {
     typeForm: 'Form',
     noResults: 'Ingen resultater for "{q}"',
     favorites: 'Favoritter',
-    addViaSearchHint: 'Tilføj via søgning + ☆',
     resultsFmt: '{n} resultater',
     unpinFromFavorites: 'Fjern fra favoritter',
     pinToFavorites: 'Føj til favoritter',
+    addToLabel: 'Tilføj til etiketten',
+    addObjectButton: 'Tilføj objekt…',
   },
   gs1builder: {
     button: 'Byg GS1-indhold…',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -17,10 +17,11 @@ const de = {
     typeForm: 'Form',
     noResults: 'Keine Treffer für „{q}“',
     favorites: 'Favoriten',
-    addViaSearchHint: 'Per Suche hinzufügen + ☆',
     resultsFmt: '{n} Treffer',
     unpinFromFavorites: 'Aus Favoriten entfernen',
     pinToFavorites: 'Zu Favoriten hinzufügen',
+    addToLabel: 'Zum Etikett hinzufügen',
+    addObjectButton: 'Objekt hinzufügen…',
   },
   gs1builder: {
     button: 'GS1-Inhalt erstellen…',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -17,10 +17,11 @@ const el = {
     typeForm: 'Σχήμα',
     noResults: 'Καμία αντιστοιχία για «{q}»',
     favorites: 'Αγαπημένα',
-    addViaSearchHint: 'Προσθήκη μέσω αναζήτησης + ☆',
     resultsFmt: '{n} αποτελέσματα',
     unpinFromFavorites: 'Αφαίρεση από τα αγαπημένα',
     pinToFavorites: 'Προσθήκη στα αγαπημένα',
+    addToLabel: 'Προσθήκη στην ετικέτα',
+    addObjectButton: 'Προσθήκη αντικειμένου…',
   },
   gs1builder: {
     button: 'Δημιουργία περιεχομένου GS1…',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -17,10 +17,11 @@ const en = {
     typeForm: 'Form',
     noResults: 'No matches for "{q}"',
     favorites: 'Favorites',
-    addViaSearchHint: 'Add via search + ☆',
     resultsFmt: '{n} matches',
     unpinFromFavorites: 'Remove from favorites',
     pinToFavorites: 'Add to favorites',
+    addToLabel: 'Add to label',
+    addObjectButton: 'Add object…',
   },
   gs1builder: {
     button: 'Build GS1 content…',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -17,10 +17,11 @@ const es = {
     typeForm: 'Forma',
     noResults: 'Sin resultados para «{q}»',
     favorites: 'Favoritos',
-    addViaSearchHint: 'Añadir mediante búsqueda + ☆',
     resultsFmt: '{n} coincidencias',
     unpinFromFavorites: 'Quitar de favoritos',
     pinToFavorites: 'Añadir a favoritos',
+    addToLabel: 'Añadir a la etiqueta',
+    addObjectButton: 'Añadir objeto…',
   },
   gs1builder: {
     button: 'Crear contenido GS1…',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -17,10 +17,11 @@ const et = {
     typeForm: 'Kuju',
     noResults: 'Tulemusi pole päringule „{q}“',
     favorites: 'Lemmikud',
-    addViaSearchHint: 'Lisa otsingu kaudu + ☆',
     resultsFmt: '{n} vastet',
     unpinFromFavorites: 'Eemalda lemmikutest',
     pinToFavorites: 'Lisa lemmikutesse',
+    addToLabel: 'Lisa etiketile',
+    addObjectButton: 'Lisa objekt…',
   },
   gs1builder: {
     button: 'Loo GS1 sisu…',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -17,10 +17,11 @@ const fa = {
     typeForm: 'شکل',
     noResults: 'نتیجه‌ای برای «{q}» یافت نشد',
     favorites: 'علاقه‌مندی‌ها',
-    addViaSearchHint: 'افزودن از طریق جستجو + ☆',
     resultsFmt: '{n} نتیجه',
     unpinFromFavorites: 'حذف از علاقه‌مندی‌ها',
     pinToFavorites: 'افزودن به علاقه‌مندی‌ها',
+    addToLabel: 'افزودن به برچسب',
+    addObjectButton: 'افزودن شیء…',
   },
   gs1builder: {
     button: 'ساخت محتوای GS1…',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -17,10 +17,11 @@ const fi = {
     typeForm: 'Muoto',
     noResults: 'Ei osumia haulle "{q}"',
     favorites: 'Suosikit',
-    addViaSearchHint: 'Lisää haun kautta + ☆',
     resultsFmt: '{n} osumaa',
     unpinFromFavorites: 'Poista suosikeista',
     pinToFavorites: 'Lisää suosikkeihin',
+    addToLabel: 'Lisää etiketille',
+    addObjectButton: 'Lisää objekti…',
   },
   gs1builder: {
     button: 'Luo GS1-sisältö…',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -17,10 +17,11 @@ const fr = {
     typeForm: 'Forme',
     noResults: 'Aucun résultat pour «{q}»',
     favorites: 'Favoris',
-    addViaSearchHint: 'Ajouter via recherche + ☆',
     resultsFmt: '{n} résultats',
     unpinFromFavorites: 'Retirer des favoris',
     pinToFavorites: 'Ajouter aux favoris',
+    addToLabel: 'Ajouter à l’étiquette',
+    addObjectButton: 'Ajouter un objet…',
   },
   gs1builder: {
     button: 'Créer un contenu GS1…',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -17,10 +17,11 @@ const he = {
     typeForm: 'צורה',
     noResults: 'אין תוצאות עבור "{q}"',
     favorites: 'מועדפים',
-    addViaSearchHint: 'הוסף דרך חיפוש + ☆',
     resultsFmt: '{n} תוצאות',
     unpinFromFavorites: 'הסר מהמועדפים',
     pinToFavorites: 'הוסף למועדפים',
+    addToLabel: 'הוסף לתווית',
+    addObjectButton: 'הוסף אובייקט…',
   },
   gs1builder: {
     button: 'בניית תוכן GS1…',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -17,10 +17,11 @@ const hr = {
     typeForm: 'Oblik',
     noResults: 'Nema rezultata za „{q}“',
     favorites: 'Favoriti',
-    addViaSearchHint: 'Dodaj pretraživanjem + ☆',
     resultsFmt: '{n} rezultata',
     unpinFromFavorites: 'Ukloni iz favorita',
     pinToFavorites: 'Dodaj u favorite',
+    addToLabel: 'Dodaj na naljepnicu',
+    addObjectButton: 'Dodaj objekt…',
   },
   gs1builder: {
     button: 'Izradi GS1 sadržaj…',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -17,10 +17,11 @@ const hu = {
     typeForm: 'Alakzat',
     noResults: 'Nincs találat erre: „{q}”',
     favorites: 'Kedvencek',
-    addViaSearchHint: 'Hozzáadás kereséssel + ☆',
     resultsFmt: '{n} találat',
     unpinFromFavorites: 'Eltávolítás a kedvencekből',
     pinToFavorites: 'Hozzáadás a kedvencekhez',
+    addToLabel: 'Hozzáadás a címkéhez',
+    addObjectButton: 'Objektum hozzáadása…',
   },
   gs1builder: {
     button: 'GS1-tartalom létrehozása…',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -17,10 +17,11 @@ const it = {
     typeForm: 'Forma',
     noResults: 'Nessun risultato per "{q}"',
     favorites: 'Preferiti',
-    addViaSearchHint: 'Aggiungi tramite ricerca + ☆',
     resultsFmt: '{n} corrispondenze',
     unpinFromFavorites: 'Rimuovi dai preferiti',
     pinToFavorites: 'Aggiungi ai preferiti',
+    addToLabel: 'Aggiungi all’etichetta',
+    addObjectButton: 'Aggiungi oggetto…',
   },
   gs1builder: {
     button: 'Crea contenuto GS1…',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -17,10 +17,11 @@ const ja = {
     typeForm: '図形',
     noResults: '「{q}」に一致する項目がありません',
     favorites: 'お気に入り',
-    addViaSearchHint: '検索から追加 + ☆',
     resultsFmt: '{n} 件',
     unpinFromFavorites: 'お気に入りから削除',
     pinToFavorites: 'お気に入りに追加',
+    addToLabel: 'ラベルに追加',
+    addObjectButton: 'オブジェクトを追加…',
   },
   gs1builder: {
     button: 'GS1コンテンツを作成…',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -17,10 +17,11 @@ const ko = {
     typeForm: '도형',
     noResults: '"{q}"에 대한 결과 없음',
     favorites: '즐겨찾기',
-    addViaSearchHint: '검색으로 추가 + ☆',
     resultsFmt: '{n}개 결과',
     unpinFromFavorites: '즐겨찾기에서 제거',
     pinToFavorites: '즐겨찾기에 추가',
+    addToLabel: '레이블에 추가',
+    addObjectButton: '개체 추가…',
   },
   gs1builder: {
     button: 'GS1 콘텐츠 만들기…',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -17,10 +17,11 @@ const lt = {
     typeForm: 'Forma',
     noResults: 'Nėra atitikmenų „{q}“',
     favorites: 'Mėgstami',
-    addViaSearchHint: 'Pridėti per paiešką + ☆',
     resultsFmt: '{n} atitikmenų',
     unpinFromFavorites: 'Pašalinti iš mėgstamiausių',
     pinToFavorites: 'Pridėti prie mėgstamiausių',
+    addToLabel: 'Pridėti prie etičetės',
+    addObjectButton: 'Pridėti objektą…',
   },
   gs1builder: {
     button: 'Kurti GS1 turinį…',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -17,10 +17,11 @@ const lv = {
     typeForm: 'Forma',
     noResults: 'Nav rezultātu vaicājumam “{q}”',
     favorites: 'Izlase',
-    addViaSearchHint: 'Pievienot meklēšanas ceļā + ☆',
     resultsFmt: '{n} atbilstības',
     unpinFromFavorites: 'Noņemt no izlases',
     pinToFavorites: 'Pievienot izlasē',
+    addToLabel: 'Pievienot etiķetei',
+    addObjectButton: 'Pievienot objektu…',
   },
   gs1builder: {
     button: 'Izveidot GS1 saturu…',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -17,10 +17,11 @@ const nl = {
     typeForm: 'Vorm',
     noResults: 'Geen resultaten voor "{q}"',
     favorites: 'Favorieten',
-    addViaSearchHint: 'Toevoegen via zoeken + ☆',
     resultsFmt: '{n} resultaten',
     unpinFromFavorites: 'Verwijderen uit favorieten',
     pinToFavorites: 'Toevoegen aan favorieten',
+    addToLabel: 'Aan label toevoegen',
+    addObjectButton: 'Object toevoegen…',
   },
   gs1builder: {
     button: 'GS1-inhoud opbouwen…',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -17,10 +17,11 @@ const no = {
     typeForm: 'Form',
     noResults: 'Ingen treff for "{q}"',
     favorites: 'Favoritter',
-    addViaSearchHint: 'Legg til via søk + ☆',
     resultsFmt: '{n} treff',
     unpinFromFavorites: 'Fjern fra favoritter',
     pinToFavorites: 'Legg til i favoritter',
+    addToLabel: 'Legg til på etiketten',
+    addObjectButton: 'Legg til objekt…',
   },
   gs1builder: {
     button: 'Bygg GS1-innhold…',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -17,10 +17,11 @@ const pl = {
     typeForm: 'Kształt',
     noResults: 'Brak wyników dla „{q}”',
     favorites: 'Ulubione',
-    addViaSearchHint: 'Dodaj przez wyszukiwanie + ☆',
     resultsFmt: '{n} wyników',
     unpinFromFavorites: 'Usuń z ulubionych',
     pinToFavorites: 'Dodaj do ulubionych',
+    addToLabel: 'Dodaj do etykiety',
+    addObjectButton: 'Dodaj obiekt…',
   },
   gs1builder: {
     button: 'Utwórz treść GS1…',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -17,10 +17,11 @@ const pt = {
     typeForm: 'Forma',
     noResults: 'Nenhum resultado para "{q}"',
     favorites: 'Favoritos',
-    addViaSearchHint: 'Adicionar via pesquisa + ☆',
     resultsFmt: '{n} correspondências',
     unpinFromFavorites: 'Remover dos favoritos',
     pinToFavorites: 'Adicionar aos favoritos',
+    addToLabel: 'Adicionar à etiqueta',
+    addObjectButton: 'Adicionar objeto…',
   },
   gs1builder: {
     button: 'Criar conteúdo GS1…',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -17,10 +17,11 @@ const ro = {
     typeForm: 'Formă',
     noResults: 'Niciun rezultat pentru „{q}”',
     favorites: 'Favorite',
-    addViaSearchHint: 'Adaugă prin căutare + ☆',
     resultsFmt: '{n} rezultate',
     unpinFromFavorites: 'Elimină din favorite',
     pinToFavorites: 'Adaugă la favorite',
+    addToLabel: 'Adaugă la etichetă',
+    addObjectButton: 'Adaugă obiect…',
   },
   gs1builder: {
     button: 'Creează conținut GS1…',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -17,10 +17,11 @@ const sk = {
     typeForm: 'Tvar',
     noResults: 'Žiadne výsledky pre „{q}“',
     favorites: 'Obľúbené',
-    addViaSearchHint: 'Pridať vyhľadávaním + ☆',
     resultsFmt: '{n} zhôd',
     unpinFromFavorites: 'Odstrániť z obľúbených',
     pinToFavorites: 'Pridať do obľúbených',
+    addToLabel: 'Pridať na štítok',
+    addObjectButton: 'Pridať objekt…',
   },
   gs1builder: {
     button: 'Vytvoriť obsah GS1…',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -17,10 +17,11 @@ const sl = {
     typeForm: 'Oblika',
     noResults: 'Ni zadetkov za „{q}“',
     favorites: 'Priljubljene',
-    addViaSearchHint: 'Dodaj prek iskanja + ☆',
     resultsFmt: '{n} zadetkov',
     unpinFromFavorites: 'Odstrani iz priljubljenih',
     pinToFavorites: 'Dodaj med priljubljene',
+    addToLabel: 'Dodaj na nalepko',
+    addObjectButton: 'Dodaj objekt…',
   },
   gs1builder: {
     button: 'Ustvari vsebino GS1…',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -17,10 +17,11 @@ const sr = {
     typeForm: 'Облик',
     noResults: 'Нема резултата за „{q}“',
     favorites: 'Омиљено',
-    addViaSearchHint: 'Додај претрагом + ☆',
     resultsFmt: '{n} резултата',
     unpinFromFavorites: 'Уклони из омиљених',
     pinToFavorites: 'Додај у омиљене',
+    addToLabel: 'Додај на налепницу',
+    addObjectButton: 'Додај објекат…',
   },
   gs1builder: {
     button: 'Направи GS1 садржај…',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -17,10 +17,11 @@ const sv = {
     typeForm: 'Form',
     noResults: 'Inga träffar för "{q}"',
     favorites: 'Favoriter',
-    addViaSearchHint: 'Lägg till via sökning + ☆',
     resultsFmt: '{n} träffar',
     unpinFromFavorites: 'Ta bort från favoriter',
     pinToFavorites: 'Lägg till i favoriter',
+    addToLabel: 'Lägg till på etiketten',
+    addObjectButton: 'Lägg till objekt…',
   },
   gs1builder: {
     button: 'Skapa GS1-innehåll…',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -17,10 +17,11 @@ const tr = {
     typeForm: 'Şekil',
     noResults: '"{q}" için sonuç yok',
     favorites: 'Favoriler',
-    addViaSearchHint: 'Arama ile ekle + ☆',
     resultsFmt: '{n} sonuç',
     unpinFromFavorites: 'Favorilerden kaldır',
     pinToFavorites: 'Favorilere ekle',
+    addToLabel: 'Etikete ekle',
+    addObjectButton: 'Nesne ekle…',
   },
   gs1builder: {
     button: 'GS1 içeriği oluştur…',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -17,10 +17,11 @@ const zhHans = {
     typeForm: '形状',
     noResults: '没有匹配“{q}”的结果',
     favorites: '收藏',
-    addViaSearchHint: '通过搜索添加 + ☆',
     resultsFmt: '{n} 个匹配',
     unpinFromFavorites: '从收藏中移除',
     pinToFavorites: '添加到收藏',
+    addToLabel: '添加到标签',
+    addObjectButton: '添加对象…',
   },
   gs1builder: {
     button: '构建 GS1 内容…',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -17,10 +17,11 @@ const zhHant = {
     typeForm: '形狀',
     noResults: '沒有符合「{q}」的結果',
     favorites: '收藏',
-    addViaSearchHint: '透過搜尋新增 + ☆',
     resultsFmt: '{n} 個符合項目',
     unpinFromFavorites: '從我的最愛中移除',
     pinToFavorites: '新增至我的最愛',
+    addToLabel: '新增至標籤',
+    addObjectButton: '新增物件…',
   },
   gs1builder: {
     button: '建立 GS1 內容…',


### PR DESCRIPTION
Generalizes the canvas context-menu renderer into ui/ContextMenu (canvas keeps its icon map as a thin wrapper). Palette rows get add-to-label / pin-toggle on right click; the favorites edit mode gains an Add-object button with category submenus (pinned entries disabled). Replaces the search-hint button.