### PR TITLE
fix(canvas): barcode reflow works in rotated views

### DIFF
--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -700,14 +700,13 @@ export function useKonvaTransformer({
       };
       useLabelStore.temporal.getState().pause();
     }
-    // 1D live reflow, armed per grabbed axis: moduleWidth axis (screen X for
-    // N/I, screen Y for R/B) re-renders per module crossing, the bar-height
-    // axis per dot. Needs the measured footprint for the start box; an
-    // unmeasured barcode falls back to bake-on-end. Gated on an unrotated view:
-    // under viewRotation != 0 boundBoxFunc bails to native Konva, so the per-tick
-    // model inversion would read rotated-frame coords (mirrors the ^FB reflow).
+    // 1D live reflow, armed per grabbed axis. Needs the measured footprint for
+    // the start box; an unmeasured barcode falls back to bake-on-end. View
+    // rotation is safe: node coords, anchor-name edges and the model inversion
+    // live in the unrotated parent frame, and the per-tick pin stands in for
+    // boundBoxFunc's band snap, which bails under rotation.
     barcodeReflowRef.current = null;
-    if (obj && !isGroup(obj) && BARCODE_1D_TYPES.has(obj.type) && viewRotation === 0) {
+    if (obj && !isGroup(obj) && BARCODE_1D_TYPES.has(obj.type)) {
       const edges = activeEdgesRef.current;
       const rot = objectRotation(obj.props);
       const swapped = isAxisSwapped(rot);
@@ -845,37 +844,39 @@ export function useKonvaTransformer({
         const mwCurrent = (cur.props as { moduleWidth?: number }).moduleWidth;
         if (typeof mwCurrent !== "number" || !(mwCurrent > 0)) return;
         const frameExtentPx = swapped ? natural.height * sy : natural.width * sx;
-        const geo = barcodeMwReflowGeometry(br, mwCurrent, frameExtentPx);
+        const geo = barcodeMwReflowGeometry(br, frameExtentPx);
         if (!geo) return;
-        const ratio = geo.moduleWidth / br.mw0;
-        // Same inversion as the end commit for the ACTIVE axis; the anchored
-        // axis keeps its pre-drag model value (mirrors the end commit's
-        // snapAxis), else the bar-zone offset (above-HRI, rotated EAN) that
-        // the FO inversion ignores would corrupt the stored anchor coordinate.
-        const model = modelPositionFromRenderedTopLeft(
-          cur,
-          pxToDots(geo.targetXPx - objectsOffsetX, scale, dpmm),
-          pxToDots(geo.targetYPx - labelOffsetY, scale, dpmm),
-          br.uprightW0 * ratio,
-          br.uprightH0,
-        );
-        flushSync(() => {
-          updateObject(id, {
-            x: swapped ? br.snapshot.x : model.x,
-            y: swapped ? model.y : br.snapshot.y,
-            props: { moduleWidth: geo.moduleWidth },
+        const crossed = geo.moduleWidth !== mwCurrent;
+        if (crossed) {
+          const ratio = geo.moduleWidth / br.mw0;
+          // Same inversion as the end commit for the ACTIVE axis; the anchored
+          // axis keeps its pre-drag model value (mirrors the end commit's
+          // snapAxis), else the bar-zone offset (above-HRI, rotated EAN) that
+          // the FO inversion ignores would corrupt the stored anchor coordinate.
+          const model = modelPositionFromRenderedTopLeft(
+            cur,
+            pxToDots(geo.targetXPx - objectsOffsetX, scale, dpmm),
+            pxToDots(geo.targetYPx - labelOffsetY, scale, dpmm),
+            br.uprightW0 * ratio,
+            br.uprightH0,
+          );
+          flushSync(() => {
+            updateObject(id, {
+              x: swapped ? br.snapshot.x : model.x,
+              y: swapped ? model.y : br.snapshot.y,
+              props: { moduleWidth: geo.moduleWidth },
+            });
           });
-        });
-        br.changed = true;
-        // Fit the re-rendered content into the frame's linear module model:
-        // the residual is 1 wherever pixels-per-module are exact and only
-        // deviates at zoom levels where adjacent module widths render at the
-        // same pixel width (there a crisp distinct width does not exist).
-        const rendered = node.getClientRect({
-          skipTransform: true,
-          skipStroke: true,
-          skipShadow: true,
-        });
+          br.changed = true;
+        }
+        // Pin every tick, not just on crossings: the reflow is the sole band
+        // pin, so the raster holds in rotated views where boundBoxFunc bails.
+        // The residual fits the re-rendered content into the linear frame (1
+        // when pixels-per-module are exact). Only a crossing re-renders, so
+        // mid-band `natural` is still the current rect.
+        const rendered = crossed
+          ? node.getClientRect({ skipTransform: true, skipStroke: true, skipShadow: true })
+          : natural;
         const renderedExtent = swapped ? rendered.height : rendered.width;
         const residual = renderedExtent > 0 ? geo.linearExtentPx / renderedExtent : 1;
         node.scaleX(swapped ? 1 : residual);
@@ -885,12 +886,11 @@ export function useKonvaTransformer({
         transformerRef.current?.forceUpdate();
         return;
       }
-      // Height axis: continuous, baked per integer dot. Each tick routes
-      // through the registry commit (identity scale + identity snap = clamp
-      // only) so per-type ranges hold mid-drag: code49 clamps into bwip's
-      // 8..50-module window, where an unclamped write would error the whole
-      // render. The pin recomputes from the committed height so the anchored
-      // edge lands exactly on the rendered size.
+      // Height axis, baked per integer dot. Route each tick through the registry
+      // commit at identity scale (= clamp only) so per-type ranges hold mid-drag:
+      // code49 must clamp into bwip's module window or the whole render errors.
+      // The height re-render lands on the frame exactly, so the pin needs no
+      // residual; the scale just resets to 1.
       const frameExtentPx = swapped ? natural.width * sx : natural.height * sy;
       const geo = barcodeHeightReflowGeometry(br, frameExtentPx);
       if (!geo) return;
@@ -908,24 +908,27 @@ export function useKonvaTransformer({
         resizeMode: blockResizeModeRef.current,
       }) as { height?: number } | undefined;
       const hNext = committed?.height ?? newHeightDots;
-      if (hNext === hCurrent) return;
       const pin = barcodeHeightReflowGeometry(br, dotsToPx(hNext, scale, dpmm));
       if (!pin) return;
-      const model = modelPositionFromRenderedTopLeft(
-        cur,
-        pxToDots(pin.targetXPx - objectsOffsetX, scale, dpmm),
-        pxToDots(pin.targetYPx - labelOffsetY, scale, dpmm),
-        br.uprightW0,
-        hNext,
-      );
-      flushSync(() => {
-        updateObject(id, {
-          x: swapped ? model.x : br.snapshot.x,
-          y: swapped ? br.snapshot.y : model.y,
-          props: { height: hNext },
+      if (hNext !== hCurrent) {
+        const model = modelPositionFromRenderedTopLeft(
+          cur,
+          pxToDots(pin.targetXPx - objectsOffsetX, scale, dpmm),
+          pxToDots(pin.targetYPx - labelOffsetY, scale, dpmm),
+          br.uprightW0,
+          hNext,
+        );
+        flushSync(() => {
+          updateObject(id, {
+            x: swapped ? model.x : br.snapshot.x,
+            y: swapped ? br.snapshot.y : model.y,
+            props: { height: hNext },
+          });
         });
-      });
-      br.changed = true;
+        br.changed = true;
+      }
+      // Pin every tick for the same reason as the mw axis: hold the node in
+      // rotated views between dot bakes, else the anchored edge jitters.
       node.scaleX(1);
       node.scaleY(1);
       node.x(pin.targetXPx);

--- a/src/components/Canvas/transformerGeometry.test.ts
+++ b/src/components/Canvas/transformerGeometry.test.ts
@@ -32,50 +32,61 @@ describe("barcodeMwReflowGeometry", () => {
     ...over,
   });
 
-  it("returns null inside the current module band (same rounding as the box snap)", () => {
-    expect(barcodeMwReflowGeometry(start(), 2, 240)).toBeNull();
-    expect(barcodeMwReflowGeometry(start(), 2, 200)).toBeNull();
+  it("holds the current band's linear frame inside a module band", () => {
+    // 240 px = 1.2x start extent, still module 2: the geometry reports the
+    // band frame (200 px) so the caller can pin the node mid-band, which is
+    // what keeps the module raster in rotated views without boundBoxFunc.
+    expect(barcodeMwReflowGeometry(start(), 240)).toEqual({
+      moduleWidth: 2, targetXPx: 100, targetYPx: 50, linearExtentPx: 200,
+    });
+    expect(barcodeMwReflowGeometry(start(), 200)).toEqual({
+      moduleWidth: 2, targetXPx: 100, targetYPx: 50, linearExtentPx: 200,
+    });
   });
 
   it("right-handle crossing keeps the left edge and bumps the module width", () => {
-    const geo = barcodeMwReflowGeometry(start(), 2, 300);
+    const geo = barcodeMwReflowGeometry(start(), 300);
     expect(geo).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 50, linearExtentPx: 300 });
   });
 
   it("left-handle crossing keeps the right edge fixed", () => {
-    const geo = barcodeMwReflowGeometry(start({ edges: edges({ left: true }) }), 2, 300);
+    const geo = barcodeMwReflowGeometry(start({ edges: edges({ left: true }) }), 300);
     // Linear width 300 pinned to rightX 300: x = 0.
     expect(geo).toEqual({ moduleWidth: 3, targetXPx: 0, targetYPx: 50, linearExtentPx: 300 });
   });
 
   it("stays quantised on the TOTAL extent after earlier bakes (no oscillation)", () => {
-    // Baked at 3, pointer parked at 1.5x the start extent: still module 3, no
-    // re-bake even though the rendered pixel width may differ stepwise.
-    expect(barcodeMwReflowGeometry(start(), 3, 300)).toBeNull();
-    // Pointer moves on to 2x: crossing to 4 from the same start baseline.
-    const geo = barcodeMwReflowGeometry(start(), 3, 400);
+    // Pointer parked at 1.5x the start extent: still module 3 on the same
+    // start baseline, regardless of what was baked meanwhile.
+    expect(barcodeMwReflowGeometry(start(), 300)?.moduleWidth).toBe(3);
+    // Pointer moves on to 2x: module 4 from the same start baseline.
+    const geo = barcodeMwReflowGeometry(start(), 400);
     expect(geo).toEqual({ moduleWidth: 4, targetXPx: 100, targetYPx: 50, linearExtentPx: 400 });
   });
 
-  it("clamps at the ^BY bounds and reports no change there", () => {
-    expect(barcodeMwReflowGeometry(start({ mw0: 10 }), 10, 600)).toBeNull();
-    expect(barcodeMwReflowGeometry(start({ mw0: 1 }), 1, 10)).toBeNull();
+  it("clamps at the ^BY bounds and pins the frame there (hard stop)", () => {
+    expect(barcodeMwReflowGeometry(start({ mw0: 10 }), 600)).toEqual({
+      moduleWidth: 10, targetXPx: 100, targetYPx: 50, linearExtentPx: 200,
+    });
+    expect(barcodeMwReflowGeometry(start({ mw0: 1 }), 10)).toEqual({
+      moduleWidth: 1, targetXPx: 100, targetYPx: 50, linearExtentPx: 200,
+    });
   });
 
   it("R/B rotations quantise the vertical axis and pin top/bottom", () => {
     const rb = start({ rotation: "R", edges: edges({ bottom: true }) });
     // Vertical extent 80 px at mw 2; 120 px crosses to 3, top fixed.
-    const geo = barcodeMwReflowGeometry(rb, 2, 120);
+    const geo = barcodeMwReflowGeometry(rb, 120);
     expect(geo).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 50, linearExtentPx: 120 });
     const topDrag = start({ rotation: "B", edges: edges({ top: true }) });
-    const geoTop = barcodeMwReflowGeometry(topDrag, 2, 120);
+    const geoTop = barcodeMwReflowGeometry(topDrag, 120);
     // Bottom fixed at 130: new top = 130 - 120 = 10.
     expect(geoTop).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 10, linearExtentPx: 120 });
   });
 
   it("rejects degenerate extents", () => {
-    expect(barcodeMwReflowGeometry(start(), 2, 0)).toBeNull();
-    expect(barcodeMwReflowGeometry(start({ rightX: 100 }), 2, 300)).toBeNull();
+    expect(barcodeMwReflowGeometry(start(), 0)).toBeNull();
+    expect(barcodeMwReflowGeometry(start({ rightX: 100 }), 300)).toBeNull();
   });
 });
 

--- a/src/components/Canvas/transformerGeometry.ts
+++ b/src/components/Canvas/transformerGeometry.ts
@@ -32,21 +32,20 @@ export interface BarcodeMwReflowStart {
  *  TOTAL drag extent against the start box (identical inputs to the in-drag
  *  box snap, so the two can never disagree or oscillate: rendered pixel
  *  widths are stepwise in moduleWidth, an incremental-scale quantiser would
- *  hunt). Returns null while the drag sits inside the current module band.
- *  Both edges come from the start box's LINEAR module model, matching the
- *  frame the box snap shows; the caller fits the re-rendered content into
- *  that frame via a residual scale. */
+ *  hunt). Always returns the band's geometry, also mid-band: the caller pins
+ *  the node to it every tick, which makes the reflow the sole band pin and
+ *  keeps the module raster in rotated views where boundBoxFunc's snap bails.
+ *  Both edges come from the start box's LINEAR module model; the caller fits
+ *  the re-rendered content into that frame via a residual scale. */
 export function barcodeMwReflowGeometry(
   start: BarcodeMwReflowStart,
-  mwCurrent: number,
   frameExtentPx: number,
 ): { moduleWidth: number; targetXPx: number; targetYPx: number; linearExtentPx: number } | null {
-  if (!(mwCurrent > 0) || !(start.mw0 > 0)) return null;
+  if (!(start.mw0 > 0)) return null;
   const swapped = isAxisSwapped(start.rotation);
   const startExtent = swapped ? start.bottomY - start.topY : start.rightX - start.leftX;
   if (!(startExtent > 0) || !(frameExtentPx > 0)) return null;
   const moduleWidth = computeNewModules(start.mw0, frameExtentPx / startExtent, 1, 10);
-  if (moduleWidth === mwCurrent) return null;
   const linearExtentPx = startExtent * (moduleWidth / start.mw0);
   if (!swapped) {
     return {


### PR DESCRIPTION
Drop the viewRotation gate; the reflow pins the node to the band frame every tick, replacing boundBoxFunc's snap/pin, which bails under view rotation.