### PR TITLE
fix(palette): correct #228 review findings

### DIFF
--- a/src/components/Palette/ObjectPalette.tsx
+++ b/src/components/Palette/ObjectPalette.tsx
@@ -244,10 +244,9 @@ export function ObjectPalette() {
         pinned: rows.some((r) => r.entryId === entry.id),
       })),
     }));
-    const sections = buildFavoritesAddMenu(groups, toggleRow);
-    if (!sections.some((s) => s.items.length > 0)) return; // everything already pinned
+    if (!groups.some((g) => g.entries.some((e) => !e.pinned))) return; // everything already pinned
     const r = e.currentTarget.getBoundingClientRect();
-    setMenu({ x: r.left, y: r.bottom + 4, sections });
+    setMenu({ x: r.left, y: r.bottom + 4, sections: buildFavoritesAddMenu(groups, toggleRow) });
   };
 
   // Track the dragged entry for the overlay chip, and reorder favorites on drop.

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -153,9 +153,14 @@ export function ContextMenu({ sections, x, y, labels, iconFor, onClose }: Props)
   // Also dismiss on scroll (the fixed menu would detach from its anchor) and on
   // a context menu elsewhere (keyboard Menu key fires no pointerdown, so two
   // could otherwise stack). Mounted after the opening event, so it isn't caught.
+  // onClose via ref so an inline callback doesn't re-bind the listeners.
+  const onCloseRef = useRef(onClose);
+  useLayoutEffect(() => {
+    onCloseRef.current = onClose;
+  });
   useEffect(() => {
     const close = (e: Event) => {
-      if (!ref.current?.contains(e.target as Node)) onClose();
+      if (!ref.current?.contains(e.target as Node)) onCloseRef.current();
     };
     window.addEventListener("scroll", close, true);
     window.addEventListener("contextmenu", close, true);
@@ -163,7 +168,7 @@ export function ContextMenu({ sections, x, y, labels, iconFor, onClose }: Props)
       window.removeEventListener("scroll", close, true);
       window.removeEventListener("contextmenu", close, true);
     };
-  }, [onClose]);
+  }, []);
 
   return createPortal(
     <div ref={ref} className={`fixed ${MENU_BOX}`} style={{ left: pos.x, top: pos.y }} role="menu">

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -20,7 +20,7 @@ const lt = {
     resultsFmt: '{n} atitikmenų',
     unpinFromFavorites: 'Pašalinti iš mėgstamiausių',
     pinToFavorites: 'Pridėti prie mėgstamiausių',
-    addToLabel: 'Pridėti prie etičetės',
+    addToLabel: 'Pridėti prie etiketės',
     addObjectButton: 'Pridėti objektą…',
   },
   gs1builder: {


### PR DESCRIPTION
Lithuanian typo (etičetės -> etiketės); the favorites add-menu 'all pinned' guard now checks for an unpinned entry instead of a never-false condition; ContextMenu keeps its dismiss listeners stable via an onClose ref.