### PR TITLE
feat(objects): new objects start blank with warning-styled placeholders

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -4,9 +4,9 @@ import type Konva from "konva";
 import { BARCODE_1D_TYPES, ObjectRegistry } from "../../registry";
 import { dotsToPx, pxToDots } from "../../lib/coordinates";
 import { barcodeFtAnchorOffset } from "../../lib/objectBounds";
-import { useColorScheme } from "../../lib/useColorScheme";
+import { useColorScheme, CANVAS_WARNING } from "../../lib/useColorScheme";
 import { useFontCacheVersion } from "../../hooks/useFontCacheVersion";
-import { selectionHandlers, type KonvaObjectProps } from "./konvaObjectProps";
+import { selectionHandlers, useBlankFieldWarns, PLACEHOLDER_DASH, PLACEHOLDER_STROKE_PX, type KonvaObjectProps } from "./konvaObjectProps";
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import {
   getDisplaySize,
@@ -18,6 +18,7 @@ import {
 } from "./bwipHelpers";
 import { resolveHriAbove, gs1HriFontDots } from "../../lib/barcodeHri";
 import { gs1ContentToElementString } from "../../lib/gs1";
+import { placeholderContentFor } from "../../registry/placeholderContent";
 import { getObjectStringContent } from "../../lib/variableBinding";
 import { objectRotation } from "../../registry/rotation";
 import { rotatedGroupTransform } from "./rotatedGroupTransform";
@@ -47,6 +48,28 @@ function resolveMwValue<T>(
   return typeof v === "function"
     ? (v as (mw: number) => T)(moduleWidth)
     : v;
+}
+
+/** Warning marker over the blank-field sample: the soft tint mirrors the
+ *  fallback-value tint, the dotted frame the empty-text placeholder. Full-
+ *  strength bars keep the drop ghost legible (an alpha fade would dim twice
+ *  under the ghost's own opacity). */
+function PlaceholderFrame({ width, height }: { width: number; height: number }) {
+  return (
+    <>
+      <Rect width={width} height={height} fill={CANVAS_WARNING} opacity={0.12} listening={false} />
+      <Rect
+        width={width}
+        height={height}
+        stroke={CANVAS_WARNING}
+        strokeWidth={PLACEHOLDER_STROKE_PX}
+        lineCap="round"
+        dash={PLACEHOLDER_DASH}
+        strokeScaleEnabled={false}
+        listening={false}
+      />
+    </>
+  );
 }
 
 export function BarcodeObject({
@@ -89,20 +112,31 @@ export function BarcodeObject({
   // parens it strips for encoding).
   const gs1Hri = !!(obj.props as { gs1?: boolean }).gs1;
   const contentRaw = getObjectStringContent(obj) ?? "";
-  const rawContent = gs1Hri ? gs1ContentToElementString(contentRaw) : contentRaw;
+  // A blank (unconfigured) field renders the symbology's sample (GS1 sample
+  // in GS1 mode): bwip still gets encodable content, so the object keeps its
+  // true footprint. The sample never reaches emit; the blank field's ^FD
+  // stays empty.
+  const blank = contentRaw.trim() === "";
+  const blankWarns = useBlankFieldWarns(obj.id);
+  const warnBlank = blank && blankWarns;
+  const placeholder = blank ? placeholderContentFor(obj.type, obj.props) ?? "" : null;
+  const renderObj =
+    placeholder !== null ? ({ ...obj, props: { ...obj.props, content: placeholder } } as typeof obj) : obj;
+  const effectiveContent = placeholder ?? contentRaw;
+  const rawContent = gs1Hri ? gs1ContentToElementString(effectiveContent) : effectiveContent;
   const printInterpEnabled =
     !ObjectRegistry[obj.type]?.interpretationLocked &&
     !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
 
   // Shared with the preflight encode check (barcodeEncodeFindings) so the
   // displayed placeholder and the badge can't disagree on what's codable.
-  const { canvas: barcodeCanvas, error: errorMsg } = renderBarcodeCanvas(obj, scale, dpmm);
+  const { canvas: barcodeCanvas, error: errorMsg } = renderBarcodeCanvas(renderObj, scale, dpmm);
 
   // Single object holding the full ZPL footprint (w/h) and the bar
   // sub-rectangle (barW/barH/barLeftPx/barTopPx). Defaults zero out
   // when the bwip canvas hasn't rendered yet.
   const dim: BarcodeDisplaySize = barcodeCanvas
-    ? getDisplaySize(obj, barcodeCanvas, scale, dpmm)
+    ? getDisplaySize(renderObj, barcodeCanvas, scale, dpmm)
     : { w: 0, h: 0, barW: 0, barH: 0, barLeftPx: 0, barTopPx: 0,
         upright: { w: 0, h: 0, barW: 0, barH: 0, barLeftPx: 0, barTopPx: 0 } };
 
@@ -406,6 +440,7 @@ export function BarcodeObject({
               />
             )}
             <Group key={`hri-${fontVersion}`} ref={setOverlayGroupRef}>{overlayContent}</Group>
+            {warnBlank && <PlaceholderFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} />}
           </Group>
         </Group>
       );
@@ -438,6 +473,7 @@ export function BarcodeObject({
             strokeWidth={isSelected ? 2 : 0}
             strokeScaleEnabled={false}
           />
+          {warnBlank && <PlaceholderFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} />}
         </Group>
       </Group>
     );

--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -10,13 +10,13 @@ import { dotsToPx, pxToDots } from "../../lib/coordinates";
 import { measureInkWidthPx } from "../../lib/labelGeometry/measureTextDots";
 import { outlineInset } from "../../lib/shapeGeometry";
 import { reverseShapeStyle } from "./reverseShapeStyle";
-import { useColorScheme } from "../../lib/useColorScheme";
+import { useColorScheme, CANVAS_WARNING } from "../../lib/useColorScheme";
 import { useLabelStore } from "../../store/labelStore";
 import { applyBindingToObject } from "../../lib/variableBinding";
 import { usePreviewBinding } from "../../store/usePreviewBinding";
 import { ZPL_FONT_HEIGHT_TO_CSS_RATIO } from "../../lib/labelGeometry/textPositionTransforms";
 import { getTextRenderMetrics } from "../../lib/labelGeometry/textRenderMetrics";
-import { selectionHandlers, CAPTURE_CHROME, type KonvaObjectProps } from "./konvaObjectProps";
+import { selectionHandlers, useBlankFieldWarns, CAPTURE_CHROME, PLACEHOLDER_DASH, PLACEHOLDER_STROKE_PX, type KonvaObjectProps } from "./konvaObjectProps";
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import { DEFAULT_GS_SYMBOL_META, GS_SYMBOLS } from "../../registry/symbol";
 import { GS_SYMBOL_PATHS, GS_VECTOR_CODES, type GsVectorCode } from "../../registry/gsSymbolPaths";
@@ -122,8 +122,6 @@ type TextFieldObj = LeafObject & { type: "text"; props: TextProps };
 /** Approx width of an empty single-line placeholder, expressed as
  *  fontHeight multiples (Glyph-row aspect ratio). */
 const EMPTY_TEXT_PLACEHOLDER_GLYPHS = 4;
-const PLACEHOLDER_STROKE_PX = 3;
-const PLACEHOLDER_DASH: [number, number] = [0.1, 8];
 
 function PlaceholderRect({
   x, y, width, height, rotation, color, fontVersion,
@@ -161,6 +159,7 @@ function TextFieldContent({
   dpmm,
   fontVersion,
   placeholderColor,
+  emptyColor,
   isSelected = false,
 }: {
   obj: TextFieldObj;
@@ -170,6 +169,9 @@ function TextFieldContent({
   dpmm: number;
   fontVersion: number;
   placeholderColor: string;
+  /** Empty-field placeholder stroke: warning orange once the untouched grace
+   *  ended, the affordance accent while pristine or on the drop ghost. */
+  emptyColor: string;
   isSelected?: boolean;
 }) {
   const shift = base.offsetXPx ?? 0;
@@ -191,7 +193,7 @@ function TextFieldContent({
           width={dotsToPx(fontHeight * EMPTY_TEXT_PLACEHOLDER_GLYPHS, scale, dpmm)}
           height={dotsToPx(fontHeight, scale, dpmm)}
           rotation={base.rotation}
-          color={placeholderColor}
+          color={emptyColor}
         />
       );
     }
@@ -232,7 +234,9 @@ function TextFieldContent({
         y={dotsToPx(bounds.y, scale, dpmm)}
         width={dotsToPx(bounds.width, scale, dpmm)}
         height={dotsToPx(bounds.height, scale, dpmm)}
-        color={placeholderColor}
+        // Unconfigured (empty) reads as the warning family, matching the
+        // blank-barcode frame; too-narrow keeps the design-affordance accent.
+        color={emptyContent ? emptyColor : placeholderColor}
       />
     );
   }
@@ -488,7 +492,7 @@ export function KonvaObject(props_: Props) {
         y={tintY}
         width={tintW}
         height={tintH}
-        fill="#fb923c"
+        fill={CANVAS_WARNING}
         opacity={0.12}
         listening={false}
       />
@@ -519,6 +523,7 @@ function KonvaObjectInner({
   const setSidebarTab = useLabelStore((s) => s.setSidebarTab);
   const selectObjects = useLabelStore((s) => s.selectObjects);
   const blockDragMode = useLabelStore((s) => s.blockDragMode);
+  const emptyPlaceholderColor = useBlankFieldWarns(obj.id) ? CANVAS_WARNING : colors.accent;
   // obj.x/y is the EM-bbox top-left; ZPL anchor delta is applied only
   // at the zplGenerator/zplParser boundary.
   const baseMetrics = getTextRenderMetrics(obj, undefined, label);
@@ -639,6 +644,7 @@ function KonvaObjectInner({
           obj={obj as TextFieldObj}
           content={fpContent}
           placeholderColor={colors.accent}
+          emptyColor={emptyPlaceholderColor}
           base={{
             fontSize: fontSizePx,
             fontFamily,

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -24,7 +24,7 @@ import type { SnapGuide } from "../../lib/snapGuides";
 import { computeAlignDeltas, computeDistribute, computeTidy } from "../../lib/align";
 import type { AlignOp, AlignBox, DistributeAxis, AlignRef } from "../../lib/align";
 import { objectBoundsDots, selectionUnionDots, printableRectDots, isBarcode } from "../../lib/objectBounds";
-import { computePreflight, markerValueFindings } from "../../lib/preflight";
+import { computePreflight, markerValueFindings, suppressPristineEmpty } from "../../lib/preflight";
 import { barcodeEncodeFindings } from "./barcodePreflight";
 import { usePreviewBinding } from "../../store/usePreviewBinding";
 import { useContextMenu } from "../../hooks/useContextMenu";
@@ -187,6 +187,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const {
     label,
     selectedIds,
+    pristineEmptyIds,
     addObject,
     updateObject,
     updateObjects,
@@ -524,15 +525,18 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const preflightLeaves = preflightSuppressed ? [] : exportableLeaves(objects);
   const preflightFindings = preflightSuppressed
     ? []
-    : [
-        ...computePreflight(preflightLeaves, frameCtx),
-        ...barcodeEncodeFindings(preflightLeaves, scale, label.dpmm, previewBinding),
-        ...markerValueFindings(preflightLeaves, {
-          variables: previewBinding.variables,
-          csvDataset,
-          csvMapping,
-        }),
-      ];
+    : suppressPristineEmpty(
+        [
+          ...computePreflight(preflightLeaves, frameCtx),
+          ...barcodeEncodeFindings(preflightLeaves, scale, label.dpmm, previewBinding),
+          ...markerValueFindings(preflightLeaves, {
+            variables: previewBinding.variables,
+            csvDataset,
+            csvMapping,
+          }),
+        ],
+        pristineEmptyIds,
+      );
   // Off-label marks pair each off-label finding with its on-screen bbox: a
   // clipped object gets a solid amber outline, a fully-outside one a dashed red
   // outline with a faint fill. Keyed on the off-label kind (not severity) so a

--- a/src/components/Canvas/barcodePreflight.test.ts
+++ b/src/components/Canvas/barcodePreflight.test.ts
@@ -23,6 +23,54 @@ describe("barcodeEncodeFindings", () => {
   it("returns nothing when every leaf encodes", () => {
     expect(barcodeEncodeFindings([bar("a")], 1, 8, noEnv, () => null)).toEqual([]);
   });
+
+  it("skips a literal-blank payload: computePreflight's emptyContent owns it, no bogus renderFailed", () => {
+    // Regression: a fresh blank UPC-A reported "EAN/UPC encode failed" on top
+    // of the emptyContent warning (the raw renderer has no dummy fallback).
+    // Literal blank (raw content "") emits nothing here (no double emptyContent).
+    const out = barcodeEncodeFindings([bar("a", "")], 1, 8, noEnv, () => "EAN/UPC encode failed");
+    expect(out).toEqual([]);
+  });
+
+  it("flags a bound field whose marker resolves empty as emptyContent, not renderFailed", () => {
+    // Bound to an empty default: raw content "«d»" is non-empty so
+    // computePreflight sees no emptyContent; the canvas shows the placeholder,
+    // so this producer surfaces the emptiness to keep panel and canvas in sync.
+    const env: EncodeEnv = {
+      variables: [{ id: "v", name: "d", fnNumber: 1, defaultValue: "" }],
+      active: null,
+    };
+    const out = barcodeEncodeFindings([bar("a", "«d»")], 1, 8, env, () => "EAN/UPC encode failed");
+    expect(out).toEqual([
+      { objectId: "a", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
+  it("ignores non-barcode leaves: a bound TEXT resolving empty stays quiet", () => {
+    // Regression (GPT finding): the resolved-empty emptyContent must not leak
+    // to text; a bound text field is configured and its canvas box is honest.
+    const textLeaf = {
+      id: "t", type: "text", x: 0, y: 0, rotation: 0,
+      props: { content: "«d»", fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as LabelObject as LeafObject;
+    const env: EncodeEnv = {
+      variables: [{ id: "v", name: "d", fnNumber: 1, defaultValue: "" }],
+      active: null,
+    };
+    const out = barcodeEncodeFindings([textLeaf], 1, 8, env, () => "never");
+    expect(out).toEqual([]);
+  });
+
+  it("still checks a bound field whose resolved payload is non-empty", () => {
+    const env: EncodeEnv = {
+      variables: [{ id: "v", name: "d", fnNumber: 1, defaultValue: "0201" }],
+      active: null,
+    };
+    const out = barcodeEncodeFindings([bar("a", "«d»")], 1, 8, env, () => "bad");
+    expect(out).toEqual([
+      { objectId: "a", kind: "renderFailed", severity: "error", detail: "bad" },
+    ]);
+  });
 });
 
 describe("resolveForEncode", () => {

--- a/src/components/Canvas/barcodePreflight.ts
+++ b/src/components/Canvas/barcodePreflight.ts
@@ -1,4 +1,5 @@
 import type { LeafObject } from "../../registry";
+import { isBarcode } from "../../lib/objectBounds";
 import { PREFLIGHT_SEVERITY, type PreflightFinding } from "../../lib/preflight";
 import type { Variable } from "../../types/Variable";
 import {
@@ -30,11 +31,10 @@ const encodeCache = new WeakMap<
 
 function cachedEncodeError(
   leaf: LeafObject,
+  resolved: LeafObject,
   scale: number,
   dpmm: number,
-  env: EncodeEnv,
 ): string | null {
-  const resolved = resolveForEncode(leaf, env);
   const content = getObjectStringContent(resolved) ?? "";
   const hit = encodeCache.get(leaf);
   if (hit && hit.scale === scale && hit.dpmm === dpmm && hit.content === content) {
@@ -59,12 +59,28 @@ export function barcodeEncodeFindings(
   scale: number,
   dpmm: number,
   env: EncodeEnv,
-  encodeError: (leaf: LeafObject) => string | null = (leaf) =>
-    cachedEncodeError(leaf, scale, dpmm, env),
+  encodeError: (leaf: LeafObject, resolved: LeafObject) => string | null = (leaf, resolved) =>
+    cachedEncodeError(leaf, resolved, scale, dpmm),
 ): PreflightFinding[] {
   const findings: PreflightFinding[] = [];
   for (const leaf of leaves) {
-    const error = encodeError(leaf);
+    // Barcode-only producer: text and shapes never encode, and a bound TEXT
+    // field resolving empty stays quiet (configured field, and the canvas
+    // shows an honest empty box there, unlike the barcode's sample bars).
+    if (!isBarcode(leaf)) continue;
+    const resolved = resolveForEncode(leaf, env);
+    if ((getObjectStringContent(resolved) ?? "").trim() === "") {
+      // A blank payload has nothing to encode, so never a renderFailed error.
+      // A literal-blank field is already owned by computePreflight's
+      // emptyContent (raw content ""); a BARCODE whose marker resolves empty
+      // (empty variable default / empty CSV cell) is raw-nonempty there, yet
+      // renders as sample bars, so surface its emptiness here.
+      if ((getObjectStringContent(leaf) ?? "").trim() !== "") {
+        findings.push({ objectId: leaf.id, kind: "emptyContent", severity: PREFLIGHT_SEVERITY.emptyContent });
+      }
+      continue;
+    }
+    const error = encodeError(leaf, resolved);
     if (error) {
       findings.push({ objectId: leaf.id, kind: "renderFailed", severity: PREFLIGHT_SEVERITY.renderFailed, detail: error });
     }

--- a/src/components/Canvas/konvaObjectProps.ts
+++ b/src/components/Canvas/konvaObjectProps.ts
@@ -1,12 +1,28 @@
 import type Konva from "konva";
 import type { RefObject } from "react";
 import type { LeafObject } from "../../registry";
-import type { ObjectChanges } from "../../store/labelStore";
+import { useLabelStore, type ObjectChanges } from "../../store/labelStore";
 import type { SnapGuide, SnapRect } from "../../lib/snapGuides";
+import { PALETTE_GHOST_ID } from "./paletteGhostMonitor";
 
 /** Konva `name` on editor-only chrome (grid, safe-area, overset ghost, …) so
  *  image capture can hide it. Shared by LabelCanvas and the renderers. */
 export const CAPTURE_CHROME = "capture-chrome";
+
+/** Dotted outline shared by every unconfigured-field placeholder (empty-text
+ *  rect, blank-barcode frame) so "not configured yet" reads as one style. */
+export const PLACEHOLDER_STROKE_PX = 3;
+export const PLACEHOLDER_DASH: [number, number] = [0.1, 8];
+
+/** Whether a blank field should show its warning styling (orange frame /
+ *  placeholder): true once the untouched-field grace has ended, false while
+ *  the object is still pristine or is the palette drop ghost. One store read +
+ *  predicate shared by every renderer so the barcode frame and the text
+ *  placeholder can't disagree. */
+export function useBlankFieldWarns(objectId: string): boolean {
+  const pristine = useLabelStore((s) => s.pristineEmptyIds.includes(objectId));
+  return !pristine && objectId !== PALETTE_GHOST_ID;
+}
 
 /**
  * Click / tap handlers shared across every per-type renderer. Click reads

--- a/src/components/Canvas/paletteGhostMonitor.ts
+++ b/src/components/Canvas/paletteGhostMonitor.ts
@@ -3,6 +3,10 @@ import { CANVAS_DROPPABLE_ID, type PaletteDragData } from "../../dnd/types";
 import { getEntry } from "../../registry";
 import type { LeafObject } from "../../registry";
 
+/** Id of the palette drop-preview object; renderers treat it like a pristine
+ *  (never-deselected) object so no warning styling flashes mid-drag. */
+export const PALETTE_GHOST_ID = "__ghost__";
+
 export interface PaletteGhostDeps {
   /** Drag-liveness flag in a ref: the handlers are rebuilt per render for
    *  fresh closures, the flag must span the whole drag. */
@@ -48,7 +52,7 @@ export function paletteGhostHandlers({ live, locked, pointerPos, setGhost, addOb
       const def = drag && getEntry(drag.type);
       if (!drag || !def) return;
       setGhost({
-        id: "__ghost__",
+        id: PALETTE_GHOST_ID,
         type: drag.type,
         ...drag.pos,
         rotation: 0,

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computePreflight, markerValueFindings } from "./preflight";
+import { computePreflight, markerValueFindings, suppressPristineEmpty, type PreflightFinding } from "./preflight";
 import { getEntry } from "../registry";
 import type { ObjectBoundsCtx } from "./objectBounds";
 import type { LabelObject } from "../types/Group";
@@ -116,6 +116,82 @@ describe("computePreflight (off-label producer)", () => {
       ["clip", "offLabelClipped"],
       ["out", "offLabelOutside"],
     ]);
+  });
+});
+
+describe("emptyContent producer", () => {
+  const text = (id: string, content: string, extraProps: object = {}): LeafObject =>
+    ({
+      id,
+      type: "text",
+      x: 10,
+      y: 10,
+      rotation: 0,
+      props: { content, fontHeight: 30, fontWidth: 0, rotation: "N", ...extraProps },
+    }) as LabelObject as LeafObject;
+
+  it("flags a blank text field as a warning, and only that", () => {
+    expect(computePreflight([text("t", "")], ctx)).toEqual([
+      { objectId: "t", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
+  it("flags whitespace-only content (prints a gap all the same)", () => {
+    expect(computePreflight([text("t", "  ")], ctx)).toEqual([
+      { objectId: "t", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
+  it("flags a blank barcode field", () => {
+    const bc = {
+      id: "bc",
+      type: "code128",
+      x: 10,
+      y: 10,
+      rotation: 0,
+      props: { content: "", height: 80, moduleWidth: 2, printInterpretation: false, checkDigit: false, rotation: "N" },
+    } as LabelObject as LeafObject;
+    expect(computePreflight([bc], ctx)).toEqual([
+      { objectId: "bc", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
+  it("flags a serial field whose seed is blank (prints nothing to increment)", () => {
+    const serial = text("s", "", { serial: { increment: 1, zplMode: "SN" } });
+    expect(computePreflight([serial], ctx)).toEqual([
+      { objectId: "s", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
+  it("does not fire on marker content: bound fields are configured even when a row resolves blank", () => {
+    expect(computePreflight([text("t", "«batch»")], ctx)).toEqual([]);
+  });
+
+  it("reports hidden-char-only content as suspiciousChars, not emptyContent", () => {
+    // NBSP-only content trims to empty but carries invisible ink: the specific
+    // 'NBSP x2' diagnostic must win over the generic 'field is empty'.
+    expect(computePreflight([text("t", "  ")], ctx)).toEqual([
+      { objectId: "t", kind: "suspiciousChars", severity: "warning", detail: "NBSP x2" },
+    ]);
+  });
+
+  it("does not fire on types without a content field", () => {
+    expect(computePreflight([box("b", 10, 10, 50, 50)], ctx)).toEqual([]);
+  });
+});
+
+describe("suppressPristineEmpty", () => {
+  const empty = (id: string): PreflightFinding => ({ objectId: id, kind: "emptyContent", severity: "warning" });
+  const outside = (id: string): PreflightFinding => ({ objectId: id, kind: "offLabelOutside", severity: "error" });
+
+  it("drops only emptyContent findings of pristine ids, everything else passes", () => {
+    const findings = [empty("a"), outside("a"), empty("b")];
+    expect(suppressPristineEmpty(findings, ["a"])).toEqual([outside("a"), empty("b")]);
+  });
+
+  it("is the identity when nothing is pristine", () => {
+    const findings = [empty("a")];
+    expect(suppressPristineEmpty(findings, [])).toBe(findings);
   });
 });
 

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -19,6 +19,19 @@ import {
 export { PREFLIGHT_SEVERITY };
 export type { PreflightFinding, PreflightKind, PreflightSeverity };
 
+/** Untouched-field grace: drop emptyContent findings for just-created,
+ *  still-selected objects (store `pristineEmptyIds`) so the panel does not
+ *  nag while the user is configuring what they just dropped. Every other
+ *  kind passes through; the grace ends on first deselect. */
+export function suppressPristineEmpty(
+  findings: PreflightFinding[],
+  pristineIds: readonly string[],
+): PreflightFinding[] {
+  if (pristineIds.length === 0) return findings;
+  const pristine = new Set(pristineIds);
+  return findings.filter((f) => f.kind !== "emptyContent" || !pristine.has(f.objectId));
+}
+
 interface MarkerValueDeps {
   variables: readonly Variable[];
   csvDataset: { headers: readonly string[]; rows: readonly (readonly string[])[] } | null;
@@ -206,11 +219,22 @@ export function computePreflight(
         : content;
       const detail = suspiciousCharDetail(scanned);
       if (detail) {
+        // Hidden chars win over emptiness: NBSP/BOM-only content trims to empty
+        // but carries invisible ink, so name it rather than call the field blank.
         findings.push({
           objectId: leaf.id,
           kind: "suspiciousChars",
           severity: PREFLIGHT_SEVERITY.suspiciousChars,
           detail,
+        });
+      } else if (content.trim() === "") {
+        // Raw content on purpose: markers make content non-empty, so bound and
+        // template fields never fire here; a blank literal (or serial seed) is
+        // the never-configured state that prints a gap.
+        findings.push({
+          objectId: leaf.id,
+          kind: "emptyContent",
+          severity: PREFLIGHT_SEVERITY.emptyContent,
         });
       }
     }

--- a/src/lib/printPreview.test.ts
+++ b/src/lib/printPreview.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildPreviewZpl } from "./printPreview";
+import type { LabelConfig } from "../types/LabelConfig";
+import type { LabelObject } from "../types/Group";
+
+const label: LabelConfig = { widthMm: 100, heightMm: 50, dpmm: 8 };
+
+const blankBarcode = (): LabelObject[] => [
+  {
+    id: "bc",
+    type: "code128",
+    x: 10,
+    y: 10,
+    rotation: 0,
+    props: { content: "", height: 80, moduleWidth: 2, printInterpretation: false, checkDigit: false, rotation: "N" },
+  } as LabelObject,
+];
+
+describe("buildPreviewZpl blank-field samples", () => {
+  it("overlay opt-in renders a blank barcode with its symbology sample", () => {
+    const zpl = buildPreviewZpl(label, blankBarcode(), [], null, { blankSamples: true });
+    expect(zpl).toContain("^FD12345678^FS");
+  });
+
+  it("default (print path) keeps the blank ^FD so sample data never prints", () => {
+    const zpl = buildPreviewZpl(label, blankBarcode(), [], null);
+    expect(zpl).toContain("^FD^FS");
+    expect(zpl).not.toContain("^FD12345678^FS");
+  });
+
+  it("blank text has no sample and stays blank even with the opt-in", () => {
+    const text = [
+      {
+        id: "t",
+        type: "text",
+        x: 10,
+        y: 10,
+        rotation: 0,
+        props: { content: "", fontHeight: 30, fontWidth: 0, rotation: "N" },
+      } as LabelObject,
+    ];
+    const zpl = buildPreviewZpl(label, text, [], null, { blankSamples: true });
+    expect(zpl).toContain("^FD^FS");
+  });
+});

--- a/src/lib/printPreview.ts
+++ b/src/lib/printPreview.ts
@@ -1,23 +1,42 @@
 import { generateZPL } from "./zplGenerator";
 import { fetchPreview } from "./labelary";
 import type { LabelConfig } from "../types/LabelConfig";
-import type { LabelObject } from "../types/Group";
+import { isGroup, type LabelObject } from "../types/Group";
 import type { Variable } from "../types/Variable";
-import { applyBindingToTree, clockCtxFromLabel, type ActiveCsvRow } from "./variableBinding";
+import { applyBindingToTree, clockCtxFromLabel, getObjectStringContent, type ActiveCsvRow } from "./variableBinding";
+import { placeholderContentFor } from "../registry/placeholderContent";
+
+/** Blank fields rendered with their symbology sample, so the preview overlay
+ *  matches the canvas (which shows the same sample behind the warning frame).
+ *  Overlay-only: print and export keep the empty ^FD. */
+function withBlankSamples(objects: LabelObject[]): LabelObject[] {
+  return objects.map((o): LabelObject => {
+    if (isGroup(o)) return { ...o, children: withBlankSamples(o.children) };
+    const content = getObjectStringContent(o);
+    if (content === undefined || content.trim() !== "") return o;
+    const sample = placeholderContentFor(o.type, o.props);
+    if (!sample) return o;
+    return { ...o, props: { ...o.props, content: sample } } as LabelObject;
+  });
+}
 
 /** Generate the ZPL we hand to Labelary: row-substituted + flat
  *  (no ^FN), so the rendered preview matches what would print for
  *  the active CSV row (or the variable defaults when no row is
  *  loaded). Shared by `printLabel` (new window with image) and
- *  `enterPreviewMode` (canvas overlay) so the two stay in lockstep. */
+ *  `enterPreviewMode` (canvas overlay) so the two stay in lockstep;
+ *  only the overlay opts into blank-field samples, printing must
+ *  never put sample data on paper. */
 export function buildPreviewZpl(
   label: LabelConfig,
   objects: LabelObject[],
   variables: readonly Variable[],
   active: ActiveCsvRow | null,
+  opts: { blankSamples?: boolean } = {},
 ): string {
   const substituted = applyBindingToTree(objects, variables, active, "preview", clockCtxFromLabel(label));
-  return generateZPL(label, substituted, []);
+  const previewed = opts.blankSamples ? withBlankSamples(substituted) : substituted;
+  return generateZPL(label, previewed, []);
 }
 
 export function buildLoadingHtml(): string {

--- a/src/lib/useColorScheme.ts
+++ b/src/lib/useColorScheme.ts
@@ -1,5 +1,11 @@
 import { useLabelStore } from '../store/labelStore';
 
+/** Warning orange for canvas "needs attention" overlays (fallback tint,
+ *  unconfigured-field placeholders). Theme-independent and readable on both
+ *  schemes; not a CanvasColors member because index.css carries no
+ *  counterpart token yet (theme-token SSOT ticket). */
+export const CANVAS_WARNING = '#fb923c';
+
 export interface CanvasColors {
   canvasBg: string;
   canvasDot: string;

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -213,6 +213,16 @@ describe('generateZPL — structure', () => {
     expect(sn).toBe(fd); // serial seed carries the same transformed payload
   });
 
+  it('a blank UPC-E emits an empty field, not a fabricated 0000000 barcode', () => {
+    const obj = [{ id: 'u', type: 'upce', x: 0, y: 0, rotation: 0,
+      props: { content: '', height: 100, moduleWidth: 2, printInterpretation: false, checkDigit: false, rotation: 'N' } },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any;
+    const zpl = generateZPL(BASE_LABEL, obj);
+    expect(zpl).toContain('^FD^FS');
+    expect(zpl).not.toContain('^FD0000000^FS');
+  });
+
   it('serial with an empty seed survives round-trip (field not dropped)', () => {
     const objs = [
       { id: 's', type: 'text', x: 0, y: 0, rotation: 0,

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -441,6 +441,7 @@ const ar = {
     barcodeTooSmall: 'الوحدة صغيرة جداً',
     textOverset: 'نص مقتطع',
     imageMissing: 'الصورة مفقودة',
+    emptyContent: 'الحقل فارغ',
     suspiciousChars: 'أحرف مريبة',
     markerValueUnsafe: 'قيمة المتغير تكسر الترميز',
     gs1ValueInvalid: 'قيمة المتغير تُفسد بيانات GS1',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -441,6 +441,7 @@ const bg = {
     barcodeTooSmall: 'Модулът е твърде малък',
     textOverset: 'Текст отрязан',
     imageMissing: 'Липсва изображение',
+    emptyContent: 'Полето е празно',
     suspiciousChars: 'Съмнителни знаци',
     markerValueUnsafe: 'Стойност нарушава кодирането',
     gs1ValueInvalid: 'Стойността на променливата нарушава GS1 данни',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -441,6 +441,7 @@ const cs = {
     barcodeTooSmall: 'Modul příliš malý',
     textOverset: 'Text oříznut',
     imageMissing: 'Chybí obrázek',
+    emptyContent: 'Pole prázdné',
     suspiciousChars: 'Podezřelé znaky',
     markerValueUnsafe: 'Hodnota proměnné porušuje kódování',
     gs1ValueInvalid: 'Hodnota proměnné porušuje GS1 data',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -441,6 +441,7 @@ const da = {
     barcodeTooSmall: 'Modul for lille',
     textOverset: 'Tekst afskåret',
     imageMissing: 'Billede mangler',
+    emptyContent: 'Felt tomt',
     suspiciousChars: 'Mærkelige tegn',
     markerValueUnsafe: 'Variabelværdi bryder kodning',
     gs1ValueInvalid: 'Variabelværdi bryder GS1-data',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -441,6 +441,7 @@ const de = {
     barcodeTooSmall: 'Modul zu klein',
     textOverset: 'Text beschnitten',
     imageMissing: 'Bild fehlt',
+    emptyContent: 'Feld ist leer',
     suspiciousChars: 'Verdächtige Zeichen',
     markerValueUnsafe: 'Variablenwert bricht Kodierung',
     gs1ValueInvalid: 'Variablenwert bricht GS1-Daten',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -441,6 +441,7 @@ const el = {
     barcodeTooSmall: 'Μονάδα πολύ μικρή',
     textOverset: 'Κείμενο αποκόπηκε',
     imageMissing: 'Λείπει εικόνα',
+    emptyContent: 'Πεδίο κενό',
     suspiciousChars: 'Ύποπτοι χαρακτήρες',
     markerValueUnsafe: 'Τιμή μεταβλητής παραβιάζει κωδικοποίηση',
     gs1ValueInvalid: 'Η τιμή μεταβλητής παραβιάζει δεδομένα GS1',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -441,6 +441,7 @@ const en = {
     barcodeTooSmall: 'Module too small',
     textOverset: 'Text clipped',
     imageMissing: 'Image missing',
+    emptyContent: 'Field is empty',
     suspiciousChars: 'Odd characters',
     markerValueUnsafe: 'Variable value breaks encoding',
     gs1ValueInvalid: 'Variable value breaks GS1 data',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -441,6 +441,7 @@ const es = {
     barcodeTooSmall: 'Módulo demasiado pequeño',
     textOverset: 'Texto recortado',
     imageMissing: 'Falta imagen',
+    emptyContent: 'Campo vacío',
     suspiciousChars: 'Caracteres extraños',
     markerValueUnsafe: 'Valor rompe la codificación',
     gs1ValueInvalid: 'El valor de variable rompe los datos GS1',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -441,6 +441,7 @@ const et = {
     barcodeTooSmall: 'Moodul liiga väike',
     textOverset: 'Tekst lõigatud',
     imageMissing: 'Pilt puudub',
+    emptyContent: 'Väli tühi',
     suspiciousChars: 'Kahtlased märgid',
     markerValueUnsafe: 'Muutuja väärtus rikub kodeeringut',
     gs1ValueInvalid: 'Muutuja väärtus rikub GS1 andmeid',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -441,6 +441,7 @@ const fa = {
     barcodeTooSmall: 'ماژول خیلی کوچک',
     textOverset: 'متن برش‌خورده',
     imageMissing: 'تصویر ناموجود',
+    emptyContent: 'فیلد خالی',
     suspiciousChars: 'نویسه‌های مشکوک',
     markerValueUnsafe: 'مقدار متغیر کدگذاری را می‌شکند',
     gs1ValueInvalid: 'مقدار متغیر داده‌های GS1 را می‌شکند',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -441,6 +441,7 @@ const fi = {
     barcodeTooSmall: 'Moduuli liian pieni',
     textOverset: 'Teksti katkaistu',
     imageMissing: 'Kuva puuttuu',
+    emptyContent: 'Kenttä tyhjä',
     suspiciousChars: 'Oudot merkit',
     markerValueUnsafe: 'Muuttujan arvo rikkoo koodauksen',
     gs1ValueInvalid: 'Muuttujan arvo rikkoo GS1-tiedot',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -441,6 +441,7 @@ const fr = {
     barcodeTooSmall: 'Module trop petit',
     textOverset: 'Texte coupé',
     imageMissing: 'Image absente',
+    emptyContent: 'Champ vide',
     suspiciousChars: 'Caractères suspects',
     markerValueUnsafe: "Valeur brise l'encodage",
     gs1ValueInvalid: 'La valeur de la variable enfreint les données GS1',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -441,6 +441,7 @@ const he = {
     barcodeTooSmall: 'מודול קטן מדי',
     textOverset: 'טקסט חתוך',
     imageMissing: 'תמונה חסרה',
+    emptyContent: 'שדה ריק',
     suspiciousChars: 'תווים חשודים',
     markerValueUnsafe: 'ערך משתנה שובר קידוד',
     gs1ValueInvalid: 'ערך המשתנה שובר נתוני GS1',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -441,6 +441,7 @@ const hr = {
     barcodeTooSmall: 'Modul premali',
     textOverset: 'Tekst odrezan',
     imageMissing: 'Slika nedostaje',
+    emptyContent: 'Polje prazno',
     suspiciousChars: 'Sumnjivi znakovi',
     markerValueUnsafe: 'Vrijednost kvari kodiranje',
     gs1ValueInvalid: 'Vrijednost varijable kvari GS1 podatke',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -441,6 +441,7 @@ const hu = {
     barcodeTooSmall: 'Modul túl kicsi',
     textOverset: 'Szöveg vágva',
     imageMissing: 'Kép hiányzik',
+    emptyContent: 'Mező üres',
     suspiciousChars: 'Gyanús karakterek',
     markerValueUnsafe: 'Változóérték megtöri a kódolást',
     gs1ValueInvalid: 'A változó értéke sérti a GS1 adatokat',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -441,6 +441,7 @@ const it = {
     barcodeTooSmall: 'Modulo troppo piccolo',
     textOverset: 'Testo tagliato',
     imageMissing: 'Immagine assente',
+    emptyContent: 'Campo vuoto',
     suspiciousChars: 'Caratteri sospetti',
     markerValueUnsafe: 'Valore rompe la codifica',
     gs1ValueInvalid: 'Il valore della variabile viola i dati GS1',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -441,6 +441,7 @@ const ja = {
     barcodeTooSmall: 'モジュールが小さすぎる',
     textOverset: 'テキスト切れ',
     imageMissing: '画像なし',
+    emptyContent: '空欄',
     suspiciousChars: '不審な文字',
     markerValueUnsafe: '変数値がエンコードを破損',
     gs1ValueInvalid: '変数値がGS1データを破損',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -441,6 +441,7 @@ const ko = {
     barcodeTooSmall: '모듈이 너무 작음',
     textOverset: '텍스트 잘림',
     imageMissing: '이미지 없음',
+    emptyContent: '빈칸',
     suspiciousChars: '의심스러운 문자',
     markerValueUnsafe: '변수 값이 인코딩을 깨뜨림',
     gs1ValueInvalid: '변수 값이 GS1 데이터를 위반',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -441,6 +441,7 @@ const lt = {
     barcodeTooSmall: 'Modulis per mažas',
     textOverset: 'Tekstas apkarpytas',
     imageMissing: 'Trūksta vaizdo',
+    emptyContent: 'Laukas tuščias',
     suspiciousChars: 'Įtartini simboliai',
     markerValueUnsafe: 'Kintamojo reikšmė laužo kodavimą',
     gs1ValueInvalid: 'Kintamojo reikšmė pažeidžia GS1 duomenis',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -441,6 +441,7 @@ const lv = {
     barcodeTooSmall: 'Modulis pārāk mazs',
     textOverset: 'Teksts apgriezts',
     imageMissing: 'Attēls trūkst',
+    emptyContent: 'Lauks tukšs',
     suspiciousChars: 'Aizdomīgas rakstzīmes',
     markerValueUnsafe: 'Mainīgā vērtība pārkāpj kodējumu',
     gs1ValueInvalid: 'Mainīgā vērtība pārkāpj GS1 datus',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -441,6 +441,7 @@ const nl = {
     barcodeTooSmall: 'Module te klein',
     textOverset: 'Tekst afgesneden',
     imageMissing: 'Afbeelding ontbreekt',
+    emptyContent: 'Veld leeg',
     suspiciousChars: 'Rare tekens',
     markerValueUnsafe: 'Variabelwaarde breekt codering',
     gs1ValueInvalid: 'Variabelewaarde schendt GS1-gegevens',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -441,6 +441,7 @@ const no = {
     barcodeTooSmall: 'Modul for liten',
     textOverset: 'Tekst avkortet',
     imageMissing: 'Bilde mangler',
+    emptyContent: 'Felt tomt',
     suspiciousChars: 'Merkelige tegn',
     markerValueUnsafe: 'Variabelverdi bryter koding',
     gs1ValueInvalid: 'Variabelverdi bryter GS1-data',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -441,6 +441,7 @@ const pl = {
     barcodeTooSmall: 'Moduł zbyt mały',
     textOverset: 'Tekst przycięty',
     imageMissing: 'Brak obrazu',
+    emptyContent: 'Pole puste',
     suspiciousChars: 'Podejrzane znaki',
     markerValueUnsafe: 'Wartość zmiennej łamie kodowanie',
     gs1ValueInvalid: 'Wartość zmiennej narusza dane GS1',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -441,6 +441,7 @@ const pt = {
     barcodeTooSmall: 'Módulo muito pequeno',
     textOverset: 'Texto cortado',
     imageMissing: 'Imagem ausente',
+    emptyContent: 'Campo vazio',
     suspiciousChars: 'Caracteres estranhos',
     markerValueUnsafe: 'Valor quebra a codificação',
     gs1ValueInvalid: 'O valor da variável viola os dados GS1',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -441,6 +441,7 @@ const ro = {
     barcodeTooSmall: 'Modul prea mic',
     textOverset: 'Text trunchiat',
     imageMissing: 'Imagine lipsă',
+    emptyContent: 'Câmp gol',
     suspiciousChars: 'Caractere suspecte',
     markerValueUnsafe: 'Valoarea variabilei strică codificarea',
     gs1ValueInvalid: 'Valoarea variabilei încalcă datele GS1',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -441,6 +441,7 @@ const sk = {
     barcodeTooSmall: 'Modul príliš malý',
     textOverset: 'Text orezaný',
     imageMissing: 'Chýba obrázok',
+    emptyContent: 'Pole prázdne',
     suspiciousChars: 'Podozrivé znaky',
     markerValueUnsafe: 'Hodnota premennej porušuje kódovanie',
     gs1ValueInvalid: 'Hodnota premennej porušuje GS1 dáta',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -441,6 +441,7 @@ const sl = {
     barcodeTooSmall: 'Modul premajhen',
     textOverset: 'Besedilo odrezano',
     imageMissing: 'Slika manjka',
+    emptyContent: 'Polje prazno',
     suspiciousChars: 'Sumljivi znaki',
     markerValueUnsafe: 'Vrednost spremenljivke krši kodiranje',
     gs1ValueInvalid: 'Vrednost spremenljivke krši GS1 podatke',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -441,6 +441,7 @@ const sr = {
     barcodeTooSmall: 'Модул превише мали',
     textOverset: 'Tekst odsečen',
     imageMissing: 'Slika nedostaje',
+    emptyContent: 'Поље празно',
     suspiciousChars: 'Сумњиви знакови',
     markerValueUnsafe: 'Вредност квари кодирање',
     gs1ValueInvalid: 'Вредност променљиве нарушава GS1 податке',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -441,6 +441,7 @@ const sv = {
     barcodeTooSmall: 'Modul för liten',
     textOverset: 'Text avklippt',
     imageMissing: 'Bild saknas',
+    emptyContent: 'Fält tomt',
     suspiciousChars: 'Konstiga tecken',
     markerValueUnsafe: 'Variabelvärde bryter kodning',
     gs1ValueInvalid: 'Variabelvärde bryter GS1-data',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -441,6 +441,7 @@ const tr = {
     barcodeTooSmall: 'Modül çok küçük',
     textOverset: 'Metin kesildi',
     imageMissing: 'Resim eksik',
+    emptyContent: 'Alan boş',
     suspiciousChars: 'Şüpheli karakterler',
     markerValueUnsafe: 'Değişken değeri kodlamayı bozuyor',
     gs1ValueInvalid: 'Değişken değeri GS1 verilerini bozuyor',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -441,6 +441,7 @@ const zhHans = {
     barcodeTooSmall: '模块太小',
     textOverset: '文本截断',
     imageMissing: '图像缺失',
+    emptyContent: '字段为空',
     suspiciousChars: '异常字符',
     markerValueUnsafe: '变量值破坏编码',
     gs1ValueInvalid: '变量值违反GS1数据',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -441,6 +441,7 @@ const zhHant = {
     barcodeTooSmall: '模組太小',
     textOverset: '文字截斷',
     imageMissing: '圖像缺失',
+    emptyContent: '欄位為空',
     suspiciousChars: '異常字元',
     markerValueUnsafe: '變數值破壞編碼',
     gs1ValueInvalid: '變數值違反GS1資料',

--- a/src/registry/aztec.ts
+++ b/src/registry/aztec.ts
@@ -25,11 +25,12 @@ export const aztec: ObjectTypeCore<AztecProps> = {
   bindable: true,
   typedContent: true,
   defaultProps: {
-    content: "1234567890",
+    content: '',
     magnification: 4,
     ecLevel: 0,
     rotation: 'N',
   },
+  placeholderContent: '1234567890',
   defaultSize: { width: 200, height: 200 },
 
   uniformScaleProp: { name: 'magnification', min: MAGNIFICATION_MIN, max: MAGNIFICATION_MAX },

--- a/src/registry/barcode1d.ts
+++ b/src/registry/barcode1d.ts
@@ -29,7 +29,8 @@ export interface Barcode1DProps {
 export interface Barcode1DCoreConfig {
   label: string;
   icon: string;
-  defaultContent: string;
+  /** See {@link ObjectTypeCore.placeholderContent}. New objects start blank. */
+  placeholderContent: string;
   /** Build the ZPL barcode command (e.g. `^BUN,100,Y,N,N`). */
   zplCommand: (p: Barcode1DProps) => string;
   group: ObjectGroup;
@@ -59,7 +60,7 @@ export interface Barcode1DCoreConfig {
 
 export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore<Barcode1DProps> {
   const defaultProps: Barcode1DProps = {
-    content: config.defaultContent,
+    content: '',
     height: 100,
     moduleWidth: 2,
     printInterpretation: !config.interpretationLocked,
@@ -98,6 +99,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
     // EAN/UPC opt out (fixed-length check digit); every other 1D serializes cleanly.
     serialisable: config.serialisable ?? true,
     defaultProps,
+    placeholderContent: config.placeholderContent,
     defaultSize: { width: 300, height: 120 },
     heightLocked: config.heightLocked,
     interpretationLocked: config.interpretationLocked,

--- a/src/registry/codabar.ts
+++ b/src/registry/codabar.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as CodabarProps } from "./barcode1d";
 export const codabarCoreConfig: Barcode1DCoreConfig = {
   label: "Codabar",
   icon: "CBA",
-  defaultContent: "A12345A",
+  placeholderContent: 'A12345A',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/codablock.ts
+++ b/src/registry/codablock.ts
@@ -24,12 +24,13 @@ export const codablock: ObjectTypeCore<CodablockProps> = {
   bindable: true,
   preflight: moduleTooSmallPreflight<CodablockProps>('moduleWidth'),
   defaultProps: {
-    content: "1234567890",
+    content: '',
     moduleWidth: 2,
     rowHeight: 2,
     securityLevel: "Y",
     rotation: 'N',
   },
+  placeholderContent: '1234567890',
   defaultSize: { width: 250, height: 120 },
 
   moduleWidthMin: CODABLOCK_MODULE_WIDTH_MIN,

--- a/src/registry/code11.ts
+++ b/src/registry/code11.ts
@@ -5,7 +5,7 @@ export type { Barcode1DProps as Code11Props } from "./barcode1d";
 export const code11CoreConfig: Barcode1DCoreConfig = {
   label: "Code 11",
   icon: "C11",
-  defaultContent: "12345",
+  placeholderContent: '12345',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/code128.ts
+++ b/src/registry/code128.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Code128Props } from './barcode1d';
 export const code128CoreConfig: Barcode1DCoreConfig = {
   label: 'Code 128',
   icon: '|||',
-  defaultContent: '12345678',
+  placeholderContent: '12345678',
   group: 'code-1d',
   gs1Capable: true,
   zplCommand: (p) => {

--- a/src/registry/code39.ts
+++ b/src/registry/code39.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Code39Props } from './barcode1d';
 export const code39CoreConfig: Barcode1DCoreConfig = {
   label: 'Code 39',
   icon: '|·|',
-  defaultContent: 'CODE39',
+  placeholderContent: 'CODE39',
   group: 'code-1d',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? 'Y' : 'N';

--- a/src/registry/code49.ts
+++ b/src/registry/code49.ts
@@ -31,13 +31,14 @@ export const code49: ObjectTypeCore<Code49Props> = {
   bindable: true,
   preflight: moduleTooSmallPreflight<Code49Props>('moduleWidth'),
   defaultProps: {
-    content: 'CODE49',
+    content: '',
     height: 20,
     moduleWidth: 2,
     printInterpretation: true,
     mode: 'A',
     rotation: 'N',
   },
+  placeholderContent: 'CODE49',
   defaultSize: { width: 300, height: 120 },
 
   // Clamp height into bwip's range so drag past the limit lands in

--- a/src/registry/code93.ts
+++ b/src/registry/code93.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Code93Props } from './barcode1d';
 export const code93CoreConfig: Barcode1DCoreConfig = {
   label: 'Code 93',
   icon: '|93|',
-  defaultContent: 'CODE93',
+  placeholderContent: 'CODE93',
   group: 'code-1d',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? 'Y' : 'N';

--- a/src/registry/datamatrix.ts
+++ b/src/registry/datamatrix.ts
@@ -25,12 +25,13 @@ export const datamatrix: ObjectTypeCore<DataMatrixProps> = {
   bindable: true,
   typedContent: true,
   defaultProps: {
-    content: '1234567890',
+    content: '',
     dimension: 5,
     quality: 200,
     rotation: 'N',
     gs1: false,
   },
+  placeholderContent: '1234567890',
   defaultSize: { width: 150, height: 150 },
 
   uniformScaleProp: { name: 'dimension', min: DIMENSION_MIN, max: DIMENSION_MAX },

--- a/src/registry/ean13.ts
+++ b/src/registry/ean13.ts
@@ -5,7 +5,7 @@ export type { Barcode1DProps as Ean13Props } from './barcode1d';
 export const ean13CoreConfig: Barcode1DCoreConfig = {
   label: 'EAN-13',
   icon: 'EAN',
-  defaultContent: '590123412345',
+  placeholderContent: '590123412345',
   group: 'code-1d',
   serialisable: false,
   zplCommand: (p) => {

--- a/src/registry/ean8.ts
+++ b/src/registry/ean8.ts
@@ -5,7 +5,7 @@ export type { Barcode1DProps as Ean8Props } from './barcode1d';
 export const ean8CoreConfig: Barcode1DCoreConfig = {
   label: 'EAN-8',
   icon: 'E8',
-  defaultContent: '1234567',
+  placeholderContent: '1234567',
   group: 'code-1d',
   serialisable: false,
   zplCommand: (p) => {

--- a/src/registry/gs1databar.ts
+++ b/src/registry/gs1databar.ts
@@ -42,11 +42,12 @@ export const gs1databar: ObjectTypeCore<Gs1DatabarProps> = {
   bindable: true,
   preflight: moduleTooSmallPreflight<Gs1DatabarProps>('magnification'),
   defaultProps: {
-    content: '0112345678901',
+    content: '',
     magnification: 2,
     symbology: 1,
     rotation: 'N',
   },
+  placeholderContent: '0112345678901',
   defaultSize: { width: 300, height: 120 },
   heightLocked: true,
 

--- a/src/registry/industrial2of5.ts
+++ b/src/registry/industrial2of5.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Industrial2of5Props } from "./barcode1d";
 export const industrial2of5CoreConfig: Barcode1DCoreConfig = {
   label: "Industrial 2 of 5",
   icon: "I25",
-  defaultContent: "12345678",
+  placeholderContent: '12345678',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/interleaved2of5.ts
+++ b/src/registry/interleaved2of5.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Interleaved2of5Props } from './barcode1d';
 export const interleaved2of5CoreConfig: Barcode1DCoreConfig = {
   label: 'Interleaved 2 of 5',
   icon: 'I25',
-  defaultContent: '12345678',
+  placeholderContent: '12345678',
   group: 'code-1d',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? 'Y' : 'N';

--- a/src/registry/logmars.ts
+++ b/src/registry/logmars.ts
@@ -6,7 +6,7 @@ export type { Barcode1DProps as LogmarsProps } from "./barcode1d";
 export const logmarsCoreConfig: Barcode1DCoreConfig = {
   label: "LOGMARS",
   icon: "LOG",
-  defaultContent: "LOGMARS1",
+  placeholderContent: 'LOGMARS1',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/maxicode.ts
+++ b/src/registry/maxicode.ts
@@ -23,10 +23,11 @@ export const maxicode: ObjectTypeCore<MaxicodeProps> = {
   group: "code-2d",
   bindable: true,
   defaultProps: {
-    content: "1234567890",
+    content: '',
     mode: MAXICODE_DEFAULT_MODE,
     rotation: "N",
   },
+  placeholderContent: '1234567890',
   // mm so palette resolves at active dpmm; heightLocked disables resize.
   defaultSize: { widthMm: 28.14, heightMm: 26.91 },
   heightLocked: true,

--- a/src/registry/micropdf417.ts
+++ b/src/registry/micropdf417.ts
@@ -20,12 +20,13 @@ export const micropdf417: ObjectTypeCore<MicroPdf417Props> = {
   barcodeClass: 'stacked2d',
   bindable: true,
   defaultProps: {
-    content: "1234",
+    content: '',
     moduleWidth: 2,
     rowHeight: 2,
     mode: 0,
     rotation: 'N',
   },
+  placeholderContent: '1234',
   defaultSize: { width: 200, height: 100 },
 
   preflight: moduleTooSmallPreflight<MicroPdf417Props>('moduleWidth'),

--- a/src/registry/msi.ts
+++ b/src/registry/msi.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as MsiProps } from "./barcode1d";
 export const msiCoreConfig: Barcode1DCoreConfig = {
   label: "MSI",
   icon: "MSI",
-  defaultContent: "12345678",
+  placeholderContent: '12345678',
   group: 'code-postal',
   // MSI standard specifies a 2:1 wide:narrow ratio, which bwip-js hardcodes
   // internally. ZPL ^BY defaults to 3.0, so we must override to keep canvas

--- a/src/registry/palettePresets.ts
+++ b/src/registry/palettePresets.ts
@@ -1,5 +1,4 @@
 import { ObjectRegistry, getEntry } from './index';
-import { GS1_SAMPLE_CONTENT } from '../lib/gs1';
 import type { ObjectGroup } from '../types/LabelObject';
 import type { ObjectTypeDefinition } from '../types/ObjectType';
 import type { Translations } from '../locales';
@@ -42,11 +41,13 @@ const PALETTE_PRESETS: PalettePreset[] = [
     label: (t) => t.registry.text.modeTextBlock, propsOverride: { textMode: 'tb', blockWidth: 400, blockHeight: 120 }, defaultSize: { width: 400, height: 120 } },
   { id: 'text-serial', type: 'text', icon: '#', zplCmd: '^SN',
     label: (t) => t.types.serial, propsOverride: { content: '001', serial: { increment: 1, zplMode: 'SN' } }, defaultSize: { width: 100, height: 30 } },
+  // GS1 presets start empty on purpose: the builder then opens on its use-case
+  // presets instead of a sample element string the user has to replace.
   { id: 'datamatrix-gs1', type: 'datamatrix', icon: '▩', zplCmd: '^BX',
-    label: (t) => t.types.datamatrixGs1, propsOverride: { gs1: true, content: GS1_SAMPLE_CONTENT },
+    label: (t) => t.types.datamatrixGs1, propsOverride: { gs1: true },
     defaultSize: { width: 150, height: 150 } },
   { id: 'code128-gs1', type: 'code128', icon: '|||', zplCmd: '^BC',
-    label: (t) => t.types.code128Gs1, propsOverride: { gs1: true, content: GS1_SAMPLE_CONTENT },
+    label: (t) => t.types.code128Gs1, propsOverride: { gs1: true },
     defaultSize: { width: 300, height: 120 } },
 ];
 

--- a/src/registry/paletteTypes.test.ts
+++ b/src/registry/paletteTypes.test.ts
@@ -21,9 +21,12 @@ describe('paletteTypes', () => {
   it('the GS1 DataMatrix preset follows datamatrix and seeds gs1:true', () => {
     const ids = addablesInGroup('code-2d', en).map((e) => e.id);
     expect(ids[ids.indexOf('datamatrix') + 1]).toBe('datamatrix-gs1');
+    // No content seed: an empty GS1 field opens the builder on its use-case
+    // presets instead of a sample element string.
     expect(resolveAddable('datamatrix-gs1', en)).toMatchObject({
       type: 'datamatrix',
-      propsOverride: { gs1: true, content: '0109501101530003' },
+      propsOverride: { gs1: true },
     });
+    expect((resolveAddable('datamatrix-gs1', en)?.propsOverride as { content?: string }).content).toBeUndefined();
   });
 });

--- a/src/registry/pdf417.ts
+++ b/src/registry/pdf417.ts
@@ -24,13 +24,14 @@ export const pdf417: ObjectTypeCore<Pdf417Props> = {
   barcodeClass: 'stacked2d',
   bindable: true,
   defaultProps: {
-    content: "1234567890",
+    content: '',
     rowHeight: 2,
     securityLevel: 0,
     columns: 0,
     moduleWidth: 2,
     rotation: 'N',
   },
+  placeholderContent: '1234567890',
   defaultSize: { width: 300, height: 150 },
 
   moduleWidthMin: PDF417_MODULE_WIDTH_MIN,

--- a/src/registry/placeholderContent.ts
+++ b/src/registry/placeholderContent.ts
@@ -1,0 +1,11 @@
+import { getEntry } from './index';
+import { GS1_SAMPLE_CONTENT } from '../lib/gs1';
+
+/** The sample a blank field renders on canvas and in the Labelary preview
+ *  overlay: the type's placeholderContent, or the GS1 sample once the field
+ *  is in GS1 mode (the type sample would not encode there). Never part of
+ *  emit, export or print; a blank field's ^FD stays empty there. */
+export function placeholderContentFor(type: string, props: object): string | undefined {
+  if ((props as { gs1?: boolean }).gs1) return GS1_SAMPLE_CONTENT;
+  return getEntry(type)?.placeholderContent;
+}

--- a/src/registry/planet.ts
+++ b/src/registry/planet.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as PlanetProps } from "./barcode1d";
 export const planetCoreConfig: Barcode1DCoreConfig = {
   label: "Planet Code",
   icon: "✉P",
-  defaultContent: "12345678901",
+  placeholderContent: '12345678901',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/plessey.ts
+++ b/src/registry/plessey.ts
@@ -8,7 +8,7 @@ export const PLESSEY_RATIO = 2;
 export const plesseyCoreConfig: Barcode1DCoreConfig = {
   label: "Plessey",
   icon: "PLS",
-  defaultContent: "12345678",
+  placeholderContent: '12345678',
   group: 'code-postal',
   byRatio: PLESSEY_RATIO,
   zplCommand: (p) => {

--- a/src/registry/postal.ts
+++ b/src/registry/postal.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as PostalProps } from "./barcode1d";
 export const postalCoreConfig: Barcode1DCoreConfig = {
   label: "POSTNET",
   icon: "✉Z",
-  defaultContent: "12345",
+  placeholderContent: '12345',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/qrcode.ts
+++ b/src/registry/qrcode.ts
@@ -31,12 +31,13 @@ export const qrcode: ObjectTypeCore<QrCodeProps> = {
   bindable: true,
   typedContent: true,
   defaultProps: {
-    content: 'https://example.com',
+    content: '',
     magnification: 4,
     errorCorrection: 'Q',
     model: 2,
     rotation: 'N',
   },
+  placeholderContent: 'https://example.com',
   defaultSize: { width: 200, height: 200 },
 
   uniformScaleProp: { name: 'magnification', min: MAGNIFICATION_MIN, max: MAGNIFICATION_MAX },

--- a/src/registry/standard2of5.ts
+++ b/src/registry/standard2of5.ts
@@ -4,7 +4,7 @@ export type { Barcode1DProps as Standard2of5Props } from "./barcode1d";
 export const standard2of5CoreConfig: Barcode1DCoreConfig = {
   label: "Standard 2 of 5",
   icon: "S25",
-  defaultContent: "12345678",
+  placeholderContent: '12345678',
   group: 'code-postal',
   zplCommand: (p) => {
     const interp = p.printInterpretation ? "Y" : "N";

--- a/src/registry/text.ts
+++ b/src/registry/text.ts
@@ -105,7 +105,7 @@ export const text: ObjectTypeCore<TextProps> = {
     return mode === "fb" ? encodeFbContent : mode === "tb" ? encodeTbContent : undefined;
   },
   defaultProps: {
-    content: "Text",
+    content: '',
     fontHeight: 30,
     fontWidth: 0,
     rotation: "N",

--- a/src/registry/tlc39.ts
+++ b/src/registry/tlc39.ts
@@ -31,13 +31,14 @@ export const tlc39: ObjectTypeCore<Tlc39Props> = {
   bindable: true,
   preflight: moduleTooSmallPreflight<Tlc39Props>('moduleWidth'),
   defaultProps: {
-    content: "123456,SERIAL",
+    content: '',
     moduleWidth: 2,
     height: 40,
     microPdfRowHeight: 4,
     microPdfRows: 4,
     rotation: "N",
   },
+  placeholderContent: '123456,SERIAL',
   defaultSize: { width: 200, height: 80 },
 
   commitTransform: commitBarcodeWidthHeightTransform,

--- a/src/registry/upcEanExtension.ts
+++ b/src/registry/upcEanExtension.ts
@@ -22,7 +22,7 @@ export type { Barcode1DProps as UpcEanExtensionProps } from './barcode1d';
 export const upcEanExtensionCoreConfig: Barcode1DCoreConfig = {
   label: 'UPC/EAN extension',
   icon: 'EXT',
-  defaultContent: '51999',
+  placeholderContent: '51999',
   group: 'code-1d',
   // Exactly 2 or 5 digits; ^SN/^SF could roll it to an invalid 3/4/6-digit
   // supplement, so it opts out of serial like EAN/UPC.

--- a/src/registry/upca.ts
+++ b/src/registry/upca.ts
@@ -5,7 +5,7 @@ export type { Barcode1DProps as UpcAProps } from './barcode1d';
 export const upcaCoreConfig: Barcode1DCoreConfig = {
   label: 'UPC-A',
   icon: 'UPC',
-  defaultContent: '01234567890',
+  placeholderContent: '01234567890',
   group: 'code-1d',
   serialisable: false,
   zplCommand: (p) => {

--- a/src/registry/upce.ts
+++ b/src/registry/upce.ts
@@ -5,7 +5,7 @@ export type { Barcode1DProps as UpcEProps } from './barcode1d';
 export const upceCoreConfig: Barcode1DCoreConfig = {
   label: 'UPC-E',
   icon: 'UPE',
-  defaultContent: '012345',
+  placeholderContent: '012345',
   group: 'code-1d',
   serialisable: false,
   zplCommand: (p) => {
@@ -17,7 +17,9 @@ export const upceCoreConfig: Barcode1DCoreConfig = {
   // ^B9 needs the number-system digit in ^FD (else Labelary lints/re-pads).
   // NS-aware so an already-prefixed content is not double-prefixed. NS
   // assumed 0 (spec allows 0 or 1; NS 1 round-trips lossily, see ticket).
-  fdContent: (c) => `0${upceData6FromFd(c)}`,
+  // Empty stays empty: the padding would otherwise fabricate a scannable
+  // 0000000 UPC-E from a blank field, breaking the empty-^FD invariant.
+  fdContent: (c) => (c === '' ? '' : `0${upceData6FromFd(c)}`),
 };
 
 export const upce = createBarcode1DCore(upceCoreConfig);

--- a/src/store/labelStore.test.ts
+++ b/src/store/labelStore.test.ts
@@ -48,6 +48,7 @@ function reset() {
     csvMappingModalOpen: false,
     previewMode: { status: 'idle' },
     canvasSettings: { ...DEFAULT_CANVAS_SETTINGS },
+    pristineEmptyIds: [],
   });
 }
 
@@ -160,18 +161,47 @@ describe('updateObject — props merging', () => {
   it('merges partial props instead of replacing them', () => {
     state().addObject('text');
     const obj = defined(objs()[0]);
+    state().updateObject(obj.id, { props: { content: 'Hello' } });
     state().updateObject(obj.id, { props: { fontHeight: 99 } });
     const updated = defined(objs()[0]);
     expect(props(updated).fontHeight).toBe(99);
-    expect(props(updated).content).toBe('Text');
+    expect(props(updated).content).toBe('Hello');
   });
 
   it('updates top-level fields (x, y) without touching props', () => {
     state().addObject('text');
     const obj = defined(objs()[0]);
+    state().updateObject(obj.id, { props: { content: 'Hello' } });
     state().updateObject(obj.id, { x: 999 });
     expect(defined(objs()[0]).x).toBe(999);
-    expect(props(defined(objs()[0])).content).toBe('Text');
+    expect(props(defined(objs()[0])).content).toBe('Hello');
+  });
+});
+
+// ── pristineEmptyIds (untouched-field grace) ──────────────────────────────────
+
+describe('pristineEmptyIds', () => {
+  it('marks a blank-born object; the first deselect ends the grace for good', () => {
+    state().addObject('text');
+    const id = defined(objs()[0]).id;
+    expect(state().pristineEmptyIds).toEqual([id]);
+    state().selectObject(null);
+    expect(state().pristineEmptyIds).toEqual([]);
+    // Re-selecting must not restore the grace (panel click-through stability).
+    state().selectObject(id);
+    expect(state().pristineEmptyIds).toEqual([]);
+  });
+
+  it('adding a second object moves the selection and ends the first grace', () => {
+    state().addObject('text');
+    state().addObject('code128');
+    expect(state().pristineEmptyIds).toEqual([ids()[1]]);
+  });
+
+  it('does not mark objects born with content or without a content field', () => {
+    state().addObject('text', undefined, { content: '001' });
+    state().addObject('box');
+    expect(state().pristineEmptyIds).toEqual([]);
   });
 });
 

--- a/src/store/labelStore.ts
+++ b/src/store/labelStore.ts
@@ -472,6 +472,18 @@ export const useLabelStore = create<LabelState>()(
   )
 );
 
+// First-deselect latch for pristineEmptyIds: one subscription instead of a
+// prune in each of the dozen actions that write selectedIds. Dropping out of
+// the selection once ends the untouched-field grace for good.
+useLabelStore.subscribe((state, prev) => {
+  if (state.selectedIds === prev.selectedIds || state.pristineEmptyIds.length === 0) return;
+  const sel = new Set(state.selectedIds);
+  const next = state.pristineEmptyIds.filter((id) => sel.has(id));
+  if (next.length !== state.pristineEmptyIds.length) {
+    useLabelStore.setState({ pristineEmptyIds: next });
+  }
+});
+
 export const useCurrentObjects = () => useLabelStore(currentObjects);
 
 /** Non-reactive sibling of `useCurrentObjects` for use inside event handlers

--- a/src/store/slices/objectSlice.ts
+++ b/src/store/slices/objectSlice.ts
@@ -100,18 +100,23 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
     const definition = getEntry(type);
     if (!definition) return;
 
+    const props = { ...definition.defaultProps, ...propsOverride };
     const obj = {
       id: crypto.randomUUID(),
       type,
       x: position.x,
       y: position.y,
       rotation: 0,
-      props: { ...definition.defaultProps, ...propsOverride },
+      props,
     } as LabelObject;
+    // A blank-born object gets the untouched-field grace: its emptyContent
+    // warning stays suppressed until the first deselect (selectionSlice).
+    const blank = (props as { content?: string }).content?.trim() === '';
 
     set((state) => ({
       ...updateCurrentObjects(state, (objs) => [...objs, obj]),
       selectedIds: [obj.id],
+      ...(blank ? { pristineEmptyIds: [...state.pristineEmptyIds, obj.id] } : {}),
     }));
   },
 

--- a/src/store/slices/previewSlice.ts
+++ b/src/store/slices/previewSlice.ts
@@ -55,7 +55,7 @@ export const createPreviewSlice: StateCreator<LabelState, [], [], PreviewSlice> 
     }
     const objs = currentObjects(state);
     const active = buildActiveCsvRow(state.csvDataset, state.csvMapping);
-    const zpl = buildPreviewZpl(state.label, objs, state.variables, active);
+    const zpl = buildPreviewZpl(state.label, objs, state.variables, active, { blankSamples: true });
     // Toggling preview off then on for a side-by-side pixel compare
     // shouldn't burn an API call when nothing changed.
     const cachedUrl = previewCache.get(zpl);

--- a/src/store/slices/selectionSlice.ts
+++ b/src/store/slices/selectionSlice.ts
@@ -5,6 +5,13 @@ import { updateCurrentObjects } from '../labelStore.internals';
 
 export interface SelectionSlice {
   selectedIds: string[];
+  /** Objects created blank and never yet deselected: their emptyContent
+   *  preflight AND the canvas warning styling (orange frame/placeholder)
+   *  stay suppressed while the user is still configuring the fresh drop
+   *  (form "touched" semantics). Ephemeral UI state, excluded from persist
+   *  and the undo timeline; the first-deselect latch lives as one store
+   *  subscription in labelStore.ts, not in every selection writer. */
+  pristineEmptyIds: string[];
   selectObject: (id: string | null) => void;
   toggleSelectObject: (id: string) => void;
   selectObjects: (ids: string[]) => void;
@@ -21,6 +28,7 @@ export interface SelectionSlice {
 
 export const createSelectionSlice: StateCreator<LabelState, [], [], SelectionSlice> = (set, get) => ({
   selectedIds: [],
+  pristineEmptyIds: [],
 
   selectObject: (id) =>
     set((state) => {

--- a/src/types/ObjectType.ts
+++ b/src/types/ObjectType.ts
@@ -17,6 +17,10 @@ export interface ObjectTypeCore<P extends object = object> {
   zplCmdFor?: (obj: LabelObjectBase & { props: P }) => string;
   group: ObjectGroup;
   defaultProps: P;
+  /** Sample the canvas and the preview overlay render while the field is
+   *  blank, so an unconfigured barcode keeps its true symbology footprint.
+   *  Never reaches emit or print; the blank field's ^FD stays empty. */
+  placeholderContent?: string;
   /** Drop footprint: dots (editor default) or mm (spec-fixed types
    *  like Maxicode). Palette resolves against current label dpmm. */
   defaultSize:

--- a/src/types/preflight.ts
+++ b/src/types/preflight.ts
@@ -15,7 +15,8 @@ export type PreflightKind =
   | 'imageMissing'
   | 'suspiciousChars'
   | 'markerValueUnsafe'
-  | 'gs1ValueInvalid';
+  | 'gs1ValueInvalid'
+  | 'emptyContent';
 
 export interface PreflightFinding {
   objectId: string;
@@ -48,6 +49,9 @@ export const PREFLIGHT_SEVERITY: Record<PreflightKind, PreflightSeverity> = {
   // (wrong fixed-AI width, charset, date) from a substitution; it still
   // prints, so warn rather than block.
   gs1ValueInvalid: 'warning',
+  // A blank field is legal ZPL and a normal drafting state; it prints a gap,
+  // so warn rather than block. Mirrors the canvas placeholder.
+  emptyContent: 'warning',
 };
 
 /** What a per-type `preflight` producer receives. Minimal on purpose (just the


### PR DESCRIPTION
Defaults drop their sample content. Blank barcodes render the symbology sample behind an orange dotted frame and tint, blank fields warn in preflight, the GS1 builder opens on its presets.