### PR TITLE
feat(properties): per-object FO/FT anchor toggle

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -23,7 +23,7 @@ import { Select } from "../ui/Select";
 import type { SnapGuide } from "../../lib/snapGuides";
 import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/align";
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
-import { objectBoundsDots, selectionUnionDots, printableRectDots } from "../../lib/objectBounds";
+import { objectBoundsDots, selectionUnionDots, printableRectDots, isBarcode } from "../../lib/objectBounds";
 import { computePreflight, markerValueFindings } from "../../lib/preflight";
 import { barcodeEncodeFindings } from "./barcodePreflight";
 import { usePreviewBinding } from "../../store/usePreviewBinding";
@@ -41,6 +41,7 @@ import { GuideLines } from "./GuideLines";
 import { Ruler, RULER_SIZE } from "./Ruler";
 import { SHAPE_PRIMITIVE_TYPES } from "../../registry";
 import type { LeafObject } from "../../registry";
+import { convertPositionType } from "../../lib/positionConvert";
 import { addableGroupsFor } from "../Palette/paletteGroups";
 import { resolveAddable, type AddableEntry } from "../../registry/palettePresets";
 import { useColorScheme } from "../../lib/useColorScheme";
@@ -116,6 +117,7 @@ export interface LabelCanvasHandle {
   alignSelection: (op: AlignOp, ref: AlignRef) => void;
   distributeSelection: (axis: DistributeAxis) => void;
   tidySelection: () => void;
+  convertObjectPositionType: (id: string, target: "FO" | "FT") => void;
 }
 
 export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCanvas({
@@ -773,9 +775,27 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
           const updates = deltas.flatMap(sel.apply);
           if (updates.length > 0) updateObjects(updates);
         },
+        // ^FO<->^FT re-anchor: owned here so the measured-footprint read stays in
+        // the layer that publishes it, like align/distribute. Pure conversion,
+        // one undo step; no-op on groups and unsupported types. Barcodes need
+        // their published footprint for the anchor delta, so an unmeasured one
+        // (hidden/unmounted, or a failed render) refuses instead of converting
+        // on fallback dims that would shift the real position.
+        convertObjectPositionType: (id: string, target: "FO" | "FT") => {
+          const state = useLabelStore.getState();
+          const obj = findObjectById(currentObjects(state), id);
+          if (!obj || isGroup(obj)) return;
+          const measured = measuredBoundsMap();
+          if (isBarcode(obj) && !measured.has(id)) return;
+          const patch = convertPositionType(obj, target, {
+            label: state.label,
+            measured,
+          });
+          if (patch) updateObject(id, patch);
+        },
       };
     },
-    [updateObjects],
+    [updateObjects, updateObject],
   );
 
   const {

--- a/src/components/Properties/PropertiesPanel.tsx
+++ b/src/components/Properties/PropertiesPanel.tsx
@@ -24,7 +24,9 @@ import { SectionCard, StaticSectionCard } from "./SectionCard";
 import { UnitNumberInput } from "./UnitNumberInput";
 import { FieldLabel, ZplCmd } from "./ZplCmd";
 import { Tooltip } from "../ui/Tooltip";
+import { SegmentedControl } from "../ui/SegmentedControl";
 import { Select } from "../ui/Select";
+import { positionTypeOf, supportsPositionToggle } from "../../lib/positionConvert";
 import { fontSelectGroups } from "./fontSelectGroups";
 import { AlignToolbar } from "./AlignToolbar";
 import { DensityRescaleModal } from "./DensityRescaleModal";
@@ -311,6 +313,26 @@ export function PropertiesPanel({ canvasRef }: PropertiesPanelProps) {
                   }
                 />
               </div>
+            </div>
+          )}
+          {/* Anchor style (^FO top-left vs ^FT baseline): power-user emit-style
+              choice, so it only appears with the ZPL-command preference. The
+              flip keeps the visual position constant. Hidden objects are
+              excluded: unmounted, so no measured footprint to convert against. */}
+          {!groupRow && showZplCommands && supportsPositionToggle(obj.type) && obj.visible !== false && (
+            <div className="flex items-center justify-between gap-2">
+              <span className={labelCls}>{t.properties.anchorMode}</span>
+              <SegmentedControl
+                value={positionTypeOf(obj)}
+                onChange={(target) => {
+                  if (target) canvasRef.current?.convertObjectPositionType(obj.id, target);
+                }}
+                options={[
+                  { value: "FO", label: "^FO", tooltip: t.properties.anchorTopLeftHint },
+                  { value: "FT", label: "^FT", tooltip: t.properties.anchorBaselineHint },
+                ]}
+                aria-label={t.properties.anchorMode}
+              />
             </div>
           )}
           <PositionSectionHeader

--- a/src/lib/positionConvert.test.ts
+++ b/src/lib/positionConvert.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { convertPositionType, supportsPositionToggle } from "./positionConvert";
+import { objectBoundsDots, type ObjectBoundsCtx } from "./objectBounds";
+import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "./bwipConstants";
+import type { LabelConfig } from "../types/LabelConfig";
+import type { LabelObject } from "../types/Group";
+import type { LeafObject } from "../registry";
+import type { ZplRotation } from "../registry/rotation";
+
+const label: LabelConfig = { widthMm: 100, heightMm: 50, dpmm: 8 };
+const ctx = (measured?: ObjectBoundsCtx["measured"]): ObjectBoundsCtx => ({ label, measured });
+
+function leaf<T extends LeafObject["type"]>(
+  type: T,
+  x: number,
+  y: number,
+  props: Extract<LeafObject, { type: T }>["props"],
+  extra: Partial<LabelObject> = {},
+): LeafObject {
+  return { id: `${type}-${x}-${y}`, type, x, y, rotation: 0, props, ...extra } as LeafObject;
+}
+
+function flipped(obj: LeafObject, target: "FO" | "FT", c: ObjectBoundsCtx): LeafObject {
+  const patch = convertPositionType(obj, target, c);
+  expect(patch).not.toBeNull();
+  return { ...obj, ...patch } as LeafObject;
+}
+
+describe("convertPositionType", () => {
+  it("returns null when the object already has the target anchor", () => {
+    const box = leaf("box", 10, 20, { width: 200, height: 100, thickness: 3, filled: false, color: "B", rounding: 0 });
+    expect(convertPositionType(box, "FO", ctx())).toBeNull();
+    const ft = { ...box, positionType: "FT" } as LeafObject;
+    expect(convertPositionType(ft, "FT", ctx())).toBeNull();
+  });
+
+  it("refuses to convert a symbol (^GS emits an uncompensated, unverified ^FT anchor)", () => {
+    const sym = leaf("symbol", 20, 30, { symbol: "B", height: 40, width: 40, rotation: "N" });
+    expect(convertPositionType(sym, "FT", ctx())).toBeNull();
+    expect(supportsPositionToggle("symbol")).toBe(false);
+    expect(supportsPositionToggle("code128")).toBe(true);
+    expect(supportsPositionToggle("text")).toBe(true);
+  });
+
+  it("text and graphics flip flag-only: model coordinates are anchor-independent", () => {
+    const cases: LeafObject[] = [
+      leaf("text", 40, 60, { content: "Hi", fontHeight: 30, fontWidth: 0, rotation: "N" }),
+      leaf("box", 10, 20, { width: 200, height: 100, thickness: 3, filled: false, color: "B", rounding: 0 }),
+      leaf("ellipse", 5, 5, { width: 150, height: 80, thickness: 3, filled: false, color: "B" }),
+      leaf("line", 300, 50, { angle: 180, length: 200, thickness: 4, color: "B" }),
+      leaf("image", 4, 8, { imageId: "a", widthDots: 90, threshold: 128 }),
+    ];
+    for (const obj of cases) {
+      const patch = convertPositionType(obj, "FT", ctx());
+      expect(patch, obj.type).toEqual({ positionType: "FT", x: obj.x, y: obj.y });
+      const back = convertPositionType({ ...obj, ...patch } as LeafObject, "FO", ctx());
+      expect(back, obj.type).toEqual({ positionType: "FO", x: obj.x, y: obj.y });
+    }
+  });
+
+  it("code128 N: FO->FT anchors at the bar base (y shifts by bar height)", () => {
+    const bc = leaf("code128", 100, 200, { content: "123", height: 80, moduleWidth: 2, rotation: "N", printInterpretation: true, checkDigit: false });
+    const measured = new Map([[bc.id, { width: 220, height: 110, uprightBarWDots: 220, uprightBarHDots: 80 }]]);
+    const patch = convertPositionType(bc, "FT", ctx(measured));
+    expect(patch).toEqual({ positionType: "FT", x: 100, y: 280 });
+  });
+
+  it("barcode: visual bounds are invariant across the flip for every rotation", () => {
+    for (const rotation of ["N", "R", "I", "B"] as ZplRotation[]) {
+      const bc = leaf("code128", 100, 200, { content: "123", height: 80, moduleWidth: 2, rotation, printInterpretation: true, checkDigit: false });
+      const measured = new Map([[bc.id, { width: 220, height: 110, uprightBarWDots: 220, uprightBarHDots: 80 }]]);
+      const before = objectBoundsDots(bc, ctx(measured));
+      const ft = flipped(bc, "FT", ctx(measured));
+      expect(objectBoundsDots(ft, ctx(measured)), `FT ${rotation}`).toEqual(before);
+      const back = flipped(ft, "FO", ctx(measured));
+      expect(objectBoundsDots(back, ctx(measured)), `FO ${rotation}`).toEqual(before);
+      expect({ x: back.x, y: back.y }).toEqual({ x: bc.x, y: bc.y });
+    }
+  });
+
+  it("qrcode: flip compensates both firmware shifts, bounds stay put", () => {
+    const qr = leaf("qrcode", 50, 70, { content: "Q", magnification: 4, rotation: "N", errorCorrection: "M", model: 2 });
+    const measured = new Map([[qr.id, { width: 100, height: 100, uprightBarWDots: 100, uprightBarHDots: 100 }]]);
+    const before = objectBoundsDots(qr, ctx(measured));
+    const ft = flipped(qr, "FT", ctx(measured));
+    expect(objectBoundsDots(ft, ctx(measured))).toEqual(before);
+    // FO renders y + QR_FO_Y_OFFSET; FT renders y - uprightH - QR_FT_MODULE_OFFSET*mag.
+    expect(ft.y).toBe(70 + QR_FO_Y_OFFSET_DOTS + 100 + QR_FT_MODULE_OFFSET * 4);
+    const back = flipped(ft, "FO", ctx(measured));
+    expect({ x: back.x, y: back.y }).toEqual({ x: qr.x, y: qr.y });
+  });
+
+  it("barcode with HRI zone offsets (barLeft/barTop) still round-trips exactly", () => {
+    const bc = leaf("code128", 100, 200, { content: "123", height: 80, moduleWidth: 2, rotation: "N", printInterpretation: true, checkDigit: false });
+    const measured = new Map([
+      [bc.id, { width: 220, height: 110, barLeftDots: 6, barTopDots: 24, uprightBarWDots: 220, uprightBarHDots: 80 }],
+    ]);
+    const before = objectBoundsDots(bc, ctx(measured));
+    const ft = flipped(bc, "FT", ctx(measured));
+    expect(objectBoundsDots(ft, ctx(measured))).toEqual(before);
+    const back = flipped(ft, "FO", ctx(measured));
+    expect({ x: back.x, y: back.y }).toEqual({ x: bc.x, y: bc.y });
+  });
+
+  it("unmeasured barcode falls back to prop height, matching the bounds fallback", () => {
+    const bc = leaf("code128", 100, 200, { content: "123", height: 80, moduleWidth: 2, rotation: "N", printInterpretation: true, checkDigit: false });
+    const before = objectBoundsDots(bc, ctx());
+    const ft = flipped(bc, "FT", ctx());
+    expect(objectBoundsDots(ft, ctx())).toEqual(before);
+  });
+});

--- a/src/lib/positionConvert.ts
+++ b/src/lib/positionConvert.ts
@@ -1,0 +1,39 @@
+import type { LeafObject } from "../registry";
+import { objectBoundsDots, type ObjectBoundsCtx } from "./objectBounds";
+
+export const positionTypeOf = (obj: { positionType?: "FO" | "FT" }): "FO" | "FT" =>
+  obj.positionType === "FT" ? "FT" : "FO";
+
+/** Whether the ^FO/^FT toggle can re-anchor `type` while holding the visual
+ *  position constant. Excludes `symbol` (^GS): it emits a raw, uncompensated
+ *  anchor (registry `fieldPos`) yet its bounds are anchor-independent, so a ^FT
+ *  flip would shift the printed glyph to its baseline with no editor change and
+ *  no verified offset. See [[project_ticket_symbol_ft_anchor]]. */
+export function supportsPositionToggle(type: string): boolean {
+  return type !== "symbol";
+}
+
+/** The model patch that re-anchors `obj` as `target` (^FO/^FT) with its visual
+ *  position unchanged, or null when there is nothing to convert. Inverts the
+ *  shared bounds numerically: flip the flag, measure the box shift, compensate
+ *  x/y. That inherits every anchor rule from objectBoundsDots (rotation-aware
+ *  ^FT offsets, QR firmware shifts, HRI zone), so the conversion cannot drift
+ *  from what canvas and emit agree on. Text and graphics are anchor-independent
+ *  (delta zero, flag only). Barcodes need their measured footprint; this stays
+ *  permissive (fallback dims keep before/after consistent), the canvas handle
+ *  refuses unmeasured ones. */
+export function convertPositionType(
+  obj: LeafObject,
+  target: "FO" | "FT",
+  ctx: ObjectBoundsCtx,
+): { positionType: "FO" | "FT"; x: number; y: number } | null {
+  if (!supportsPositionToggle(obj.type)) return null;
+  if (positionTypeOf(obj) === target) return null;
+  const before = objectBoundsDots(obj, ctx);
+  const after = objectBoundsDots({ ...obj, positionType: target } as LeafObject, ctx);
+  return {
+    positionType: target,
+    x: Math.round(obj.x + before.x - after.x),
+    y: Math.round(obj.y + before.y - after.y),
+  };
+}

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -340,6 +340,9 @@ const ar = {
 
   properties: {
     positionSection: 'الموضع (مم)',
+    anchorMode: 'مرساة',
+    anchorTopLeftHint: 'الموضع هو الزاوية العلوية اليسرى',
+    anchorBaselineHint: 'الموضع هو خط الأساس (الحافة السفلية للأشكال والرموز الشريطية)',
     optionsSection: 'خيارات',
     contentSection: 'المحتوى',
     settingsSection: 'الإعدادات',
@@ -644,7 +647,7 @@ const ar = {
     app: {
       editorHeading: 'المحرر',
       powerUser: 'وضع المستخدم المتقدم',
-      powerUserHint: 'عرض أمر ZPL المُولَّد بجوار كل خاصية',
+      powerUserHint: 'عرض أمر ZPL المُولَّد بجوار كل خاصية وتفعيل عناصر التحكم المتقدمة',
       smartSnap: 'الإرساء الذكي',
       smartSnapHint: 'محاذاة مع الكائنات الأخرى أثناء السحب. اضغط Ctrl/Cmd للتخطي.',
       privacyHeading: 'الخصوصية',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -340,6 +340,9 @@ const bg = {
 
   properties: {
     positionSection: 'Позиция',
+    anchorMode: 'Котва',
+    anchorTopLeftHint: 'Позицията е горният ляв ъгъл',
+    anchorBaselineHint: 'Позицията е базовата линия (долен ръб за форми и баркодове)',
     optionsSection: 'Опции',
     contentSection: 'Съдържание',
     settingsSection: 'Настройки',
@@ -644,7 +647,7 @@ const bg = {
     app: {
       editorHeading: 'Редактор',
       powerUser: 'Режим за напреднали потребители',
-      powerUserHint: 'Показва генерирания ZPL команд до всяко свойство',
+      powerUserHint: 'Показва генерираната ZPL команда до всяко свойство и отключва разширени контроли',
       smartSnap: 'Интелигентно закрепване',
       smartSnapHint: 'Подравнява към другите обекти при плъзгане. Задръжте Ctrl/Cmd за заобикаляне.',
       privacyHeading: 'Поверителност',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -340,6 +340,9 @@ const cs = {
 
   properties: {
     positionSection: 'Pozice',
+    anchorMode: 'Kotva',
+    anchorTopLeftHint: 'Poloha je levý horní roh',
+    anchorBaselineHint: 'Poloha je účaří (dolní hrana pro tvary a čárové kódy)',
     optionsSection: 'Možnosti',
     contentSection: 'Obsah',
     settingsSection: 'Nastavení',
@@ -644,7 +647,7 @@ const cs = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Pokročilý režim',
-      powerUserHint: 'Zobrazit vygenerovaný ZPL příkaz vedle každé vlastnosti',
+      powerUserHint: 'Zobrazit vygenerovaný ZPL příkaz vedle každé vlastnosti a odemknout pokročilé ovládání',
       smartSnap: 'Inteligentní přichycení',
       smartSnapHint: 'Zarovnávat na ostatní objekty při přetahování. Podržte Ctrl/Cmd pro přeskočení.',
       privacyHeading: 'Soukromí',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -340,6 +340,9 @@ const da = {
 
   properties: {
     positionSection: 'Position',
+    anchorMode: 'Anker',
+    anchorTopLeftHint: 'Positionen er øverste venstre hjørne',
+    anchorBaselineHint: 'Positionen er grundlinjen (underkant for former og stregkoder)',
     optionsSection: 'Valg',
     contentSection: 'Indhold',
     settingsSection: 'Indstillinger',
@@ -644,7 +647,7 @@ const da = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Avanceret brugertilstand',
-      powerUserHint: 'Vis den genererede ZPL-kommando ved siden af hver egenskab',
+      powerUserHint: 'Vis den genererede ZPL-kommando ved siden af hver egenskab og lås avancerede indstillinger op',
       smartSnap: 'Smart snap',
       smartSnapHint: 'Juster mod andre objekter under trækning. Hold Ctrl/Cmd nede for at omgå.',
       privacyHeading: 'Privatliv',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -340,6 +340,9 @@ const de = {
 
   properties: {
     positionSection: 'Position',
+    anchorMode: 'Anker',
+    anchorTopLeftHint: 'Position ist die linke obere Ecke',
+    anchorBaselineHint: 'Position ist die Grundlinie (bei Formen und Barcodes die Unterkante)',
     optionsSection: 'Optionen',
     contentSection: 'Inhalt',
     settingsSection: 'Einstellungen',
@@ -644,7 +647,7 @@ const de = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Power-User-Modus',
-      powerUserHint: 'Den erzeugten ZPL-Befehl neben jeder Eigenschaft anzeigen',
+      powerUserHint: 'Zeigt den erzeugten ZPL-Befehl neben jeder Eigenschaft und schaltet erweiterte Funktionen frei',
       smartSnap: 'Intelligentes Einrasten',
       smartSnapHint: 'Beim Ziehen an anderen Objekten ausrichten. Ctrl/Cmd halten zum Überspringen.',
       privacyHeading: 'Datenschutz',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -340,6 +340,9 @@ const el = {
 
   properties: {
     positionSection: 'Θέση',
+    anchorMode: 'Άγκυρα',
+    anchorTopLeftHint: 'Η θέση είναι η επάνω αριστερή γωνία',
+    anchorBaselineHint: 'Η θέση είναι η γραμμή βάσης (κάτω άκρη για σχήματα και barcodes)',
     optionsSection: 'Επιλογές',
     contentSection: 'Περιεχόμενο',
     settingsSection: 'Ρυθμίσεις',
@@ -644,7 +647,7 @@ const el = {
     app: {
       editorHeading: 'Επεξεργαστής',
       powerUser: 'Λειτουργία έμπειρου χρήστη',
-      powerUserHint: 'Εμφάνιση της εκπεμπόμενης εντολής ZPL δίπλα σε κάθε ιδιότητα',
+      powerUserHint: 'Εμφάνιση της εκπεμπόμενης εντολής ZPL δίπλα σε κάθε ιδιότητα και ενεργοποίηση σύνθετων ρυθμίσεων',
       smartSnap: 'Έξυπνη προσάρτηση',
       smartSnapHint: 'Ευθυγράμμιση με άλλα αντικείμενα κατά τη μεταφορά. Κρατήστε Ctrl/Cmd για παράκαμψη.',
       privacyHeading: 'Απόρρητο',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -340,6 +340,9 @@ const en = {
 
   properties: {
     positionSection: 'Position',
+    anchorMode: 'Anchor',
+    anchorTopLeftHint: 'Position is the top-left corner',
+    anchorBaselineHint: 'Position is the baseline (bottom edge for shapes and barcodes)',
     optionsSection: 'Options',
     contentSection: 'Content',
     settingsSection: 'Settings',
@@ -644,7 +647,7 @@ const en = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Power-user mode',
-      powerUserHint: 'Show the emitted ZPL command next to each property',
+      powerUserHint: 'Show the generated ZPL command next to each property and unlock advanced controls',
       smartSnap: 'Smart snapping',
       smartSnapHint: 'Align to other objects while dragging. Hold Ctrl/Cmd to bypass.',
       privacyHeading: 'Privacy',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -340,6 +340,9 @@ const es = {
 
   properties: {
     positionSection: 'Posición',
+    anchorMode: 'Anclaje',
+    anchorTopLeftHint: 'La posición es la esquina superior izquierda',
+    anchorBaselineHint: 'La posición es la línea base (borde inferior para formas y códigos de barras)',
     optionsSection: 'Opciones',
     contentSection: 'Contenido',
     settingsSection: 'Ajustes',
@@ -644,7 +647,7 @@ const es = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Modo avanzado',
-      powerUserHint: 'Mostrar el comando ZPL generado junto a cada propiedad',
+      powerUserHint: 'Mostrar el comando ZPL generado junto a cada propiedad y desbloquear controles avanzados',
       smartSnap: 'Ajuste inteligente',
       smartSnapHint: 'Alinear con otros objetos al arrastrar. Mantén Ctrl/Cmd para omitir.',
       privacyHeading: 'Privacidad',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -340,6 +340,9 @@ const et = {
 
   properties: {
     positionSection: 'Asukoht',
+    anchorMode: 'Ankur',
+    anchorTopLeftHint: 'Asukoht on vasak ülemine nurk',
+    anchorBaselineHint: 'Asukoht on baasjoon (alumine serv kujundite ja vöötkoodi jaoks)',
     optionsSection: 'Valikud',
     contentSection: 'Sisu',
     settingsSection: 'Sätted',
@@ -644,7 +647,7 @@ const et = {
     app: {
       editorHeading: 'Redaktor',
       powerUser: 'Power-kasutaja režiim',
-      powerUserHint: 'Kuva emiteeritud ZPL käsk iga atribuudi kõrval',
+      powerUserHint: 'Kuva emiteeritud ZPL käsk iga atribuudi kõrval ja luba täpsemad juhtelemendid',
       smartSnap: 'Nutikas haakimine',
       smartSnapHint: 'Joonda teiste objektidega lohistades. Hoidke Ctrl/Cmd all, et vahele jätta.',
       privacyHeading: 'Privaatsus',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -340,6 +340,9 @@ const fa = {
 
   properties: {
     positionSection: 'موقعیت (میلی‌متر)',
+    anchorMode: 'لنگر',
+    anchorTopLeftHint: 'موقعیت گوشه بالا سمت چپ است',
+    anchorBaselineHint: 'موقعیت خط پایه است (لبه پایین برای اشکال و بارکدها)',
     optionsSection: 'گزینه‌ها',
     contentSection: 'محتوا',
     settingsSection: 'تنظیمات',
@@ -644,7 +647,7 @@ const fa = {
     app: {
       editorHeading: 'ویرایشگر',
       powerUser: 'حالت کاربر حرفه‌ای',
-      powerUserHint: 'نمایش دستور ZPL تولیدشده در کنار هر ویژگی',
+      powerUserHint: 'نمایش دستور ZPL تولیدشده در کنار هر ویژگی و فعال‌سازی کنترل‌های پیشرفته',
       smartSnap: 'تراز هوشمند',
       smartSnapHint: 'در هنگام کشیدن با سایر اشیاء تراز شود. برای رد کردن Ctrl/Cmd را نگه دارید.',
       privacyHeading: 'حریم خصوصی',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -340,6 +340,9 @@ const fi = {
 
   properties: {
     positionSection: 'Sijainti',
+    anchorMode: 'Ankkuri',
+    anchorTopLeftHint: 'Sijainti on vasen yläkulma',
+    anchorBaselineHint: 'Sijainti on perusviiva (alareuna muodoille ja viivakoodeille)',
     optionsSection: 'Valinnat',
     contentSection: 'Sisältö',
     settingsSection: 'Asetukset',
@@ -644,7 +647,7 @@ const fi = {
     app: {
       editorHeading: 'Editori',
       powerUser: 'Tehokäyttäjätila',
-      powerUserHint: 'Näytä lähetetty ZPL-komento jokaisen ominaisuuden vieressä',
+      powerUserHint: 'Näytä lähetetty ZPL-komento jokaisen ominaisuuden vieressä ja ota käyttöön lisäasetukset',
       smartSnap: 'Älykäs napsautus',
       smartSnapHint: 'Kohdistaa muihin objekteihin vedettäessä. Pidä Ctrl/Cmd ohitusta varten.',
       privacyHeading: 'Tietosuoja',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -340,6 +340,9 @@ const fr = {
 
   properties: {
     positionSection: 'Position',
+    anchorMode: 'Ancrage',
+    anchorTopLeftHint: 'La position est le coin supérieur gauche',
+    anchorBaselineHint: 'La position est la ligne de base (bord inférieur pour les formes et codes-barres)',
     optionsSection: 'Options',
     contentSection: 'Contenu',
     settingsSection: 'Paramètres',
@@ -644,7 +647,7 @@ const fr = {
     app: {
       editorHeading: 'Éditeur',
       powerUser: 'Mode utilisateur avancé',
-      powerUserHint: 'Afficher la commande ZPL émise à côté de chaque propriété',
+      powerUserHint: 'Afficher la commande ZPL émise à côté de chaque propriété et déverrouiller les contrôles avancés',
       smartSnap: 'Accrochage intelligent',
       smartSnapHint: 'Aligner sur les autres objets en faisant glisser. Maintenir Ctrl/Cmd pour ignorer.',
       privacyHeading: 'Confidentialité',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -340,6 +340,9 @@ const he = {
 
   properties: {
     positionSection: 'מיקום (מ"מ)',
+    anchorMode: 'עוגן',
+    anchorTopLeftHint: 'המיקום הוא הפינה השמאלית העליונה',
+    anchorBaselineHint: 'המיקום הוא קו הבסיס (הקצה התחתון לצורות ולברקודים)',
     optionsSection: 'אפשרויות',
     contentSection: 'תוכן',
     settingsSection: 'הגדרות',
@@ -644,7 +647,7 @@ const he = {
     app: {
       editorHeading: 'עורך',
       powerUser: 'מצב מתקדם',
-      powerUserHint: 'הצג את פקודת ZPL שנוצרה ליד כל מאפיין',
+      powerUserHint: 'הצג את פקודת ZPL שנוצרה ליד כל מאפיין ופתח פקדים מתקדמים',
       smartSnap: 'הצמדה חכמה',
       smartSnapHint: 'ישר לאובייקטים אחרים בזמן גרירה. לחץ Ctrl/Cmd לדילוג.',
       privacyHeading: 'פרטיות',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -340,6 +340,9 @@ const hr = {
 
   properties: {
     positionSection: 'Položaj',
+    anchorMode: 'Sidro',
+    anchorTopLeftHint: 'Položaj je gornji lijevi kut',
+    anchorBaselineHint: 'Položaj je osnovna linija (donji rub za oblike i barkodove)',
     optionsSection: 'Opcije',
     contentSection: 'Sadržaj',
     settingsSection: 'Postavke',
@@ -644,7 +647,7 @@ const hr = {
     app: {
       editorHeading: 'Uređivač',
       powerUser: 'Napredni korisnički način',
-      powerUserHint: 'Prikaži generirani ZPL naredbu pored svakog svojstva',
+      powerUserHint: 'Prikaži generiranu ZPL naredbu pored svakog svojstva i otključaj napredne kontrole',
       smartSnap: 'Pametno prianjanje',
       smartSnapHint: 'Poravnaj s drugim objektima pri povlačenju. Drži Ctrl/Cmd za zaobilaženje.',
       privacyHeading: 'Privatnost',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -340,6 +340,9 @@ const hu = {
 
   properties: {
     positionSection: 'Pozíció',
+    anchorMode: 'Horgony',
+    anchorTopLeftHint: 'A pozíció a bal felső sarok',
+    anchorBaselineHint: 'A pozíció az alapvonal (alakzatok és vonalkódok alsó széle)',
     optionsSection: 'Lehetőségek',
     contentSection: 'Tartalom',
     settingsSection: 'Beállítások',
@@ -644,7 +647,7 @@ const hu = {
     app: {
       editorHeading: 'Szerkesztő',
       powerUser: 'Haladó felhasználói mód',
-      powerUserHint: 'Mutassa az emittált ZPL parancsot minden tulajdonság mellett',
+      powerUserHint: 'Mutassa az emittált ZPL parancsot minden tulajdonság mellett, és oldja fel a speciális vezérlőket',
       smartSnap: 'Intelligens illesztés',
       smartSnapHint: 'Igazítás más objektumokhoz húzás közben. Tartsa lenyomva a Ctrl/Cmd billentyűt az átugráshoz.',
       privacyHeading: 'Adatvédelem',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -340,6 +340,9 @@ const it = {
 
   properties: {
     positionSection: 'Posizione',
+    anchorMode: 'Ancora',
+    anchorTopLeftHint: "La posizione è l'angolo in alto a sinistra",
+    anchorBaselineHint: 'La posizione è la linea di base (bordo inferiore per forme e codici a barre)',
     optionsSection: 'Opzioni',
     contentSection: 'Contenuto',
     settingsSection: 'Impostazioni',
@@ -644,7 +647,7 @@ const it = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Modalità avanzata',
-      powerUserHint: 'Mostra il comando ZPL generato accanto ad ogni proprietà',
+      powerUserHint: 'Mostra il comando ZPL generato accanto ad ogni proprietà e sblocca i controlli avanzati',
       smartSnap: 'Aggancio intelligente',
       smartSnapHint: 'Allineato agli altri oggetti durante il trascinamento. Tenere Ctrl/Cmd per ignorare.',
       privacyHeading: 'Privacy',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -340,6 +340,9 @@ const ja = {
 
   properties: {
     positionSection: '位置',
+    anchorMode: 'アンカー',
+    anchorTopLeftHint: '位置は左上の隅です',
+    anchorBaselineHint: '位置はベースライン（図形やバーコードの下端）です',
     optionsSection: 'オプション',
     contentSection: 'コンテンツ',
     settingsSection: '設定',
@@ -644,7 +647,7 @@ const ja = {
     app: {
       editorHeading: 'エディター',
       powerUser: 'パワーユーザーモード',
-      powerUserHint: '各プロパティの横に出力されるZPLコマンドを表示する',
+      powerUserHint: '各プロパティの横に出力されるZPLコマンドを表示し、高度なコントロールを有効にする',
       smartSnap: 'スマートスナップ',
       smartSnapHint: 'ドラッグ中に他のオブジェクトに合わせて整列します。Ctrl/Cmdを押し続けると無効になります。',
       privacyHeading: 'プライバシー',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -340,6 +340,9 @@ const ko = {
 
   properties: {
     positionSection: '위치',
+    anchorMode: '앵커',
+    anchorTopLeftHint: '위치는 왼쪽 위 모서리입니다',
+    anchorBaselineHint: '위치는 기준선입니다 (도형 및 바코드의 하단 모서리)',
     optionsSection: '옵션',
     contentSection: '콘텐츠',
     settingsSection: '설정',
@@ -644,7 +647,7 @@ const ko = {
     app: {
       editorHeading: '편집기',
       powerUser: '고급 사용자 모드',
-      powerUserHint: '각 속성 옆에 생성된 ZPL 명령어 표시',
+      powerUserHint: '각 속성 옆에 생성된 ZPL 명령어를 표시하고 고급 컨트롤을 활성화합니다',
       smartSnap: '스마트 스냅',
       smartSnapHint: '드래그하는 동안 다른 오브젝트에 맞춰 정렬합니다. Ctrl/Cmd를 누르면 건너뜁니다.',
       privacyHeading: '개인정보',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -340,6 +340,9 @@ const lt = {
 
   properties: {
     positionSection: 'Padėtis',
+    anchorMode: 'Inkaras',
+    anchorTopLeftHint: 'Padėtis yra viršutinis kairysis kampas',
+    anchorBaselineHint: 'Padėtis yra bazinė linija (apatinis kraštas formoms ir brūkšniniams kodams)',
     optionsSection: 'Parinktys',
     contentSection: 'Turinys',
     settingsSection: 'Nustatymai',
@@ -644,7 +647,7 @@ const lt = {
     app: {
       editorHeading: 'Redaktorius',
       powerUser: 'Pažengusio vartotojo režimas',
-      powerUserHint: 'Rodyti sugeneruotą ZPL komandą šalia kiekvienos savybės',
+      powerUserHint: 'Rodyti sugeneruotą ZPL komandą šalia kiekvienos savybės ir atrakinti išplėstines valdymo parinktis',
       smartSnap: 'Išmanusis pritvirtinimas',
       smartSnapHint: 'Lygiuoja su kitais objektais tempiant. Laikykite Ctrl/Cmd, kad praleistumėte.',
       privacyHeading: 'Privatumas',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -340,6 +340,9 @@ const lv = {
 
   properties: {
     positionSection: 'Pozīcija',
+    anchorMode: 'Enkurs',
+    anchorTopLeftHint: 'Pozīcija ir augšējais kreisais stūris',
+    anchorBaselineHint: 'Pozīcija ir bāzlīnija (apakšējā mala formām un svītrkodiem)',
     optionsSection: 'Opcijas',
     contentSection: 'Saturs',
     settingsSection: 'Iestatījumi',
@@ -644,7 +647,7 @@ const lv = {
     app: {
       editorHeading: 'Redaktors',
       powerUser: 'Pieredzējuša lietotāja režīms',
-      powerUserHint: 'Rādīt emitēto ZPL komandu blakus katram rekvizītam',
+      powerUserHint: 'Rādīt emitēto ZPL komandu blakus katram rekvizītam un atbloķēt papildu vadīklas',
       smartSnap: 'Viedā piestiprināšana',
       smartSnapHint: 'Vilkšanas laikā izlīdzina ar citiem objektiem. Turiet Ctrl/Cmd, lai apietu.',
       privacyHeading: 'Privātums',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -340,6 +340,9 @@ const nl = {
 
   properties: {
     positionSection: 'Positie',
+    anchorMode: 'Anker',
+    anchorTopLeftHint: 'De positie is de linkerbovenhoek',
+    anchorBaselineHint: 'De positie is de basislijn (onderrand voor vormen en barcodes)',
     optionsSection: 'Opties',
     contentSection: 'Inhoud',
     settingsSection: 'Instellingen',
@@ -644,7 +647,7 @@ const nl = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Geavanceerde gebruikersmodus',
-      powerUserHint: 'Toon het geëmitteerde ZPL-commando naast elke eigenschap',
+      powerUserHint: 'Toon het geëmitteerde ZPL-commando naast elke eigenschap en ontgrendel geavanceerde bedieningselementen',
       smartSnap: 'Slim uitlijnen',
       smartSnapHint: 'Uitlijnen op andere objecten tijdens slepen. Houd Ctrl/Cmd ingedrukt om te omzeilen.',
       privacyHeading: 'Privacy',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -340,6 +340,9 @@ const no = {
 
   properties: {
     positionSection: 'Posisjon',
+    anchorMode: 'Anker',
+    anchorTopLeftHint: 'Posisjonen er øverste venstre hjørne',
+    anchorBaselineHint: 'Posisjonen er grunnlinjen (underkant for former og strekkoder)',
     optionsSection: 'Alternativer',
     contentSection: 'Innhold',
     settingsSection: 'Innstillinger',
@@ -644,7 +647,7 @@ const no = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Avansert brukermodus',
-      powerUserHint: 'Vis den genererte ZPL-kommandoen ved siden av hver egenskap',
+      powerUserHint: 'Vis den genererte ZPL-kommandoen ved siden av hver egenskap og lås opp avanserte kontroller',
       smartSnap: 'Smart snapping',
       smartSnapHint: 'Juster mot andre objekter ved draing. Hold Ctrl/Cmd for å omgå.',
       privacyHeading: 'Personvern',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -340,6 +340,9 @@ const pl = {
 
   properties: {
     positionSection: 'Pozycja',
+    anchorMode: 'Kotwica',
+    anchorTopLeftHint: 'Pozycja to lewy górny róg',
+    anchorBaselineHint: 'Pozycja to linia bazowa (dolna krawędź dla kształtów i kodów kreskowych)',
     optionsSection: 'Opcje',
     contentSection: 'Treść',
     settingsSection: 'Ustawienia',
@@ -644,7 +647,7 @@ const pl = {
     app: {
       editorHeading: 'Edytor',
       powerUser: 'Tryb zaawansowany',
-      powerUserHint: 'Pokaż emitowane polecenie ZPL obok każdej właściwości',
+      powerUserHint: 'Pokaż emitowane polecenie ZPL obok każdej właściwości i odblokuj zaawansowane kontrolki',
       smartSnap: 'Inteligentne przyciąganie',
       smartSnapHint: 'Wyrównuje do innych obiektów podczas przeciągania. Przytrzymaj Ctrl/Cmd, aby pominąć.',
       privacyHeading: 'Prywatność',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -340,6 +340,9 @@ const pt = {
 
   properties: {
     positionSection: 'Posição',
+    anchorMode: 'Âncora',
+    anchorTopLeftHint: 'A posição é o canto superior esquerdo',
+    anchorBaselineHint: 'A posição é a linha de base (borda inferior para formas e códigos de barras)',
     optionsSection: 'Opções',
     contentSection: 'Conteúdo',
     settingsSection: 'Definições',
@@ -644,7 +647,7 @@ const pt = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Modo avançado',
-      powerUserHint: 'Mostrar o comando ZPL emitido junto de cada propriedade',
+      powerUserHint: 'Mostrar o comando ZPL emitido junto de cada propriedade e desbloquear controlos avançados',
       smartSnap: 'Encaixe inteligente',
       smartSnapHint: 'Alinhar com outros objetos ao arrastar. Segure Ctrl/Cmd para ignorar.',
       privacyHeading: 'Privacidade',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -340,6 +340,9 @@ const ro = {
 
   properties: {
     positionSection: 'Poziție',
+    anchorMode: 'Ancoră',
+    anchorTopLeftHint: 'Poziția este colțul din stânga sus',
+    anchorBaselineHint: 'Poziția este linia de bază (marginea inferioară pentru forme și coduri de bare)',
     optionsSection: 'Opțiuni',
     contentSection: 'Conținut',
     settingsSection: 'Setări',
@@ -644,7 +647,7 @@ const ro = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Modul utilizator avansat',
-      powerUserHint: 'Afișează comanda ZPL emisă lângă fiecare proprietate',
+      powerUserHint: 'Afișează comanda ZPL emisă lângă fiecare proprietate și deblochează controalele avansate',
       smartSnap: 'Fixare inteligentă',
       smartSnapHint: 'Aliniați la alte obiecte în timp ce trageți. Țineți Ctrl/Cmd pentru a ocoli.',
       privacyHeading: 'Confidențialitate',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -340,6 +340,9 @@ const sk = {
 
   properties: {
     positionSection: 'Pozícia',
+    anchorMode: 'Kotva',
+    anchorTopLeftHint: 'Poloha je ľavý horný roh',
+    anchorBaselineHint: 'Poloha je základná čiara (dolný okraj pre tvary a čiarové kódy)',
     optionsSection: 'Možnosti',
     contentSection: 'Obsah',
     settingsSection: 'Nastavenia',
@@ -644,7 +647,7 @@ const sk = {
     app: {
       editorHeading: 'Editor',
       powerUser: 'Pokročilý režim',
-      powerUserHint: 'Zobraziť vygenerovaný ZPL príkaz vedľa každej vlastnosti',
+      powerUserHint: 'Zobraziť vygenerovaný ZPL príkaz vedľa každej vlastnosti a odomknúť rozšírené ovládacie prvky',
       smartSnap: 'Inteligentné prichytávanie',
       smartSnapHint: 'Zarovnanie na ostatné objekty pri presúvaní. Podržte Ctrl/Cmd pre preskočenie.',
       privacyHeading: 'Súkromie',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -340,6 +340,9 @@ const sl = {
 
   properties: {
     positionSection: 'Položaj',
+    anchorMode: 'Sidro',
+    anchorTopLeftHint: 'Položaj je zgornji levi kot',
+    anchorBaselineHint: 'Položaj je osnovna linija (spodnji rob za oblike in črtne kode)',
     optionsSection: 'Možnosti',
     contentSection: 'Vsebina',
     settingsSection: 'Nastavitve',
@@ -644,7 +647,7 @@ const sl = {
     app: {
       editorHeading: 'Urejevalnik',
       powerUser: 'Napredni uporabniški način',
-      powerUserHint: 'Pokaži generirani ZPL ukaz poleg vsake lastnosti',
+      powerUserHint: 'Pokaži generirani ZPL ukaz poleg vsake lastnosti in odkleni napredne kontrole',
       smartSnap: 'Pametno pritrjevanje',
       smartSnapHint: 'Poravnaj z drugimi objekti med vlečenjem. Drži Ctrl/Cmd za obhod.',
       privacyHeading: 'Zasebnost',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -340,6 +340,9 @@ const sr = {
 
   properties: {
     positionSection: 'Položaj',
+    anchorMode: 'Сидро',
+    anchorTopLeftHint: 'Положај је горњи леви угао',
+    anchorBaselineHint: 'Положај је основна линија (доња ивица за облике и бар-кодове)',
     optionsSection: 'Опције',
     contentSection: 'Садржај',
     settingsSection: 'Подешавања',
@@ -644,7 +647,7 @@ const sr = {
     app: {
       editorHeading: 'Уређивач',
       powerUser: 'Напредни кориснички режим',
-      powerUserHint: 'Прикажи генерисану ZPL наредбу поред сваке особине',
+      powerUserHint: 'Прикажи генерисану ZPL наредбу поред сваке особине и откључај напредне контроле',
       smartSnap: 'Паметно причвршћивање',
       smartSnapHint: 'Поравнај са другим објектима при превлачењу. Држите Ctrl/Cmd за заобилажење.',
       privacyHeading: 'Приватност',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -340,6 +340,9 @@ const sv = {
 
   properties: {
     positionSection: 'Position',
+    anchorMode: 'Ankare',
+    anchorTopLeftHint: 'Positionen är det övre vänstra hörnet',
+    anchorBaselineHint: 'Positionen är baslinjen (underkant för former och streckkoder)',
     optionsSection: 'Alternativ',
     contentSection: 'Innehåll',
     settingsSection: 'Inställningar',
@@ -644,7 +647,7 @@ const sv = {
     app: {
       editorHeading: 'Redigerare',
       powerUser: 'Avancerat användarläge',
-      powerUserHint: 'Visa det utsända ZPL-kommandot bredvid varje egenskap',
+      powerUserHint: 'Visa det utsända ZPL-kommandot bredvid varje egenskap och lås upp avancerade kontroller',
       smartSnap: 'Smart snäppning',
       smartSnapHint: 'Justera mot andra objekt under dragning. Håll Ctrl/Cmd för att kringgå.',
       privacyHeading: 'Integritet',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -340,6 +340,9 @@ const tr = {
 
   properties: {
     positionSection: 'Konum',
+    anchorMode: 'Çapa',
+    anchorTopLeftHint: 'Konum sol üst köşedir',
+    anchorBaselineHint: 'Konum taban çizgisidir (şekiller ve barkodlar için alt kenar)',
     optionsSection: 'Seçenekler',
     contentSection: 'İçerik',
     settingsSection: 'Ayarlar',
@@ -644,7 +647,7 @@ const tr = {
     app: {
       editorHeading: 'Editör',
       powerUser: 'Uzman kullanıcı modu',
-      powerUserHint: 'Her özelliğin yanında gönderilen ZPL komutunu göster',
+      powerUserHint: 'Her özelliğin yanında gönderilen ZPL komutunu göster ve gelişmiş kontrolleri etkinleştir',
       smartSnap: 'Akıllı hizalama',
       smartSnapHint: 'Sürükleme sırasında diğer nesnelere hizala. Atlamak için Ctrl/Cmd basılı tutun.',
       privacyHeading: 'Gizlilik',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -340,6 +340,9 @@ const zhHans = {
 
   properties: {
     positionSection: '位置 (毫米)',
+    anchorMode: '锚点',
+    anchorTopLeftHint: '位置为左上角',
+    anchorBaselineHint: '位置为基线（图形和条形码的下边缘）',
     optionsSection: '选项',
     contentSection: '内容',
     settingsSection: '设置',
@@ -644,7 +647,7 @@ const zhHans = {
     app: {
       editorHeading: '编辑器',
       powerUser: '高级用户模式',
-      powerUserHint: '在每个属性旁边显示生成的ZPL命令',
+      powerUserHint: '在每个属性旁边显示生成的ZPL命令，并解锁高级控制项',
       smartSnap: '智能吸附',
       smartSnapHint: '拖动时对齐其他对象。按住Ctrl/Cmd可跳过对齐。',
       privacyHeading: '隐私',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -340,6 +340,9 @@ const zhHant = {
 
   properties: {
     positionSection: '位置 (公釐)',
+    anchorMode: '錨點',
+    anchorTopLeftHint: '位置為左上角',
+    anchorBaselineHint: '位置為基線（圖形和條碼的下緣）',
     optionsSection: '選項',
     contentSection: '內容',
     settingsSection: '設定',
@@ -644,7 +647,7 @@ const zhHant = {
     app: {
       editorHeading: '編輯器',
       powerUser: '進階使用者模式',
-      powerUserHint: '在每個屬性旁顯示產生的ZPL指令',
+      powerUserHint: '在每個屬性旁顯示產生的ZPL指令，並解鎖進階控制項',
       smartSnap: '智慧對齊',
       smartSnapHint: '拖曳時對齊其他物件。按住Ctrl/Cmd可跳過對齊。',
       privacyHeading: '隱私',


### PR DESCRIPTION
Pure bounds inversion keeps the visual position constant; barcodes shift their raw anchor, text and graphics flip flag-only. Power-user gated.