### PR TITLE
refactor(palette): move legacy 1D codes into the Postal & Legacy group

### DIFF
--- a/src/registry/codabar.ts
+++ b/src/registry/codabar.ts
@@ -5,7 +5,7 @@ export const codabarCoreConfig: Barcode1DCoreConfig = {
   label: "Codabar",
   icon: "CBA",
   defaultContent: "A12345A",
-  group: 'code-1d',
+  group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";
     const check = p.checkDigit ? "Y" : "N";

--- a/src/registry/code11.ts
+++ b/src/registry/code11.ts
@@ -6,7 +6,7 @@ export const code11CoreConfig: Barcode1DCoreConfig = {
   label: "Code 11",
   icon: "C11",
   defaultContent: "12345",
-  group: 'code-1d',
+  group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";
     const check = p.checkDigit ? "Y" : "N";

--- a/src/registry/code49.ts
+++ b/src/registry/code49.ts
@@ -26,7 +26,7 @@ export const code49: ObjectTypeCore<Code49Props> = {
   label: 'Code 49',
   icon: 'C49',
   zplCmd: '^B4',
-  group: 'code-1d',
+  group: 'code-2d',
   bindable: true,
   preflight: moduleTooSmallPreflight<Code49Props>('moduleWidth'),
   defaultProps: {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -60,7 +60,7 @@ const _ObjectRegistry = {
   // text
   text,
   symbol,
-  // code-1d (frequency order)
+  // code-1d (modern, frequency order)
   code128,
   ean13,
   upca,
@@ -70,15 +70,7 @@ const _ObjectRegistry = {
   ean8,
   upce,
   upcEanExtension,
-  code49,
-  logmars,
   code93,
-  codabar,
-  code11,
-  industrial2of5,
-  standard2of5,
-  msi,
-  plessey,
   // code-2d (frequency order)
   qrcode,
   datamatrix,
@@ -87,10 +79,18 @@ const _ObjectRegistry = {
   maxicode,
   micropdf417,
   codablock,
+  code49,
   tlc39,
-  // code-postal
-  planet,
+  // code-postal ("Postal & Legacy"): postal codes first, then legacy linear
   postal,
+  planet,
+  code11,
+  codabar,
+  logmars,
+  msi,
+  plessey,
+  standard2of5,
+  industrial2of5,
   // shape
   box,
   ellipse,

--- a/src/registry/industrial2of5.ts
+++ b/src/registry/industrial2of5.ts
@@ -5,7 +5,7 @@ export const industrial2of5CoreConfig: Barcode1DCoreConfig = {
   label: "Industrial 2 of 5",
   icon: "I25",
   defaultContent: "12345678",
-  group: 'code-1d',
+  group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";
     return `^BI${p.rotation},${p.height},${interp},${p.printInterpretationAbove ? "Y" : "N"}`;

--- a/src/registry/logmars.ts
+++ b/src/registry/logmars.ts
@@ -7,7 +7,7 @@ export const logmarsCoreConfig: Barcode1DCoreConfig = {
   label: "LOGMARS",
   icon: "LOG",
   defaultContent: "LOGMARS1",
-  group: 'code-1d',
+  group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";
     return `^BL${p.rotation},${p.height},${interp}`;

--- a/src/registry/msi.ts
+++ b/src/registry/msi.ts
@@ -5,7 +5,7 @@ export const msiCoreConfig: Barcode1DCoreConfig = {
   label: "MSI",
   icon: "MSI",
   defaultContent: "12345678",
-  group: 'code-1d',
+  group: 'code-postal',
   // MSI standard specifies a 2:1 wide:narrow ratio, which bwip-js hardcodes
   // internally. ZPL ^BY defaults to 3.0, so we must override to keep canvas
   // and Labelary preview in sync.

--- a/src/registry/plessey.ts
+++ b/src/registry/plessey.ts
@@ -5,7 +5,7 @@ export const plesseyCoreConfig: Barcode1DCoreConfig = {
   label: "Plessey",
   icon: "PLS",
   defaultContent: "12345678",
-  group: 'code-1d',
+  group: 'code-postal',
   // Plessey uses 2:1 wide:narrow ratio (same as MSI), so override ZPL default of 3.0
   byRatio: 2,
   zplCommand: (p) => {

--- a/src/registry/standard2of5.ts
+++ b/src/registry/standard2of5.ts
@@ -5,7 +5,7 @@ export const standard2of5CoreConfig: Barcode1DCoreConfig = {
   label: "Standard 2 of 5",
   icon: "S25",
   defaultContent: "12345678",
-  group: 'code-1d',
+  group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";
     return `^BJ${p.rotation},${p.height},${interp},${p.printInterpretationAbove ? "Y" : "N"}`;

--- a/src/types/LabelObject.ts
+++ b/src/types/LabelObject.ts
@@ -44,4 +44,7 @@ export type LabelObjectBase = z.infer<typeof labelObjectBaseSchema>;
 
 export type ObjectChanges = Partial<Omit<LabelObjectBase, 'id' | 'type'>> & { props?: object };
 
+/** Palette DISPLAY grouping only, not a barcode's dimension: `code-postal` is
+ *  the "Postal & Legacy" bucket (postal + obsolete linear). The 1D/2D truth
+ *  lives in BARCODE_1D_TYPES / STACKED_2D_TYPES, which emit/rotation read. */
 export type ObjectGroup = 'text' | 'code-1d' | 'code-2d' | 'code-postal' | 'shape';


### PR DESCRIPTION
Code 11, 2of5 variants, Codabar, LOGMARS, MSI, Plessey and Code 49 move from 1D Linear (now the ~10 common modern codes) into the existing Postal & Legacy group, ordered postal-first. Pure palette grouping (the group field is display-only); BARCODE_1D_TYPES and emit/rotation are untouched.