### PR TITLE
refactor(registry): derive barcode dimension sets; content accessor s…

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -18,6 +18,7 @@ import {
 } from "./bwipHelpers";
 import { resolveHriAbove, gs1HriFontDots } from "../../lib/barcodeHri";
 import { gs1ContentToElementString } from "../../lib/gs1";
+import { getObjectStringContent } from "../../lib/variableBinding";
 import { objectRotation } from "../../registry/rotation";
 import { rotatedGroupTransform } from "./rotatedGroupTransform";
 import { buildEanUpcDigitOverlay } from "./eanUpcDigitNodes";
@@ -87,7 +88,7 @@ export function BarcodeObject({
   // GS1-128 shows the parenthesized element string as HRI (firmware prints the
   // parens it strips for encoding).
   const gs1Hri = !!(obj.props as { gs1?: boolean }).gs1;
-  const contentRaw = (obj.props as { content?: string }).content ?? "";
+  const contentRaw = getObjectStringContent(obj) ?? "";
   const rawContent = gs1Hri ? gs1ContentToElementString(contentRaw) : contentRaw;
   const printInterpEnabled =
     !ObjectRegistry[obj.type]?.interpretationLocked &&

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -15,6 +15,7 @@ import {
   gtin14WithCheck,
   gs1ContentToElementString,
 } from "../../lib/gs1";
+import { getObjectStringContent } from "../../lib/variableBinding";
 import {
   barSubRect,
   CODE11_QUIET_ZONE_DELTA_MODULES,
@@ -987,7 +988,7 @@ export function renderBarcodeCanvas(
       !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
     const canvas = renderEanUpcRawCanvas({
       type: obj.type as EanUpcType,
-      text: (obj.props as { content?: string }).content ?? "",
+      text: getObjectStringContent(obj) ?? "",
       modulePxInt: get1DBwipScale(moduleWidth, scale, dpmm),
       barHeightPx: dotsToPx((obj.props as { height: number }).height, scale, dpmm),
       tailHeightPx: dotsToPx(EAN_TEXT_ZONE_DOTS, scale, dpmm),

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -197,8 +197,8 @@ export function computePreflight(
     // Cross-cutting: any content-bearing field (text, every barcode) can carry
     // invisible/ambiguous chars smuggled in via scan or foreign-tool import, so
     // check here once instead of duplicating the producer across every type.
-    const content = (leaf.props as { content?: unknown }).content;
-    if (typeof content === "string") {
+    const content = getObjectStringContent(leaf);
+    if (content !== undefined) {
       // GS1 fields carry a structural GS separator (0x1D) between chained AIs;
       // it's intentional, not smuggled, so drop it before the scan.
       const scanned = (leaf.props as { gs1?: boolean }).gs1

--- a/src/lib/zplRoundtrip.integration.test.ts
+++ b/src/lib/zplRoundtrip.integration.test.ts
@@ -3,6 +3,7 @@ import { useLabelStore } from "../store/labelStore";
 import { importZplText } from "./zplImportService";
 import { generateMultiPageZPL } from "./zplGenerator";
 import { serializeDesign, parseDesignFile } from "./designFile";
+import { getObjectStringContent } from "./variableBinding";
 
 // Integration: drive the REAL user paths (importZplText -> loadDesign -> store ->
 // generateMultiPageZPL), not parseZPL/generate in isolation. Asserts the actual
@@ -69,7 +70,7 @@ describe("round-trip integration (real import -> store -> export)", () => {
   it("a realistic foreign label: edit one field, the rest stays byte-identical", () => {
     importInto(REAL_LABEL);
     const addr = store().pages[0]!.objects.find(
-      (o) => "props" in o && (o.props as { content?: string }).content === "123 Main Street",
+      (o) => "props" in o && getObjectStringContent(o) === "123 Main Street",
     )!;
     store().updateObject(addr.id, { x: 60 });
     const out = exportZpl();

--- a/src/lib/zplRoundtrip.integration.test.ts
+++ b/src/lib/zplRoundtrip.integration.test.ts
@@ -70,7 +70,7 @@ describe("round-trip integration (real import -> store -> export)", () => {
   it("a realistic foreign label: edit one field, the rest stays byte-identical", () => {
     importInto(REAL_LABEL);
     const addr = store().pages[0]!.objects.find(
-      (o) => "props" in o && getObjectStringContent(o) === "123 Main Street",
+      (o) => getObjectStringContent(o) === "123 Main Street",
     )!;
     store().updateObject(addr.id, { x: 60 });
     const out = exportZpl();

--- a/src/registry/barcode1d.ts
+++ b/src/registry/barcode1d.ts
@@ -93,6 +93,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
     icon: config.icon,
     zplCmd,
     group: config.group,
+    barcodeClass: '1d',
     bindable: true,
     // EAN/UPC opt out (fixed-length check digit); every other 1D serializes cleanly.
     serialisable: config.serialisable ?? true,

--- a/src/registry/codablock.ts
+++ b/src/registry/codablock.ts
@@ -20,6 +20,7 @@ export const codablock: ObjectTypeCore<CodablockProps> = {
   icon: "▥B",
   zplCmd: "^BB",
   group: "code-2d",
+  barcodeClass: 'stacked2d',
   bindable: true,
   preflight: moduleTooSmallPreflight<CodablockProps>('moduleWidth'),
   defaultProps: {

--- a/src/registry/code49.ts
+++ b/src/registry/code49.ts
@@ -27,6 +27,7 @@ export const code49: ObjectTypeCore<Code49Props> = {
   icon: 'C49',
   zplCmd: '^B4',
   group: 'code-2d',
+  barcodeClass: '1d',
   bindable: true,
   preflight: moduleTooSmallPreflight<Code49Props>('moduleWidth'),
   defaultProps: {

--- a/src/registry/gs1databar.ts
+++ b/src/registry/gs1databar.ts
@@ -38,6 +38,7 @@ export const gs1databar: ObjectTypeCore<Gs1DatabarProps> = {
   icon: 'GS1',
   zplCmd: '^BR',
   group: 'code-1d',
+  barcodeClass: '1d',
   bindable: true,
   preflight: moduleTooSmallPreflight<Gs1DatabarProps>('magnification'),
   defaultProps: {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -38,14 +38,6 @@ import { maxicode } from './maxicode';
 import { tlc39 } from './tlc39';
 import { symbol } from './symbol';
 
-export const BARCODE_1D_TYPES = new Set([
-  'code128', 'code39', 'ean13', 'ean8', 'upca', 'upce', 'interleaved2of5', 'code93',
-  'code11', 'industrial2of5', 'standard2of5', 'codabar', 'logmars', 'msi', 'plessey',
-  'gs1databar', 'planet', 'postal', 'upcEanExtension', 'code49',
-]);
-
-export const STACKED_2D_TYPES = new Set(['pdf417', 'micropdf417', 'codablock']);
-
 // Graphic shape primitives (no `props.rotation`): box/ellipse/line. They
 // quarter-turn via geometry (w/h swap, or a line's angle), unlike image which
 // shares `group: 'shape'` but cannot turn. Shared by single-object rotation and
@@ -102,6 +94,18 @@ const _ObjectRegistry = {
  *  {@link getEntry} for dynamic `LabelObject['type']` lookups. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const ObjectRegistry: Record<LeafType, ObjectTypeCore<any>> = _ObjectRegistry;
+
+/** Dimensional truth for emit/rotation/bounds consumers, derived from each
+ *  entry's `barcodeClass`: a symbology missing here would silently lose
+ *  HRI/transformer/bounds behaviour, so membership is never hand-maintained
+ *  and is pinned by registry-isolation.test. */
+export const BARCODE_1D_TYPES: ReadonlySet<string> = new Set(
+  (Object.keys(ObjectRegistry) as LeafType[]).filter((t) => ObjectRegistry[t].barcodeClass === '1d'),
+);
+
+export const STACKED_2D_TYPES: ReadonlySet<string> = new Set(
+  (Object.keys(ObjectRegistry) as LeafType[]).filter((t) => ObjectRegistry[t].barcodeClass === 'stacked2d'),
+);
 
 /** Dynamic lookup for `LabelObject['type']`; undefined for non-leaf (e.g. `'group'`). */
 export function getEntry(type: string): (typeof ObjectRegistry)[LeafType] | undefined {

--- a/src/registry/micropdf417.ts
+++ b/src/registry/micropdf417.ts
@@ -17,6 +17,7 @@ export const micropdf417: ObjectTypeCore<MicroPdf417Props> = {
   icon: "▤",
   zplCmd: "^BF",
   group: "code-2d",
+  barcodeClass: 'stacked2d',
   bindable: true,
   defaultProps: {
     content: "1234",

--- a/src/registry/pdf417.ts
+++ b/src/registry/pdf417.ts
@@ -21,6 +21,7 @@ export const pdf417: ObjectTypeCore<Pdf417Props> = {
   icon: "▥",
   zplCmd: "^B7",
   group: "code-2d",
+  barcodeClass: 'stacked2d',
   bindable: true,
   defaultProps: {
     content: "1234567890",

--- a/src/registry/registry-isolation.test.ts
+++ b/src/registry/registry-isolation.test.ts
@@ -14,12 +14,20 @@ describe("registry isolation baseline", () => {
     expect(Object.keys(ObjectRegistry)).toHaveLength(34);
   });
 
-  it("classifies 20 1D barcodes", () => {
-    expect(BARCODE_1D_TYPES.size).toBe(20);
+  // Exact membership, not just size: the sets are derived from each entry's
+  // barcodeClass, and emit/rotation/bounds read them, so a reclassified or
+  // forgotten type must fail loudly here, not degrade silently on canvas.
+  it("classifies the 1D barcodes by barcodeClass", () => {
+    expect([...BARCODE_1D_TYPES].sort()).toEqual([
+      "codabar", "code11", "code128", "code39", "code49", "code93", "ean13",
+      "ean8", "gs1databar", "industrial2of5", "interleaved2of5", "logmars",
+      "msi", "planet", "plessey", "postal", "standard2of5", "upcEanExtension",
+      "upca", "upce",
+    ]);
   });
 
-  it("classifies 3 stacked 2D barcodes", () => {
-    expect(STACKED_2D_TYPES.size).toBe(3);
+  it("classifies the stacked 2D barcodes by barcodeClass", () => {
+    expect([...STACKED_2D_TYPES].sort()).toEqual(["codablock", "micropdf417", "pdf417"]);
   });
 
   it("Core and Panels maps stay key-parallel", () => {

--- a/src/test/labelarySync.test.ts
+++ b/src/test/labelarySync.test.ts
@@ -6,6 +6,7 @@ import {
   buildBwipOptions,
   getDisplaySize,
 } from "../components/Canvas/bwipHelpers";
+import { getObjectStringContent } from "../lib/variableBinding";
 import { upcSuppTextZoneDots, QR_FT_MODULE_OFFSET } from "../lib/bwipConstants";
 import { barcodeFtAnchorOffset } from "../lib/objectBounds";
 import { ObjectRegistry } from "../registry";
@@ -174,7 +175,7 @@ describe("Labelary Sync - Canvas Dimension Logic", () => {
       // single fixture.
       const hasBwipSizeMismatch =
         obj.type === "upcEanExtension" &&
-        ((obj.props as { content?: string }).content ?? "").length === 2;
+        (getObjectStringContent(obj) ?? "").length === 2;
       // GS1 Databar variant 7 (Expanded Stacked) is segments-dependent; bwip-natural
       // height differs from spec and we don't yet have a per-segment formula.
       const isGs1Sym7 = obj.type === "gs1databar" && obj.props.symbology === 7;

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -22,6 +22,13 @@ export interface ObjectTypeCore<P extends object = object> {
   defaultSize:
     | { width: number; height: number }
     | { widthMm: number; heightMm: number };
+  /** Dimensional truth for emit/rotation/bounds consumers: '1d' = linear bars
+   *  (HRI overlay, width-from-modules transformer), 'stacked2d' = row-stacked
+   *  matrix (PDF417 family). Distinct from the palette-only `group` (code49 is
+   *  displayed under 2D but IS dimensionally 1d). The registry derives its
+   *  BARCODE_1D_TYPES / STACKED_2D_TYPES sets from this field, so a new
+   *  symbology cannot silently miss them. */
+  barcodeClass?: '1d' | 'stacked2d';
   /** Height fixed by symbology spec; disables transformer height anchors. */
   heightLocked?: boolean;
   /** Symbology has no HRI in ZPL output; hides checkbox + suppresses overlay. */


### PR DESCRIPTION
…weep

BARCODE_1D_TYPES/STACKED_2D_TYPES derive from a per-entry barcodeClass so a new symbology cannot silently miss them; membership pinned by test. Remaining props.content duck-casts replaced with getObjectStringContent.