### PR TITLE
fix(canvas): stop shape resize oscillation and float dims in preview

### DIFF
--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -1131,8 +1131,8 @@ export function useKonvaTransformer({
         commit = {
           restore: { x: sr.snapshot.x, y: sr.snapshot.y, props: { width: sr.snapshot.width, height: sr.snapshot.height } },
           final: {
-            x: Math.round(pinAnchoredEdge(!!edges?.left, cur.x, sp.width, width)),
-            y: Math.round(pinAnchoredEdge(!!edges?.top, cur.y, sp.height, height)),
+            x: pinAnchoredEdge(!!edges?.left, sr.snapshot.x, sr.snapshot.width, width),
+            y: pinAnchoredEdge(!!edges?.top, sr.snapshot.y, sr.snapshot.height, height),
             props: { width, height },
           },
         };

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -22,6 +22,7 @@ import {
   barcodeHeightReflowGeometry,
   barcodeMwReflowGeometry,
   computeNewModules,
+  pinAnchoredEdge,
   pinInactiveEdges,
   positionDidMove,
   forceSquareBox,
@@ -934,8 +935,9 @@ export function useKonvaTransformer({
       return;
     }
 
-    // Box/ellipse: bake the group scale into width/height each tick for correct
-    // stroke inset; dims stay float until release to avoid per-tick rounding drift.
+    // Box/ellipse: bake the group scale into width/height each tick. Rounding
+    // into the store is drift-free because forceUpdate re-baselines to it each
+    // tick, so the store dim times the live scale stays the true current size.
     const sr = shapeReflowRef.current;
     if (sr) {
       const sp = cur.props as { width: number; height: number; lockAspect?: boolean };
@@ -944,20 +946,21 @@ export function useKonvaTransformer({
       const [scaleW, scaleH] = sp.lockAspect
         ? [Math.min(sx, sy), Math.min(sx, sy)]
         : [sx, sy];
-      const newW = Math.max(1, sp.width * scaleW);
-      const newH = Math.max(1, sp.height * scaleH);
-      // Konva already pinned the anchored edge via node.x/y; commit that, then
-      // re-pin from the same dots so node and store agree after the re-render.
-      const xDots = pxToDots(node.x() - objectsOffsetX, scale, dpmm);
-      const yDots = pxToDots(node.y() - labelOffsetY, scale, dpmm);
+      const width = Math.max(1, Math.round(sp.width * scaleW));
+      const height = Math.max(1, Math.round(sp.height * scaleH));
+      // Pin the anchored edge from the snapshot (mirrors the end commit):
+      // rebuilding it from a rounded node.x/y plus a float dim oscillated it.
+      const edges = activeEdgesRef.current;
+      const x = pinAnchoredEdge(!!edges?.left, sr.snapshot.x, sr.snapshot.width, width);
+      const y = pinAnchoredEdge(!!edges?.top, sr.snapshot.y, sr.snapshot.height, height);
       flushSync(() => {
-        updateObject(id, { x: xDots, y: yDots, props: { width: newW, height: newH } });
+        updateObject(id, { x, y, props: { width, height } });
       });
       sr.changed = true;
       node.scaleX(1);
       node.scaleY(1);
-      node.x(objectsOffsetX + dotsToPx(xDots, scale, dpmm));
-      node.y(labelOffsetY + dotsToPx(yDots, scale, dpmm));
+      node.x(objectsOffsetX + dotsToPx(x, scale, dpmm));
+      node.y(labelOffsetY + dotsToPx(y, scale, dpmm));
       transformerRef.current?.forceUpdate();
     }
   };
@@ -1120,18 +1123,16 @@ export function useKonvaTransformer({
       let commit: ReflowCommit = null;
       if (sr.changed && id && cur && !isGroup(cur)) {
         const sp = cur.props as { width: number; height: number };
-        // Same snap/round/clamp contract as commitWidthHeightTransform, applied
-        // to the already-baked float dims.
+        // Apply the grid snap the per-tick bake skips (round only); the anchored
+        // edge is then re-pinned from the snapped size so it can't walk.
         const width = Math.max(1, snap(Math.round(sp.width)));
         const height = Math.max(1, snap(Math.round(sp.height)));
-        // Pin the anchored edge: when dragging left/top, derive x/y from the
-        // snapped size so the opposite edge doesn't walk by the snap delta.
         const edges = activeEdgesRef.current;
         commit = {
           restore: { x: sr.snapshot.x, y: sr.snapshot.y, props: { width: sr.snapshot.width, height: sr.snapshot.height } },
           final: {
-            x: Math.round(edges?.left ? cur.x + sp.width - width : cur.x),
-            y: Math.round(edges?.top ? cur.y + sp.height - height : cur.y),
+            x: Math.round(pinAnchoredEdge(!!edges?.left, cur.x, sp.width, width)),
+            y: Math.round(pinAnchoredEdge(!!edges?.top, cur.y, sp.height, height)),
             props: { width, height },
           },
         };

--- a/src/components/Canvas/transformerGeometry.test.ts
+++ b/src/components/Canvas/transformerGeometry.test.ts
@@ -11,6 +11,7 @@ import {
   pinInactiveEdges,
   computeNewModules,
   activeEdgesFromAnchorName,
+  pinAnchoredEdge,
   shrinkingBelowFloor,
   type BarcodeHeightReflowStart,
   type BarcodeMwReflowStart,
@@ -129,6 +130,19 @@ describe("barcodeHeightReflowGeometry", () => {
   it("rejects a collapsed frame", () => {
     expect(barcodeHeightReflowGeometry(start(), 0)).toBeNull();
     expect(barcodeHeightReflowGeometry(start(), -5)).toBeNull();
+  });
+});
+
+describe("pinAnchoredEdge", () => {
+  // Start edge 100, extent 40 (so the opposite edge sits at 140).
+  it("holds the min edge when the max side is grabbed", () => {
+    expect(pinAnchoredEdge(false, 100, 40, 60)).toBe(100);
+  });
+
+  it("moves the min edge so the max edge stays fixed when the min side is grabbed", () => {
+    // Opposite edge pinned at 140: grow to 60 -> start 80, shrink to 25 -> 115.
+    expect(pinAnchoredEdge(true, 100, 40, 60)).toBe(80);
+    expect(pinAnchoredEdge(true, 100, 40, 25)).toBe(115);
   });
 });
 

--- a/src/components/Canvas/transformerGeometry.ts
+++ b/src/components/Canvas/transformerGeometry.ts
@@ -274,6 +274,17 @@ export function applyUniformModuleSnap(
   return { ...newBox, x, y, width: snapped, height: snapped };
 }
 
+/** Pin the anchored side of a resize: a grabbed min edge (left/top) shifts the
+ *  position so the opposite edge stays fixed; else the min edge holds. */
+export function pinAnchoredEdge(
+  minEdgeActive: boolean,
+  start: number,
+  startExtent: number,
+  newExtent: number,
+): number {
+  return minEdgeActive ? start + startExtent - newExtent : start;
+}
+
 /** Absorbs px<->dot float rounding so integer positions are preserved. */
 export const POSITION_MOVE_TOLERANCE_DOTS = 1;
 


### PR DESCRIPTION
Round width/height into the store each tick (store x scale is exact because the transformer re-baselines per tick) and pin the anchored edge from the snapshot, so the opposite edge no longer wobbles and the ZPL preview stays integral.