### PR TITLE
feat(canvas): live-reflow 1D barcode resize per size step

### DIFF
--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Image as KImage, Group, Rect, Text } from "react-konva";
 import type Konva from "konva";
 import { BARCODE_1D_TYPES, ObjectRegistry } from "../../registry";
@@ -84,8 +84,6 @@ export function BarcodeObject({
   onSelect,
   dragHandlers,
 }: KonvaObjectProps) {
-  const groupRef = useRef<Konva.Group>(null);
-  const overlayGroupRef = useRef<Konva.Group>(null);
   const colors = useColorScheme();
   // Vera Mono (HRI) loads async; Konva won't repaint on an unchanged
   // fontFamily once the FontFace resolves. Keying the overlay on this
@@ -93,11 +91,8 @@ export function BarcodeObject({
   const fontVersion = useFontCacheVersion();
 
   // Overlay group (HRI text + start/stop glyphs, or EAN/UPC digits) with
-  // getClientRect zeroed so the parent bbox stays tight on the bars, and the
-  // counter-scale target during resize so every element keeps constant size
-  // while the bars stretch (see handleTransform), not just the centered text.
+  // getClientRect zeroed so the parent bbox stays tight on the bars.
   const setOverlayGroupRef = useCallback((node: Konva.Group | null) => {
-    overlayGroupRef.current = node;
     if (node) {
       node.getClientRect = () => ({ x: 0, y: 0, width: 0, height: 0 });
     }
@@ -283,9 +278,7 @@ export function BarcodeObject({
     //    sys/trail digits stay visible (their x extends past the
     //    bar bbox); rotated EAN/UPC gets no clipping because the
     //    floated digits land within the rotated bbox after Konva's
-    //    bbox computation. Upright Other 1D additionally counter-
-    //    scales the HRI text during a resize drag so it stays at
-    //    constant visual size while the bars stretch.
+    //    bbox computation.
     const isEanUpc = EAN_UPC_TYPES.has(obj.type);
     const showHriOverlay =
       printInterpEnabled && BARCODE_1D_TYPES.has(obj.type);
@@ -333,9 +326,6 @@ export function BarcodeObject({
         overlayContent = eanOverlay.nodes;
       } else {
         // Other 1D: centered text, optionally flanked by start/stop glyphs.
-        // Counter-scaled as a group when upright (handleTransform); rotated
-        // paths can't (upright-Y is screen-X after R/B) and scale with the
-        // bars, a minor visual nit with no broken print output.
         // GS1-128 HRI prints in Font 0, not the generic HRI face.
         const fontFamily = gs1Hri
           ? HRI_FONT_0
@@ -373,29 +363,9 @@ export function BarcodeObject({
         overlayContent = startStopGlyphs ? [dataText, ...startStopGlyphs] : dataText;
       }
 
-      // Counter-scale the overlay group around the bar edge it hugs (bottom
-      // below-bars, top above-bars) so an element at local y c lands at
-      // anchor*sy + (c - anchor): constant size, gap to the bars preserved.
-      const useUprightTransform = isUpright && !isEanUpc;
-      const counterAnchorY = isTextAbove
-        ? ub.barTopPx
-        : ub.barTopPx + ub.barH;
-      const handleTransform = () => {
-        const grp = groupRef.current;
-        const overlay = overlayGroupRef.current;
-        if (!grp || !overlay) return;
-        const sy = grp.scaleY();
-        if (sy <= 0) return;
-        overlay.scaleY(1 / sy);
-        overlay.y(counterAnchorY * (1 - 1 / sy));
-      };
-      // react-konva doesn't track imperative scaleY/y; reset to JSX defaults.
-      const handleTransformEnd = () => {
-        const overlay = overlayGroupRef.current;
-        if (!overlay) return;
-        overlay.scaleY(1);
-        overlay.y(0);
-      };
+      // No counter-scaling: both resize axes live-reflow in useKonvaTransformer
+      // (per-tick re-render at the committed size), so bars, HRI, text zone and
+      // clip are always drawn at their true size and nothing stretches mid-drag.
 
       // Clip-expansion is upright-EAN/UPC only, absent on other paths
       // so Konva computes a natural bbox. Spread-or-empty keeps the
@@ -411,7 +381,6 @@ export function BarcodeObject({
 
       return (
         <Group
-          ref={useUprightTransform ? groupRef : undefined}
           id={obj.id}
           x={x}
           y={y}
@@ -420,8 +389,6 @@ export function BarcodeObject({
           {...selectionHandlers(onSelect)}
           onDragMove={handleDragMove}
           onDragEnd={handleDragEnd}
-          onTransform={useUprightTransform ? handleTransform : undefined}
-          onTransformEnd={useUprightTransform ? handleTransformEnd : undefined}
         >
           <Group x={innerTr.x} y={innerTr.y} rotation={innerTr.rotation}>
             <KImage

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -19,12 +19,16 @@ import {
   applyHeightSnap,
   applyModuleWidthSnap,
   applyUniformModuleSnap,
+  barcodeHeightReflowGeometry,
+  barcodeMwReflowGeometry,
   computeNewModules,
   pinInactiveEdges,
   positionDidMove,
   forceSquareBox,
   shrinkingBelowFloor,
   type ActiveEdgeFlags,
+  type BarcodeHeightReflowStart,
+  type BarcodeMwReflowStart,
   type BoundingBox,
   type TransformAnchor,
 } from "../transformerGeometry";
@@ -34,7 +38,7 @@ import {
   renderedTopLeftFromModel,
 } from "../transformPosition";
 import { isBarcode } from "../../../lib/objectBounds";
-import { objectRotation } from "../../../registry/rotation";
+import { isAxisSwapped, objectRotation } from "../../../registry/rotation";
 import { getMeasuredSnapshot } from "../measuredBoundsCache";
 import {
   computeResizeSnap,
@@ -225,6 +229,10 @@ export interface TransformerState {
   onTransformEnd: () => void;
 }
 
+/** Pre-drag snapshot + collapsed final for a one-entry reflow commit, or null
+ *  when the drag baked nothing. */
+type ReflowCommit = { restore: ObjectChanges; final: ObjectChanges } | null;
+
 export function useKonvaTransformer({
   transformerRef,
   stageRef,
@@ -303,6 +311,33 @@ export function useKonvaTransformer({
     changed: boolean;
   } | null>(null);
 
+  // 1D barcode live reflow, both resize axes: the moduleWidth axis re-renders
+  // on each integer module crossing, the bar-height axis on each integer dot,
+  // so bars, HRI and text zone always draw at their true size instead of
+  // stretching the old bitmap until release.
+  const barcodeReflowRef = useRef<
+    | (BarcodeMwReflowStart & {
+        mode: "mw";
+        uprightW0: number;
+        uprightH0: number;
+        snapshot: { x: number; y: number; moduleWidth: number; height?: number };
+        changed: boolean;
+      })
+    | (BarcodeHeightReflowStart & {
+        mode: "height";
+        uprightW0: number;
+        snapshot: { x: number; y: number; height: number };
+        changed: boolean;
+      })
+    | null
+  >(null);
+
+  // True while any live reflow (text block, shape, or barcode) owns the drag.
+  const anyReflowActive = () =>
+    liveReflowRef.current !== null ||
+    shapeReflowRef.current !== null ||
+    barcodeReflowRef.current !== null;
+
   // Block resize mode resolved once at drag start (panel mode + Alt). Reused at
   // commit so toggling Alt mid-drag can't make start and end disagree.
   const blockResizeModeRef = useRef<"frame" | "glyph">("frame");
@@ -329,7 +364,7 @@ export function useKonvaTransformer({
   // idempotent set, so the no-active-drag case is a harmless no-op.
   useEffect(() => {
     return () => {
-      if (liveReflowRef.current || shapeReflowRef.current) {
+      if (anyReflowActive()) {
         useLabelStore.temporal.getState().resume();
       }
     };
@@ -363,7 +398,7 @@ export function useKonvaTransformer({
     // During a live reflow the per-tick store update re-runs this effect;
     // re-attaching (.nodes()) mid-drag aborts the gesture, so skip it. The
     // reflow handler keeps the transformer in sync via forceUpdate().
-    if (liveReflowRef.current || shapeReflowRef.current) return;
+    if (anyReflowActive()) return;
     if (selectedIds.length === 0) {
       transformerRef.current.nodes([]);
       return;
@@ -461,9 +496,35 @@ export function useKonvaTransformer({
     activeEdgesRef.current = null;
     liveReflowRef.current = null;
     shapeReflowRef.current = null;
+    barcodeReflowRef.current = null;
     glyphBlockStartRectRef.current = null;
     blockResizeModeRef.current = "frame";
     setGuides([]);
+  }
+
+  /** Collapse a paused live-reflow drag into one undo entry: reset any residual
+   *  node scale, and when the drag baked something (`commit` non-null), restore
+   *  the pre-drag snapshot while still paused, resume, then re-apply the final
+   *  geometry as a single tracked change. Always resumes + cleans up, even on a
+   *  throw (resume is idempotent). */
+  function collapseReflowToOneEntry(
+    id: string | undefined,
+    commit: ReflowCommit,
+  ) {
+    const node = id ? stageRef.current?.findOne<Konva.Node>(`#${id}`) : null;
+    node?.scaleX(1);
+    node?.scaleY(1);
+    const temporal = useLabelStore.temporal.getState();
+    try {
+      if (id && commit) {
+        updateObject(id, commit.restore);
+        temporal.resume();
+        updateObject(id, commit.final);
+      }
+    } finally {
+      temporal.resume();
+      cleanupTransformState();
+    }
   }
 
   const onTransformStart = () => {
@@ -639,6 +700,66 @@ export function useKonvaTransformer({
       };
       useLabelStore.temporal.getState().pause();
     }
+    // 1D live reflow, armed per grabbed axis: moduleWidth axis (screen X for
+    // N/I, screen Y for R/B) re-renders per module crossing, the bar-height
+    // axis per dot. Needs the measured footprint for the start box; an
+    // unmeasured barcode falls back to bake-on-end. Gated on an unrotated view:
+    // under viewRotation != 0 boundBoxFunc bails to native Konva, so the per-tick
+    // model inversion would read rotated-frame coords (mirrors the ^FB reflow).
+    barcodeReflowRef.current = null;
+    if (obj && !isGroup(obj) && BARCODE_1D_TYPES.has(obj.type) && viewRotation === 0) {
+      const edges = activeEdgesRef.current;
+      const rot = objectRotation(obj.props);
+      const swapped = isAxisSwapped(rot);
+      const cache = getMeasuredSnapshot().get(singleId);
+      const p = obj.props as { moduleWidth?: number; height?: number };
+      if (edges && cache) {
+        const leftX = node.x();
+        const topY = node.y();
+        const box = {
+          leftX,
+          topY,
+          rightX: leftX + dotsToPx(cache.width, scale, dpmm),
+          bottomY: topY + dotsToPx(cache.height, scale, dpmm),
+        };
+        const uprightH0 = cache.uprightBarHDots ?? p.height ?? 0;
+        const mwAxisActive = swapped ? edges.top || edges.bottom : edges.left || edges.right;
+        const heightAxisActive = swapped ? edges.left || edges.right : edges.top || edges.bottom;
+        if (mwAxisActive && typeof p.moduleWidth === "number" && p.moduleWidth > 0) {
+          barcodeReflowRef.current = {
+            mode: "mw",
+            rotation: rot,
+            edges,
+            ...box,
+            mw0: p.moduleWidth,
+            uprightW0: cache.uprightBarWDots ?? 0,
+            uprightH0,
+            // height rides along: normalizeChanges may re-clamp it as a side
+            // effect of the per-tick moduleWidth writes (code49), and the undo
+            // baseline must restore that too.
+            snapshot: { x: obj.x, y: obj.y, moduleWidth: p.moduleWidth, height: p.height },
+            changed: false,
+          };
+          useLabelStore.temporal.getState().pause();
+        } else if (heightAxisActive && typeof p.height === "number" && p.height > 0 && uprightH0 > 0) {
+          // The transformer frames the bars only, so per tick the bar height IS
+          // the frame extent; the constant non-bar zone (HRI text, EAN guard
+          // tails) is added back solely to pin the anchored bbox edge.
+          const axisFootprintDots = swapped ? cache.width : cache.height;
+          barcodeReflowRef.current = {
+            mode: "height",
+            rotation: rot,
+            edges,
+            ...box,
+            zonePx: Math.max(0, dotsToPx(axisFootprintDots - uprightH0, scale, dpmm)),
+            uprightW0: cache.uprightBarWDots ?? 0,
+            snapshot: { x: obj.x, y: obj.y, height: p.height },
+            changed: false,
+          };
+          useLabelStore.temporal.getState().pause();
+        }
+      }
+    }
   };
 
   // Per-tick live reflow for a frame-mode ^FB block: convert the group scale
@@ -702,6 +823,113 @@ export function useKonvaTransformer({
       node.scaleY(1);
       node.x(geo.targetXPx);
       node.y(geo.targetYPx);
+      transformerRef.current?.forceUpdate();
+      return;
+    }
+
+    // 1D barcode reflow: bake the next size step the moment the frame crosses
+    // it, so bars, HRI and text zone re-render at their true size instead of
+    // stretching. The moduleWidth axis quantises from the TOTAL drag extent
+    // (same inputs as the box snap) because rendered pixel widths are stepwise
+    // in moduleWidth; an incremental-scale quantiser would oscillate wherever
+    // adjacent module widths render at the same pixel width.
+    const br = barcodeReflowRef.current;
+    if (br) {
+      const swapped = isAxisSwapped(br.rotation);
+      const natural = node.getClientRect({
+        skipTransform: true,
+        skipStroke: true,
+        skipShadow: true,
+      });
+      if (br.mode === "mw") {
+        const mwCurrent = (cur.props as { moduleWidth?: number }).moduleWidth;
+        if (typeof mwCurrent !== "number" || !(mwCurrent > 0)) return;
+        const frameExtentPx = swapped ? natural.height * sy : natural.width * sx;
+        const geo = barcodeMwReflowGeometry(br, mwCurrent, frameExtentPx);
+        if (!geo) return;
+        const ratio = geo.moduleWidth / br.mw0;
+        // Same inversion as the end commit for the ACTIVE axis; the anchored
+        // axis keeps its pre-drag model value (mirrors the end commit's
+        // snapAxis), else the bar-zone offset (above-HRI, rotated EAN) that
+        // the FO inversion ignores would corrupt the stored anchor coordinate.
+        const model = modelPositionFromRenderedTopLeft(
+          cur,
+          pxToDots(geo.targetXPx - objectsOffsetX, scale, dpmm),
+          pxToDots(geo.targetYPx - labelOffsetY, scale, dpmm),
+          br.uprightW0 * ratio,
+          br.uprightH0,
+        );
+        flushSync(() => {
+          updateObject(id, {
+            x: swapped ? br.snapshot.x : model.x,
+            y: swapped ? model.y : br.snapshot.y,
+            props: { moduleWidth: geo.moduleWidth },
+          });
+        });
+        br.changed = true;
+        // Fit the re-rendered content into the frame's linear module model:
+        // the residual is 1 wherever pixels-per-module are exact and only
+        // deviates at zoom levels where adjacent module widths render at the
+        // same pixel width (there a crisp distinct width does not exist).
+        const rendered = node.getClientRect({
+          skipTransform: true,
+          skipStroke: true,
+          skipShadow: true,
+        });
+        const renderedExtent = swapped ? rendered.height : rendered.width;
+        const residual = renderedExtent > 0 ? geo.linearExtentPx / renderedExtent : 1;
+        node.scaleX(swapped ? 1 : residual);
+        node.scaleY(swapped ? residual : 1);
+        node.x(geo.targetXPx);
+        node.y(geo.targetYPx);
+        transformerRef.current?.forceUpdate();
+        return;
+      }
+      // Height axis: continuous, baked per integer dot. Each tick routes
+      // through the registry commit (identity scale + identity snap = clamp
+      // only) so per-type ranges hold mid-drag: code49 clamps into bwip's
+      // 8..50-module window, where an unclamped write would error the whole
+      // render. The pin recomputes from the committed height so the anchored
+      // edge lands exactly on the rendered size.
+      const frameExtentPx = swapped ? natural.width * sx : natural.height * sy;
+      const geo = barcodeHeightReflowGeometry(br, frameExtentPx);
+      if (!geo) return;
+      const newHeightDots = pxToDots(geo.barExtentPx, scale, dpmm);
+      const hCurrent = (cur.props as { height?: number }).height;
+      if (!(newHeightDots >= 1)) return;
+      const commitFn = getEntry(cur.type)?.commitTransform;
+      const candidate = { ...cur, props: { ...cur.props, height: newHeightDots } } as typeof cur;
+      const committed = commitFn?.(candidate, {
+        sx: 1,
+        sy: 1,
+        snap: (n: number) => n,
+        nodeHeight: 0,
+        anchor: null,
+        resizeMode: blockResizeModeRef.current,
+      }) as { height?: number } | undefined;
+      const hNext = committed?.height ?? newHeightDots;
+      if (hNext === hCurrent) return;
+      const pin = barcodeHeightReflowGeometry(br, dotsToPx(hNext, scale, dpmm));
+      if (!pin) return;
+      const model = modelPositionFromRenderedTopLeft(
+        cur,
+        pxToDots(pin.targetXPx - objectsOffsetX, scale, dpmm),
+        pxToDots(pin.targetYPx - labelOffsetY, scale, dpmm),
+        br.uprightW0,
+        hNext,
+      );
+      flushSync(() => {
+        updateObject(id, {
+          x: swapped ? model.x : br.snapshot.x,
+          y: swapped ? br.snapshot.y : model.y,
+          props: { height: hNext },
+        });
+      });
+      br.changed = true;
+      node.scaleX(1);
+      node.scaleY(1);
+      node.x(pin.targetXPx);
+      node.y(pin.targetYPx);
       transformerRef.current?.forceUpdate();
       return;
     }
@@ -823,91 +1051,92 @@ export function useKonvaTransformer({
   };
 
   const onTransformEnd = () => {
-    // Live reflow applied blockWidth/blockLines + position each tick while undo
-    // recording was paused. Collapse the whole drag into one history entry:
-    // restore the pre-drag snapshot (still paused), resume, then re-apply the
-    // final geometry as a single tracked change.
+    // Each live-reflow branch derives its (restore, final) prop delta and hands
+    // it to collapseReflowToOneEntry, which folds the paused per-tick writes into
+    // one undo entry (or resets the residual scale and bails when nothing baked).
     const lr = liveReflowRef.current;
     if (lr) {
       const id = selectedIds[0];
-      // A final tick that early-returned (e.g. node briefly unresolved) can
-      // leave a residual scale; reset it so the box doesn't stay stretched.
-      const lrNode = id ? stageRef.current?.findOne<Konva.Node>(`#${id}`) : null;
-      lrNode?.scaleX(1);
-      lrNode?.scaleY(1);
       const cur = id ? findObjectById(getCurrentObjects(), id) : undefined;
-      const temporal = useLabelStore.temporal.getState();
-      // try/finally so a throw can't leave undo paused (resume is idempotent).
-      try {
-        if (lr.changed && id && cur && !isGroup(cur)) {
-          const cp = cur.props as { blockWidth?: number; blockLines?: number; blockHeight?: number };
-          // ^TB collapses width + clip height; ^FB width + line count.
-          const secondAxis = lr.mode === "tb"
-            ? { blockHeight: cp.blockHeight }
-            : { blockLines: cp.blockLines };
-          const snapAxis = lr.mode === "tb"
-            ? { blockHeight: lr.snapshot.blockHeight }
-            : { blockLines: lr.snapshot.blockLines };
-          const final = {
-            x: cur.x,
-            y: cur.y,
-            props: { blockWidth: cp.blockWidth, ...secondAxis },
-          };
-          updateObject(id, {
-            x: lr.snapshot.x,
-            y: lr.snapshot.y,
-            props: {
-              blockWidth: lr.snapshot.blockWidth,
-              ...snapAxis,
-            },
-          });
-          temporal.resume();
-          updateObject(id, final);
-        }
-      } finally {
-        temporal.resume();
-        cleanupTransformState();
+      let commit: ReflowCommit = null;
+      if (lr.changed && id && cur && !isGroup(cur)) {
+        const cp = cur.props as { blockWidth?: number; blockLines?: number; blockHeight?: number };
+        // ^TB collapses width + clip height; ^FB width + line count.
+        const secondAxis = lr.mode === "tb" ? { blockHeight: cp.blockHeight } : { blockLines: cp.blockLines };
+        const snapAxis = lr.mode === "tb" ? { blockHeight: lr.snapshot.blockHeight } : { blockLines: lr.snapshot.blockLines };
+        commit = {
+          restore: { x: lr.snapshot.x, y: lr.snapshot.y, props: { blockWidth: lr.snapshot.blockWidth, ...snapAxis } },
+          final: { x: cur.x, y: cur.y, props: { blockWidth: cp.blockWidth, ...secondAxis } },
+        };
       }
+      collapseReflowToOneEntry(id, commit);
       return;
     }
-    // Shape live reflow: same collapse-to-one-entry as the text block. Dims were
-    // kept float during the drag; round + snap them once here for the commit.
+    const br = barcodeReflowRef.current;
+    if (br) {
+      const id = selectedIds[0];
+      const cur = id ? findObjectById(getCurrentObjects(), id) : undefined;
+      let commit: ReflowCommit = null;
+      if (br.changed && id && cur && !isGroup(cur)) {
+        const cp = cur.props as { moduleWidth?: number; height?: number };
+        // Final goes through the registry commit at identity scale (= re-commit
+        // the baked props) so per-type contracts hold: grid snap for height,
+        // the ^BY clamp, code49's bwip range clamp. The fallback mirrors the
+        // generic formula for entries without a commitTransform.
+        const commitFn = getEntry(cur.type)?.commitTransform;
+        const finalProps = commitFn
+          ? commitFn(cur, {
+              sx: 1,
+              sy: 1,
+              snap,
+              nodeHeight: 0,
+              anchor: null,
+              resizeMode: blockResizeModeRef.current,
+            })
+          : br.mode === "mw"
+            ? { moduleWidth: cp.moduleWidth }
+            : { height: Math.max(1, snap(Math.round(cp.height ?? 1))) };
+        commit = {
+          restore: {
+            x: br.snapshot.x,
+            y: br.snapshot.y,
+            props:
+              br.mode === "mw"
+                ? typeof br.snapshot.height === "number"
+                  ? { moduleWidth: br.snapshot.moduleWidth, height: br.snapshot.height }
+                  : { moduleWidth: br.snapshot.moduleWidth }
+                : { height: br.snapshot.height },
+          },
+          final: { x: cur.x, y: cur.y, props: finalProps },
+        };
+      }
+      collapseReflowToOneEntry(id, commit);
+      return;
+    }
     const sr = shapeReflowRef.current;
     if (sr) {
       const id = selectedIds[0];
-      const srNode = id ? stageRef.current?.findOne<Konva.Node>(`#${id}`) : null;
-      srNode?.scaleX(1);
-      srNode?.scaleY(1);
       const cur = id ? findObjectById(getCurrentObjects(), id) : undefined;
-      const temporal = useLabelStore.temporal.getState();
-      // try/finally so a throw can't leave undo paused (resume is idempotent).
-      try {
-        if (sr.changed && id && cur && !isGroup(cur)) {
-          const sp = cur.props as { width: number; height: number };
-          // Same snap/round/clamp contract as commitWidthHeightTransform, applied
-          // to the already-baked float dims.
-          const width = Math.max(1, snap(Math.round(sp.width)));
-          const height = Math.max(1, snap(Math.round(sp.height)));
-          // Pin the anchored edge: when dragging left/top, derive x/y from the
-          // snapped size so the opposite edge doesn't walk by the snap delta.
-          const edges = activeEdgesRef.current;
-          const final = {
+      let commit: ReflowCommit = null;
+      if (sr.changed && id && cur && !isGroup(cur)) {
+        const sp = cur.props as { width: number; height: number };
+        // Same snap/round/clamp contract as commitWidthHeightTransform, applied
+        // to the already-baked float dims.
+        const width = Math.max(1, snap(Math.round(sp.width)));
+        const height = Math.max(1, snap(Math.round(sp.height)));
+        // Pin the anchored edge: when dragging left/top, derive x/y from the
+        // snapped size so the opposite edge doesn't walk by the snap delta.
+        const edges = activeEdgesRef.current;
+        commit = {
+          restore: { x: sr.snapshot.x, y: sr.snapshot.y, props: { width: sr.snapshot.width, height: sr.snapshot.height } },
+          final: {
             x: Math.round(edges?.left ? cur.x + sp.width - width : cur.x),
             y: Math.round(edges?.top ? cur.y + sp.height - height : cur.y),
             props: { width, height },
-          };
-          updateObject(id, {
-            x: sr.snapshot.x,
-            y: sr.snapshot.y,
-            props: { width: sr.snapshot.width, height: sr.snapshot.height },
-          });
-          temporal.resume();
-          updateObject(id, final);
-        }
-      } finally {
-        temporal.resume();
-        cleanupTransformState();
+          },
+        };
       }
+      collapseReflowToOneEntry(id, commit);
       return;
     }
     if (selectedIds.length !== 1 || !selectedIds[0] || !stageRef.current) {

--- a/src/components/Canvas/transformerGeometry.test.ts
+++ b/src/components/Canvas/transformerGeometry.test.ts
@@ -6,12 +6,131 @@ import {
   applyHeightSnap,
   applyModuleWidthSnap,
   applyUniformModuleSnap,
+  barcodeHeightReflowGeometry,
+  barcodeMwReflowGeometry,
   pinInactiveEdges,
   computeNewModules,
   activeEdgesFromAnchorName,
   shrinkingBelowFloor,
+  type BarcodeHeightReflowStart,
+  type BarcodeMwReflowStart,
   type BoundingBox,
 } from "./transformerGeometry";
+
+describe("barcodeMwReflowGeometry", () => {
+  const edges = (over: Partial<BarcodeMwReflowStart["edges"]>): BarcodeMwReflowStart["edges"] =>
+    ({ left: false, right: false, top: false, bottom: false, ...over });
+  // Start box 100..300 x 50..130 px at moduleWidth 2 (mw axis: 100 px per module).
+  const start = (over: Partial<BarcodeMwReflowStart> = {}): BarcodeMwReflowStart => ({
+    rotation: "N",
+    edges: edges({ right: true }),
+    mw0: 2,
+    leftX: 100,
+    topY: 50,
+    rightX: 300,
+    bottomY: 130,
+    ...over,
+  });
+
+  it("returns null inside the current module band (same rounding as the box snap)", () => {
+    expect(barcodeMwReflowGeometry(start(), 2, 240)).toBeNull();
+    expect(barcodeMwReflowGeometry(start(), 2, 200)).toBeNull();
+  });
+
+  it("right-handle crossing keeps the left edge and bumps the module width", () => {
+    const geo = barcodeMwReflowGeometry(start(), 2, 300);
+    expect(geo).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 50, linearExtentPx: 300 });
+  });
+
+  it("left-handle crossing keeps the right edge fixed", () => {
+    const geo = barcodeMwReflowGeometry(start({ edges: edges({ left: true }) }), 2, 300);
+    // Linear width 300 pinned to rightX 300: x = 0.
+    expect(geo).toEqual({ moduleWidth: 3, targetXPx: 0, targetYPx: 50, linearExtentPx: 300 });
+  });
+
+  it("stays quantised on the TOTAL extent after earlier bakes (no oscillation)", () => {
+    // Baked at 3, pointer parked at 1.5x the start extent: still module 3, no
+    // re-bake even though the rendered pixel width may differ stepwise.
+    expect(barcodeMwReflowGeometry(start(), 3, 300)).toBeNull();
+    // Pointer moves on to 2x: crossing to 4 from the same start baseline.
+    const geo = barcodeMwReflowGeometry(start(), 3, 400);
+    expect(geo).toEqual({ moduleWidth: 4, targetXPx: 100, targetYPx: 50, linearExtentPx: 400 });
+  });
+
+  it("clamps at the ^BY bounds and reports no change there", () => {
+    expect(barcodeMwReflowGeometry(start({ mw0: 10 }), 10, 600)).toBeNull();
+    expect(barcodeMwReflowGeometry(start({ mw0: 1 }), 1, 10)).toBeNull();
+  });
+
+  it("R/B rotations quantise the vertical axis and pin top/bottom", () => {
+    const rb = start({ rotation: "R", edges: edges({ bottom: true }) });
+    // Vertical extent 80 px at mw 2; 120 px crosses to 3, top fixed.
+    const geo = barcodeMwReflowGeometry(rb, 2, 120);
+    expect(geo).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 50, linearExtentPx: 120 });
+    const topDrag = start({ rotation: "B", edges: edges({ top: true }) });
+    const geoTop = barcodeMwReflowGeometry(topDrag, 2, 120);
+    // Bottom fixed at 130: new top = 130 - 120 = 10.
+    expect(geoTop).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 10, linearExtentPx: 120 });
+  });
+
+  it("rejects degenerate extents", () => {
+    expect(barcodeMwReflowGeometry(start(), 2, 0)).toBeNull();
+    expect(barcodeMwReflowGeometry(start({ rightX: 100 }), 2, 300)).toBeNull();
+  });
+});
+
+describe("barcodeHeightReflowGeometry", () => {
+  const edges = (over: Partial<BarcodeHeightReflowStart["edges"]>): BarcodeHeightReflowStart["edges"] =>
+    ({ left: false, right: false, top: false, bottom: false, ...over });
+  // Footprint 100..300 x 50..150 px; 20 px of the height axis is the HRI zone.
+  const start = (over: Partial<BarcodeHeightReflowStart> = {}): BarcodeHeightReflowStart => ({
+    rotation: "N",
+    edges: edges({ bottom: true }),
+    leftX: 100,
+    topY: 50,
+    rightX: 300,
+    bottomY: 150,
+    zonePx: 20,
+    ...over,
+  });
+
+  it("bottom-handle drag keeps the top edge and maps frame straight to bar height", () => {
+    // Frame is bar-only, so bar extent == frame (no zone subtraction); top edge
+    // is the bbox top, unaffected by the bottom drag.
+    expect(barcodeHeightReflowGeometry(start(), 140)).toEqual({
+      barExtentPx: 140,
+      targetXPx: 100,
+      targetYPx: 50,
+    });
+  });
+
+  it("top-handle drag pins the bottom edge via the bbox (frame + zone)", () => {
+    const geo = barcodeHeightReflowGeometry(start({ edges: edges({ top: true }) }), 100);
+    // Bbox extent = frame 100 + zone 20 = 120; bottom fixed at 150 -> top = 30.
+    expect(geo).toEqual({ barExtentPx: 100, targetXPx: 100, targetYPx: 30 });
+  });
+
+  it("R/B rotations run the height axis on screen X and pin left/right", () => {
+    const rb = start({ rotation: "R", edges: edges({ right: true }) });
+    expect(barcodeHeightReflowGeometry(rb, 240)).toEqual({
+      barExtentPx: 240,
+      targetXPx: 100,
+      targetYPx: 50,
+    });
+    const leftDrag = start({ rotation: "B", edges: edges({ left: true }) });
+    // Bbox extent = frame 240 + zone 20 = 260; right fixed at 300 -> left = 40.
+    expect(barcodeHeightReflowGeometry(leftDrag, 240)).toEqual({
+      barExtentPx: 240,
+      targetXPx: 40,
+      targetYPx: 50,
+    });
+  });
+
+  it("rejects a collapsed frame", () => {
+    expect(barcodeHeightReflowGeometry(start(), 0)).toBeNull();
+    expect(barcodeHeightReflowGeometry(start(), -5)).toBeNull();
+  });
+});
 
 describe("shrinkingBelowFloor", () => {
   const box = (width: number, height: number): BoundingBox => ({ x: 0, y: 0, width, height, rotation: 0 });

--- a/src/components/Canvas/transformerGeometry.ts
+++ b/src/components/Canvas/transformerGeometry.ts
@@ -15,6 +15,98 @@ export interface ActiveEdgeFlags {
   bottom: boolean;
 }
 
+/** Start-of-drag frame for the 1D moduleWidth live reflow: the model box in
+ *  parent px plus the starting module width, captured once so the anchored
+ *  edge stays fixed across every re-render of the drag. */
+export interface BarcodeMwReflowStart {
+  rotation: ZplRotation;
+  edges: ActiveEdgeFlags;
+  mw0: number;
+  leftX: number;
+  topY: number;
+  rightX: number;
+  bottomY: number;
+}
+
+/** Per-tick geometry of the 1D moduleWidth live reflow. Quantises from the
+ *  TOTAL drag extent against the start box (identical inputs to the in-drag
+ *  box snap, so the two can never disagree or oscillate: rendered pixel
+ *  widths are stepwise in moduleWidth, an incremental-scale quantiser would
+ *  hunt). Returns null while the drag sits inside the current module band.
+ *  Both edges come from the start box's LINEAR module model, matching the
+ *  frame the box snap shows; the caller fits the re-rendered content into
+ *  that frame via a residual scale. */
+export function barcodeMwReflowGeometry(
+  start: BarcodeMwReflowStart,
+  mwCurrent: number,
+  frameExtentPx: number,
+): { moduleWidth: number; targetXPx: number; targetYPx: number; linearExtentPx: number } | null {
+  if (!(mwCurrent > 0) || !(start.mw0 > 0)) return null;
+  const swapped = isAxisSwapped(start.rotation);
+  const startExtent = swapped ? start.bottomY - start.topY : start.rightX - start.leftX;
+  if (!(startExtent > 0) || !(frameExtentPx > 0)) return null;
+  const moduleWidth = computeNewModules(start.mw0, frameExtentPx / startExtent, 1, 10);
+  if (moduleWidth === mwCurrent) return null;
+  const linearExtentPx = startExtent * (moduleWidth / start.mw0);
+  if (!swapped) {
+    return {
+      moduleWidth,
+      targetXPx: start.edges.left ? start.rightX - linearExtentPx : start.leftX,
+      targetYPx: start.topY,
+      linearExtentPx,
+    };
+  }
+  return {
+    moduleWidth,
+    targetXPx: start.leftX,
+    targetYPx: start.edges.top ? start.bottomY - linearExtentPx : start.topY,
+    linearExtentPx,
+  };
+}
+
+/** Start-of-drag frame for the 1D bar-height live reflow: the footprint bbox in
+ *  parent px plus the constant non-bar share of the height axis (HRI text zone,
+ *  EAN guard-tail zone). The transformer frames the bars only (the zone is
+ *  outside the client rect), so the frame extent is the bar height directly;
+ *  the zone is added back only to reconstruct the bbox for the anchored-edge
+ *  pin. The height axis is the screen Y for N/I and the screen X for R/B. */
+export interface BarcodeHeightReflowStart {
+  rotation: ZplRotation;
+  edges: ActiveEdgeFlags;
+  leftX: number;
+  topY: number;
+  rightX: number;
+  bottomY: number;
+  /** Constant (non-bar) share of the height-axis extent, px. */
+  zonePx: number;
+}
+
+/** Per-tick geometry of the 1D bar-height live reflow: the bar extent the frame
+ *  implies and the pinned top-left. The frame is bar-only, so bar height = frame
+ *  extent; the pin reconstructs the bbox as frame + zone so the anchored edge
+ *  holds. Null for a collapsed frame. */
+export function barcodeHeightReflowGeometry(
+  start: BarcodeHeightReflowStart,
+  frameExtentPx: number,
+): { barExtentPx: number; targetXPx: number; targetYPx: number } | null {
+  if (!(frameExtentPx > 0)) return null;
+  const barExtentPx = frameExtentPx;
+  const bboxExtentPx = frameExtentPx + start.zonePx;
+  const swapped = isAxisSwapped(start.rotation);
+  if (swapped) {
+    return {
+      barExtentPx,
+      targetXPx: start.edges.left ? start.rightX - bboxExtentPx : start.leftX,
+      targetYPx: start.topY,
+    };
+  }
+  return {
+    barExtentPx,
+    targetXPx: start.leftX,
+    targetYPx: start.edges.top ? start.bottomY - bboxExtentPx : start.topY,
+  };
+}
+
 /** Snap a height to a multiple of stepPx, with stepPx as the minimum. */
 export function snapBoxHeight(height: number, stepPx: number): number {
   return Math.max(stepPx, Math.round(height / stepPx) * stepPx);

--- a/src/registry/code49.test.ts
+++ b/src/registry/code49.test.ts
@@ -99,3 +99,22 @@ describe('code49 — commitTransform height clamp on resize drag', () => {
     expect(result?.height).toBeLessThanOrEqual(100);
   });
 });
+
+describe('code49 — commitTransform at identity scale (live-reflow contract)', () => {
+  // The barcode live reflow bakes per-tick heights and re-commits them through
+  // commitTransform with sx=sy=1 and identity snap: the call must act as a
+  // pure range clamp, and must not disturb already-valid props.
+  const identityCtx = { sx: 1, sy: 1, snap: (v: number) => v, nodeHeight: 0, anchor: null };
+
+  it('clamps an out-of-range baked height at both bounds', () => {
+    const low = code49.commitTransform?.(baseObj({ height: 10, moduleWidth: 2 }), identityCtx);
+    expect(low?.height).toBe(16);
+    const high = code49.commitTransform?.(baseObj({ height: 300, moduleWidth: 2 }), identityCtx);
+    expect(high?.height).toBe(100);
+  });
+
+  it('passes valid props through unchanged', () => {
+    const result = code49.commitTransform?.(baseObj({ height: 40, moduleWidth: 3 }), identityCtx);
+    expect(result).toMatchObject({ height: 40, moduleWidth: 3 });
+  });
+});


### PR DESCRIPTION
moduleWidth re-renders per module crossing, bar height per dot; HRI and text zone keep their true size instead of stretching (counter-scale removed).