### PR TITLE
fix(canvas): drop stale drag moves so the palette ghost cannot outliv…

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -10,7 +10,8 @@ import {
   useCallback,
 } from "react";
 import { useDroppable, useDndMonitor } from "@dnd-kit/core";
-import { CANVAS_DROPPABLE_ID, type PaletteDragData } from "../../dnd/types";
+import { CANVAS_DROPPABLE_ID } from "../../dnd/types";
+import { paletteGhostHandlers } from "./paletteGhostMonitor";
 import { Stage, Layer, Group, Image as KImage, Rect, Transformer } from "react-konva";
 import type Konva from "konva";
 import { useLabelStore, useCurrentObjects, currentObjects, getCurrentObjects, selectPreviewLocksEditor } from "../../store/labelStore";
@@ -38,7 +39,7 @@ import { CAPTURE_CHROME } from "./konvaObjectProps";
 import { Grid } from "./Grid";
 import { GuideLines } from "./GuideLines";
 import { Ruler, RULER_SIZE } from "./Ruler";
-import { getEntry, SHAPE_PRIMITIVE_TYPES } from "../../registry";
+import { SHAPE_PRIMITIVE_TYPES } from "../../registry";
 import type { LeafObject } from "../../registry";
 import { addableGroupsFor } from "../Palette/paletteGroups";
 import { resolveAddable, type AddableEntry } from "../../registry/palettePresets";
@@ -1135,42 +1136,16 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     ctxMenu.openAtPointer(e.evt, sections);
   };
 
-  useDndMonitor({
-    onDragMove(event) {
-      if (previewLocks || event.over?.id !== CANVAS_DROPPABLE_ID) {
-        setGhost(null);
-        return;
-      }
-      const pos = pointerToLabelDots(lastPointerRef.current.x, lastPointerRef.current.y);
-      if (!pos) return;
-      const dragData = event.active.data.current as PaletteDragData | undefined;
-      const type = dragData?.type;
-      if (!type) return;
-      const def = getEntry(type);
-      if (!def) return;
-      setGhost({
-        id: "__ghost__",
-        type,
-        ...pos,
-        rotation: 0,
-        props: { ...def.defaultProps, ...dragData?.propsOverride },
-      } as LeafObject);
-    },
-    onDragEnd(event) {
-      setGhost(null);
-      if (previewLocks) return;
-      if (event.over?.id !== CANVAS_DROPPABLE_ID) return;
-      const pos = pointerToLabelDots(lastPointerRef.current.x, lastPointerRef.current.y);
-      if (!pos) return;
-      const dragData = event.active.data.current as PaletteDragData | undefined;
-      const type = dragData?.type;
-      if (!type) return;
-      addObject(type, pos, dragData.propsOverride);
-    },
-    onDragCancel() {
-      setGhost(null);
-    },
-  });
+  const ghostLiveRef = useRef(false);
+  useDndMonitor(
+    paletteGhostHandlers({
+      live: ghostLiveRef,
+      locked: previewLocks,
+      pointerPos: () => pointerToLabelDots(lastPointerRef.current.x, lastPointerRef.current.y),
+      setGhost,
+      addObject,
+    }),
+  );
 
   const { setNodeRef: setDropRef } = useDroppable({ id: CANVAS_DROPPABLE_ID });
 

--- a/src/components/Canvas/paletteGhostMonitor.test.ts
+++ b/src/components/Canvas/paletteGhostMonitor.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import type { DragEndEvent, DragMoveEvent } from "@dnd-kit/core";
+import { paletteGhostHandlers, type PaletteGhostDeps } from "./paletteGhostMonitor";
+import { CANVAS_DROPPABLE_ID } from "../../dnd/types";
+import type { LeafObject } from "../../registry";
+
+const CANVAS = CANVAS_DROPPABLE_ID;
+
+interface Added {
+  type: string;
+  position?: { x: number; y: number };
+  propsOverride?: object;
+}
+
+function dragEvent(
+  overId: string | null,
+  data: { type?: string; propsOverride?: object } = { type: "text" },
+): DragMoveEvent & DragEndEvent {
+  return {
+    active: { data: { current: data } },
+    over: overId === null ? null : { id: overId },
+  } as unknown as DragMoveEvent & DragEndEvent;
+}
+
+function harness(overrides: Partial<PaletteGhostDeps> = {}) {
+  const calls: { ghost: (LeafObject | null)[]; added: Added[] } = { ghost: [], added: [] };
+  const deps: PaletteGhostDeps = {
+    live: { current: false },
+    locked: false,
+    pointerPos: () => ({ x: 10, y: 20 }),
+    setGhost: (g) => calls.ghost.push(g),
+    addObject: (type, position, propsOverride) => calls.added.push({ type, position, propsOverride }),
+    ...overrides,
+  };
+  return { deps, calls, handlers: () => paletteGhostHandlers(deps) };
+}
+
+describe("paletteGhostHandlers", () => {
+  it("sets the ghost while moving over the canvas and spawns at the pointer on drop", () => {
+    const { calls, handlers } = harness();
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).toMatchObject({ id: "__ghost__", type: "text", x: 10, y: 20 });
+    handlers().onDragEnd(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).toBeNull();
+    // Assert the full spawn contract: the drop lands at the mapped pointer.
+    expect(calls.added).toEqual([{ type: "text", position: { x: 10, y: 20 }, propsOverride: undefined }]);
+  });
+
+  it("forwards the drag's propsOverride to both the ghost preview and the spawn", () => {
+    const { calls, handlers } = harness();
+    const propsOverride = { fontSize: 42 };
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS, { type: "text", propsOverride }));
+    expect(calls.ghost.at(-1)?.props).toMatchObject(propsOverride);
+    handlers().onDragEnd(dragEvent(CANVAS, { type: "text", propsOverride }));
+    expect(calls.added.at(-1)).toEqual({ type: "text", position: { x: 10, y: 20 }, propsOverride });
+  });
+
+  it("drops a stale onDragMove arriving after onDragEnd (lingering-ghost regression)", () => {
+    // dnd-kit dispatches moves from a passive effect keyed on the drag
+    // translate, which the end reducer resets, so this ordering is real.
+    const { calls, handlers } = harness();
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    handlers().onDragEnd(dragEvent(CANVAS));
+    handlers().onDragMove(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).toBeNull();
+  });
+
+  it("drops a stale onDragMove after onDragCancel", () => {
+    const { calls, handlers } = harness();
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    handlers().onDragCancel();
+    handlers().onDragMove(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).toBeNull();
+  });
+
+  it("clears the ghost when the pointer leaves the canvas droppable", () => {
+    const { calls, handlers } = harness();
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    handlers().onDragMove(dragEvent(null));
+    expect(calls.ghost.at(-1)).toBeNull();
+  });
+
+  it("keeps the last ghost when a canvas move arrives with the pointer unmeasured", () => {
+    // pointerPos() is null only transiently (container unmeasured); the move is
+    // skipped rather than clearing a valid ghost, matching the inline original.
+    let pos: { x: number; y: number } | null = { x: 10, y: 20 };
+    const { calls, handlers } = harness({ pointerPos: () => pos });
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).not.toBeNull();
+    pos = null;
+    handlers().onDragMove(dragEvent(CANVAS));
+    expect(calls.ghost.at(-1)).not.toBeNull();
+    expect(calls.added).toEqual([]);
+  });
+
+  it("does not spawn on drop outside the canvas and clears the ghost", () => {
+    const { calls, handlers } = harness();
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    handlers().onDragEnd(dragEvent(null));
+    expect(calls.ghost.at(-1)).toBeNull();
+    expect(calls.added).toEqual([]);
+  });
+
+  it("never shows a ghost and never spawns while the preview locks the editor", () => {
+    const { calls, handlers } = harness({ locked: true });
+    handlers().onDragStart();
+    handlers().onDragMove(dragEvent(CANVAS));
+    handlers().onDragEnd(dragEvent(CANVAS));
+    expect(calls.ghost.every((g) => g === null)).toBe(true);
+    expect(calls.added).toEqual([]);
+  });
+});

--- a/src/components/Canvas/paletteGhostMonitor.ts
+++ b/src/components/Canvas/paletteGhostMonitor.ts
@@ -1,0 +1,72 @@
+import type { DragEndEvent, DragMoveEvent } from "@dnd-kit/core";
+import { CANVAS_DROPPABLE_ID, type PaletteDragData } from "../../dnd/types";
+import { getEntry } from "../../registry";
+import type { LeafObject } from "../../registry";
+
+export interface PaletteGhostDeps {
+  /** Drag-liveness flag in a ref: the handlers are rebuilt per render for
+   *  fresh closures, the flag must span the whole drag. */
+  live: { current: boolean };
+  locked: boolean;
+  /** Last pointer position mapped into label dots (null while unmeasured). */
+  pointerPos: () => { x: number; y: number } | null;
+  setGhost: (ghost: LeafObject | null) => void;
+  addObject: (type: string, position?: { x: number; y: number }, propsOverride?: object) => void;
+}
+
+/** The addable drag resolved at pointer, or null when the pointer is unmeasured
+ *  or the drag carries no type. Shared so ghost preview and actual spawn agree
+ *  on which drags are addable and where. */
+function resolvePaletteDrag(
+  event: DragMoveEvent | DragEndEvent,
+  pointerPos: PaletteGhostDeps["pointerPos"],
+) {
+  const pos = pointerPos();
+  if (!pos) return null;
+  const dragData = event.active.data.current as PaletteDragData | undefined;
+  if (!dragData?.type) return null;
+  return { pos, type: dragData.type, propsOverride: dragData.propsOverride };
+}
+
+/** Ghost lifecycle for palette drags, extracted so the event ordering is
+ *  regression-testable: dnd-kit dispatches onDragMove from a passive effect
+ *  keyed on the drag translate, which the drag-end reducer resets, so a stale
+ *  move can arrive after onDragEnd. The live flag drops those moves, else the
+ *  ghost outlives the drag. */
+export function paletteGhostHandlers({ live, locked, pointerPos, setGhost, addObject }: PaletteGhostDeps) {
+  return {
+    onDragStart() {
+      live.current = true;
+      setGhost(null);
+    },
+    onDragMove(event: DragMoveEvent) {
+      if (!live.current || locked || event.over?.id !== CANVAS_DROPPABLE_ID) {
+        setGhost(null);
+        return;
+      }
+      const drag = resolvePaletteDrag(event, pointerPos);
+      const def = drag && getEntry(drag.type);
+      if (!drag || !def) return;
+      setGhost({
+        id: "__ghost__",
+        type: drag.type,
+        ...drag.pos,
+        rotation: 0,
+        props: { ...def.defaultProps, ...drag.propsOverride },
+      } as LeafObject);
+    },
+    onDragEnd(event: DragEndEvent) {
+      live.current = false;
+      setGhost(null);
+      if (locked) return;
+      if (event.over?.id !== CANVAS_DROPPABLE_ID) return;
+      const drag = resolvePaletteDrag(event, pointerPos);
+      if (!drag) return;
+      addObject(drag.type, drag.pos, drag.propsOverride);
+    },
+    onDragCancel() {
+      live.current = false;
+      setGhost(null);
+    },
+  };
+}


### PR DESCRIPTION
…e the drag

dnd-kit dispatches onDragMove from a passive effect keyed on the drag translate, which the drag-end reducer resets, so a move can land after onDragEnd.