### PR TITLE
feat(canvas): uncodable barcodes fall back to sample bars behind a re…

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -20,6 +20,7 @@ import { resolveHriAbove, gs1HriFontDots } from "../../lib/barcodeHri";
 import { gs1ContentToElementString } from "../../lib/gs1";
 import { placeholderContentFor } from "../../registry/placeholderContent";
 import { getObjectStringContent } from "../../lib/variableBinding";
+import { hasTemplateMarkers } from "../../lib/fnTemplate";
 import { objectRotation } from "../../registry/rotation";
 import { rotatedGroupTransform } from "./rotatedGroupTransform";
 import { buildEanUpcDigitOverlay } from "./eanUpcDigitNodes";
@@ -50,18 +51,19 @@ function resolveMwValue<T>(
     : v;
 }
 
-/** Warning marker over the blank-field sample: the soft tint mirrors the
- *  fallback-value tint, the dotted frame the empty-text placeholder. Full-
- *  strength bars keep the drop ghost legible (an alpha fade would dim twice
- *  under the ghost's own opacity). */
-function PlaceholderFrame({ width, height }: { width: number; height: number }) {
+/** State marker over sample bars: warning orange for a blank field, error red
+ *  for uncodable content. The soft tint mirrors the fallback-value tint, the
+ *  dotted frame the empty-text placeholder. Full-strength bars keep the drop
+ *  ghost legible (an alpha fade would dim twice under the ghost's own
+ *  opacity). */
+function StateFrame({ width, height, color }: { width: number; height: number; color: string }) {
   return (
     <>
-      <Rect width={width} height={height} fill={CANVAS_WARNING} opacity={0.12} listening={false} />
+      <Rect width={width} height={height} fill={color} opacity={0.12} listening={false} />
       <Rect
         width={width}
         height={height}
-        stroke={CANVAS_WARNING}
+        stroke={color}
         strokeWidth={PLACEHOLDER_STROKE_PX}
         lineCap="round"
         dash={PLACEHOLDER_DASH}
@@ -119,24 +121,39 @@ export function BarcodeObject({
   const blank = contentRaw.trim() === "";
   const blankWarns = useBlankFieldWarns(obj.id);
   const warnBlank = blank && blankWarns;
-  const placeholder = blank ? placeholderContentFor(obj.type, obj.props) ?? "" : null;
-  const renderObj =
-    placeholder !== null ? ({ ...obj, props: { ...obj.props, content: placeholder } } as typeof obj) : obj;
-  const effectiveContent = placeholder ?? contentRaw;
+  const sample = placeholderContentFor(obj.type, obj.props) ?? "";
+  const withSample = { ...obj, props: { ...obj.props, content: sample } } as typeof obj;
+
+  // Same encoder as the renderFailed preflight, on the same marker-resolved
+  // obj, so the canvas and the badge agree on what's codable.
+  const primary = renderBarcodeCanvas(blank ? withSample : obj, scale, dpmm);
+  // Uncodable content falls back to the sample bars so the object keeps its
+  // footprint instead of collapsing to the error box; the encoder message
+  // lives in the renderFailed preflight, not on the canvas.
+  const codableFail = !blank && primary.error !== null && sample !== "";
+  const secondary = codableFail ? renderBarcodeCanvas(withSample, scale, dpmm) : null;
+  // Prefer the sample render only if it actually produced a canvas; else the
+  // primary carries the real error to the fallback box (sample also failed).
+  const source = secondary?.canvas ? secondary : primary;
+  const usingSample = source === secondary;
+  const { canvas: barcodeCanvas, error: errorMsg } = source;
+  const showSample = blank || usingSample;
+  // Red "content is wrong" frame only for genuine content: an unresolved
+  // «marker» in schema-preview mode is expected to be uncodable (it resolves
+  // fine in preview/print), so it shows the sample bars without the alarm.
+  const invalid = usingSample && !hasTemplateMarkers(contentRaw);
+  const displayObj = showSample ? withSample : obj;
+  const effectiveContent = showSample ? sample : contentRaw;
   const rawContent = gs1Hri ? gs1ContentToElementString(effectiveContent) : effectiveContent;
   const printInterpEnabled =
     !ObjectRegistry[obj.type]?.interpretationLocked &&
     !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
 
-  // Shared with the preflight encode check (barcodeEncodeFindings) so the
-  // displayed placeholder and the badge can't disagree on what's codable.
-  const { canvas: barcodeCanvas, error: errorMsg } = renderBarcodeCanvas(renderObj, scale, dpmm);
-
   // Single object holding the full ZPL footprint (w/h) and the bar
   // sub-rectangle (barW/barH/barLeftPx/barTopPx). Defaults zero out
   // when the bwip canvas hasn't rendered yet.
   const dim: BarcodeDisplaySize = barcodeCanvas
-    ? getDisplaySize(renderObj, barcodeCanvas, scale, dpmm)
+    ? getDisplaySize(displayObj, barcodeCanvas, scale, dpmm)
     : { w: 0, h: 0, barW: 0, barH: 0, barLeftPx: 0, barTopPx: 0,
         upright: { w: 0, h: 0, barW: 0, barH: 0, barLeftPx: 0, barTopPx: 0 } };
 
@@ -205,6 +222,11 @@ export function BarcodeObject({
   // top-left and KImage offsets back to land bars at FO.
   const x = offsetX + dotsToPx(displayX, scale, dpmm) - dim.barLeftPx;
   const y = offsetY + dotsToPx(displayY, scale, dpmm) - dim.barTopPx;
+
+  // Dotted frame over the sample bars: orange for a blank (unconfigured) field,
+  // red for genuinely uncodable content. Shared by both render branches.
+  const showStateFrame = warnBlank || invalid;
+  const stateFrameColor = invalid ? colors.error : CANVAS_WARNING;
 
   // Whole-object drag (snap + commit) is centralized in the drag controller;
   // the commit is a pure translation, so the bar-anchor offset math is moot.
@@ -440,7 +462,7 @@ export function BarcodeObject({
               />
             )}
             <Group key={`hri-${fontVersion}`} ref={setOverlayGroupRef}>{overlayContent}</Group>
-            {warnBlank && <PlaceholderFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} />}
+            {showStateFrame && <StateFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} color={stateFrameColor} />}
           </Group>
         </Group>
       );
@@ -473,7 +495,7 @@ export function BarcodeObject({
             strokeWidth={isSelected ? 2 : 0}
             strokeScaleEnabled={false}
           />
-          {warnBlank && <PlaceholderFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} />}
+          {showStateFrame && <StateFrame width={Math.max(ub.w, 1)} height={Math.max(ub.h, 1)} color={stateFrameColor} />}
         </Group>
       </Group>
     );

--- a/src/components/Canvas/PreflightOverlay.tsx
+++ b/src/components/Canvas/PreflightOverlay.tsx
@@ -4,6 +4,7 @@ import { getEntry } from "../../registry";
 import type { LeafObject } from "../../registry";
 import { useT } from "../../lib/useT";
 import { useDismiss } from "../../hooks/useDismiss";
+import { Tooltip } from "../ui/Tooltip";
 import type { PreflightFinding, PreflightKind } from "../../lib/preflight";
 
 interface Props {
@@ -68,25 +69,29 @@ export function PreflightOverlay({ findings, objects, onSelect }: Props) {
             {findings.map((f, i) => {
               const Icon = f.severity === "error" ? ExclamationCircleIcon : ExclamationTriangleIcon;
               const tone = f.severity === "error" ? "text-error" : "text-accent";
+              // Tooltip instead of native title: the truncated detail is
+              // readable in full without the ~1s hover delay, and on focus.
+              // role="none" keeps the wrapper transparent so the menuitem
+              // stays a direct owned child of role=menu.
               return (
-                <button
-                  key={`${f.objectId}-${i}`}
-                  type="button"
-                  role="menuitem"
-                  title={f.detail || undefined}
-                  onClick={() => {
-                    onSelect(f.objectId);
-                    setOpen(false);
-                  }}
-                  className="flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-surface-2 transition-colors"
-                >
-                  <Icon className={`w-3.5 h-3.5 shrink-0 ${tone}`} />
-                  <span className="flex flex-col min-w-0">
-                    <span className="truncate text-text">{nameOf(f.objectId)}</span>
-                    {f.detail && <span className="truncate text-[10px] text-muted">{f.detail}</span>}
-                  </span>
-                  <span className="ml-auto shrink-0 text-muted">{kindText(f.kind)}</span>
-                </button>
+                <Tooltip key={`${f.objectId}-${i}`} content={f.detail} className="w-full" wrapperRole="none">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      onSelect(f.objectId);
+                      setOpen(false);
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-surface-2 transition-colors"
+                  >
+                    <Icon className={`w-3.5 h-3.5 shrink-0 ${tone}`} />
+                    <span className="flex flex-col min-w-0">
+                      <span className="truncate text-text">{nameOf(f.objectId)}</span>
+                      {f.detail && <span className="truncate text-[10px] text-muted">{f.detail}</span>}
+                    </span>
+                    <span className="ml-auto shrink-0 text-muted">{kindText(f.kind)}</span>
+                  </button>
+                </Tooltip>
               );
             })}
           </div>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -15,6 +15,10 @@ interface TooltipProps {
   delayMs?: number;
   /** Extra classes for the inline-flex wrapper (e.g. self-start in a column). */
   className?: string;
+  /** ARIA role for the wrapper span. Pass "none" when wrapping a child that
+   *  must stay a direct owned child of its parent (e.g. a role=menuitem inside
+   *  a role=menu), so the wrapper is transparent in the accessibility tree. */
+  wrapperRole?: string;
 }
 
 /**
@@ -24,7 +28,7 @@ interface TooltipProps {
  * the rendered tip so it flips to the side with room and clamps into the
  * viewport (never clipped behind the top menu bar or a side edge).
  */
-export function Tooltip({ content, children, placement = "top", delayMs = 120, className }: TooltipProps) {
+export function Tooltip({ content, children, placement = "top", delayMs = 120, className, wrapperRole }: TooltipProps) {
   const id = useId();
   const wrapRef = useRef<HTMLSpanElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
@@ -70,6 +74,7 @@ export function Tooltip({ content, children, placement = "top", delayMs = 120, c
   return (
     <span
       ref={wrapRef}
+      role={wrapperRole}
       className={className ? `inline-flex ${className}` : "inline-flex"}
       onPointerEnter={showAfterDelay}
       onPointerLeave={hide}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { cloneElement, isValidElement, useEffect, useId, useRef, useState } from "react";
-import type { ReactElement, ReactNode } from "react";
+import type { AriaRole, ReactElement, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useAnchoredPosition } from "../../hooks/useAnchoredPosition";
 import { resolveTooltipPosition } from "../../lib/tooltipPosition";
@@ -18,7 +18,7 @@ interface TooltipProps {
   /** ARIA role for the wrapper span. Pass "none" when wrapping a child that
    *  must stay a direct owned child of its parent (e.g. a role=menuitem inside
    *  a role=menu), so the wrapper is transparent in the accessibility tree. */
-  wrapperRole?: string;
+  wrapperRole?: AriaRole;
 }
 
 /**


### PR DESCRIPTION
…d frame

The encoder message stays in the renderFailed preflight; unresolved schema-mode markers show sample bars without the frame. Preflight finding details use the shared Tooltip instead of native title.