### PR TITLE
fix(preflight): render barcode module-size warning in the active disp…

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -527,7 +527,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     ? []
     : suppressPristineEmpty(
         [
-          ...computePreflight(preflightLeaves, frameCtx),
+          ...computePreflight(preflightLeaves, frameCtx, unit),
           ...barcodeEncodeFindings(preflightLeaves, scale, label.dpmm, previewBinding),
           ...markerValueFindings(preflightLeaves, {
             variables: previewBinding.variables,

--- a/src/lib/barcodeScannability.ts
+++ b/src/lib/barcodeScannability.ts
@@ -1,16 +1,31 @@
 import type { PreflightCtx, PreflightProducerResult } from "../types/preflight";
+import { mmToUnitExact, unitLabel, type Unit } from "./units";
 
 /** Recommended minimum barcode module / X-dimension in mm for reliable general
  *  scanning, per GS1/AIM guidance (~0.25 mm). Below this the preflight warns.
  *  Shared floor for 1D X-dimension and 2D cell size. */
 export const MIN_BARCODE_MODULE_MM = 0.25;
 
+/** Display precision per unit for module sizes (sub-millimetre values). */
+const MODULE_DECIMALS: Record<Unit, number> = { mm: 2, cm: 3, in: 3 };
+
+function formatModule(mm: number, unit: Unit): string {
+  return `${mmToUnitExact(mm, unit).toFixed(MODULE_DECIMALS[unit])} ${unitLabel(unit)}`;
+}
+
 /** A `barcodeTooSmall` finding when the module size (dots) is below the minimum
  *  scannable X-dimension at the device density. Used by every 1D and 2D type. */
-export function moduleTooSmallFindings(moduleDots: number, dpmm: number): PreflightProducerResult[] {
+export function moduleTooSmallFindings(
+  moduleDots: number,
+  dpmm: number,
+  unit: Unit,
+): PreflightProducerResult[] {
   const mm = moduleDots / dpmm;
   if (!(mm < MIN_BARCODE_MODULE_MM)) return []; // also short-circuits NaN/Infinity
-  return [{ kind: "barcodeTooSmall", detail: `${mm.toFixed(2)} mm (min ${MIN_BARCODE_MODULE_MM} mm)` }];
+  return [{
+    kind: "barcodeTooSmall",
+    detail: `${formatModule(mm, unit)} (min ${formatModule(MIN_BARCODE_MODULE_MM, unit)})`,
+  }];
 }
 
 /** Curried registry `preflight` producer: warns when the named module-size prop
@@ -19,5 +34,5 @@ export function moduleTooSmallFindings(moduleDots: number, dpmm: number): Prefli
 export function moduleTooSmallPreflight<P extends object>(
   prop: keyof P & string,
 ): (obj: { props: P }, ctx: PreflightCtx) => PreflightProducerResult[] {
-  return (obj, ctx) => moduleTooSmallFindings(obj.props[prop] as number, ctx.label.dpmm);
+  return (obj, ctx) => moduleTooSmallFindings(obj.props[prop] as number, ctx.label.dpmm, ctx.unit);
 }

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -8,6 +8,7 @@ import type { LabelConfig } from "../types/LabelConfig";
 
 const label: LabelConfig = { widthMm: 100, heightMm: 50, dpmm: 8 }; // printable 800 x 400
 const ctx: ObjectBoundsCtx = { label };
+const pctx = { label, unit: "mm" } as const;
 
 function box(id: string, x: number, y: number, width: number, height: number): LeafObject {
   return {
@@ -22,17 +23,17 @@ function box(id: string, x: number, y: number, width: number, height: number): L
 
 describe("computePreflight (off-label producer)", () => {
   it("returns no findings when every leaf is inside", () => {
-    expect(computePreflight([box("a", 10, 10, 100, 50)], ctx)).toEqual([]);
+    expect(computePreflight([box("a", 10, 10, 100, 50)], ctx, "mm")).toEqual([]);
   });
 
   it("flags a clipped leaf as a warning", () => {
-    expect(computePreflight([box("a", 750, 10, 100, 50)], ctx)).toEqual([
+    expect(computePreflight([box("a", 750, 10, 100, 50)], ctx, "mm")).toEqual([
       { objectId: "a", kind: "offLabelClipped", severity: "warning" },
     ]);
   });
 
   it("flags a fully-outside leaf as an error", () => {
-    expect(computePreflight([box("a", 900, 10, 50, 50)], ctx)).toEqual([
+    expect(computePreflight([box("a", 900, 10, 50, 50)], ctx, "mm")).toEqual([
       { objectId: "a", kind: "offLabelOutside", severity: "error" },
     ]);
   });
@@ -54,7 +55,7 @@ describe("computePreflight (off-label producer)", () => {
     const bc = ftBarcode("bc", 100, 350, 100);
     // ^FT N anchors the bar BOTTOM at (100,350); measured dims put the visual
     // bbox at y 250..350, fully inside, and the emitted anchor (100,350) is on label.
-    expect(computePreflight([bc], { label, measured: measuredFor("bc", 200, 100) })).toEqual([]);
+    expect(computePreflight([bc], { label, measured: measuredFor("bc", 200, 100) }, "mm")).toEqual([]);
   });
 
   it("does not flag an ^FT barcode whose bars extend above the top (valid positive anchor)", () => {
@@ -62,14 +63,14 @@ describe("computePreflight (off-label producer)", () => {
     // but the emitted ^FT origin (60,80) is on-label, the field prints (top
     // clipped). Must NOT be the hard offLabelOutside (was, when keyed on the bbox).
     const bc = ftBarcode("bc", 60, 80, 120);
-    expect(computePreflight([bc], { label, measured: measuredFor("bc", 200, 120) })).toEqual([]);
+    expect(computePreflight([bc], { label, measured: measuredFor("bc", 200, 120) }, "mm")).toEqual([]);
   });
 
   it("treats a negative-origin left crossing as outside, not clipped", () => {
     // Regression: a ^FO-50 field straddles x=0, so the bbox still reaches onto
     // the label, but the emitted origin is negative (off the printable area) ->
     // error, not the softer clipped warning.
-    expect(computePreflight([box("a", -50, 10, 200, 50)], ctx)).toEqual([
+    expect(computePreflight([box("a", -50, 10, 200, 50)], ctx, "mm")).toEqual([
       { objectId: "a", kind: "offLabelOutside", severity: "error" },
     ]);
   });
@@ -85,7 +86,7 @@ describe("computePreflight (off-label producer)", () => {
       rotation: 0,
       props: { angle: 180, length: 200, thickness: 4, color: "B" },
     } as LabelObject as LeafObject;
-    expect(computePreflight([line], ctx)).toEqual([
+    expect(computePreflight([line], ctx, "mm")).toEqual([
       { objectId: "ln", kind: "offLabelOutside", severity: "error" },
     ]);
   });
@@ -102,7 +103,7 @@ describe("computePreflight (off-label producer)", () => {
       positionType: "FO",
       props: { content: "Text", fontHeight: 188, fontWidth: 188, rotation: "N" },
     } as LabelObject as LeafObject;
-    expect(computePreflight([txt], ctx)).toEqual([
+    expect(computePreflight([txt], ctx, "mm")).toEqual([
       { objectId: "t", kind: "offLabelOutside", severity: "error" },
     ]);
   });
@@ -111,6 +112,7 @@ describe("computePreflight (off-label producer)", () => {
     const findings = computePreflight(
       [box("in", 10, 10, 50, 50), box("clip", 760, 10, 80, 50), box("out", -200, 0, 50, 50)],
       ctx,
+      "mm",
     );
     expect(findings.map((f) => [f.objectId, f.kind])).toEqual([
       ["clip", "offLabelClipped"],
@@ -131,13 +133,13 @@ describe("emptyContent producer", () => {
     }) as LabelObject as LeafObject;
 
   it("flags a blank text field as a warning, and only that", () => {
-    expect(computePreflight([text("t", "")], ctx)).toEqual([
+    expect(computePreflight([text("t", "")], ctx, "mm")).toEqual([
       { objectId: "t", kind: "emptyContent", severity: "warning" },
     ]);
   });
 
   it("flags whitespace-only content (prints a gap all the same)", () => {
-    expect(computePreflight([text("t", "  ")], ctx)).toEqual([
+    expect(computePreflight([text("t", "  ")], ctx, "mm")).toEqual([
       { objectId: "t", kind: "emptyContent", severity: "warning" },
     ]);
   });
@@ -151,32 +153,32 @@ describe("emptyContent producer", () => {
       rotation: 0,
       props: { content: "", height: 80, moduleWidth: 2, printInterpretation: false, checkDigit: false, rotation: "N" },
     } as LabelObject as LeafObject;
-    expect(computePreflight([bc], ctx)).toEqual([
+    expect(computePreflight([bc], ctx, "mm")).toEqual([
       { objectId: "bc", kind: "emptyContent", severity: "warning" },
     ]);
   });
 
   it("flags a serial field whose seed is blank (prints nothing to increment)", () => {
     const serial = text("s", "", { serial: { increment: 1, zplMode: "SN" } });
-    expect(computePreflight([serial], ctx)).toEqual([
+    expect(computePreflight([serial], ctx, "mm")).toEqual([
       { objectId: "s", kind: "emptyContent", severity: "warning" },
     ]);
   });
 
   it("does not fire on marker content: bound fields are configured even when a row resolves blank", () => {
-    expect(computePreflight([text("t", "«batch»")], ctx)).toEqual([]);
+    expect(computePreflight([text("t", "«batch»")], ctx, "mm")).toEqual([]);
   });
 
   it("reports hidden-char-only content as suspiciousChars, not emptyContent", () => {
     // NBSP-only content trims to empty but carries invisible ink: the specific
     // 'NBSP x2' diagnostic must win over the generic 'field is empty'.
-    expect(computePreflight([text("t", "  ")], ctx)).toEqual([
+    expect(computePreflight([text("t", "  ")], ctx, "mm")).toEqual([
       { objectId: "t", kind: "suspiciousChars", severity: "warning", detail: "NBSP x2" },
     ]);
   });
 
   it("does not fire on types without a content field", () => {
-    expect(computePreflight([box("b", 10, 10, 50, 50)], ctx)).toEqual([]);
+    expect(computePreflight([box("b", 10, 10, 50, 50)], ctx, "mm")).toEqual([]);
   });
 });
 
@@ -205,30 +207,30 @@ describe("per-type producers (registry preflight capability)", () => {
     } as LabelObject as LeafObject);
 
   it("text: a block narrower than one glyph cell flags blockTooNarrow", () => {
-    const narrow = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 2 }), { label });
+    const narrow = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 2 }), pctx);
     expect(narrow).toEqual([{ kind: "blockTooNarrow" }]);
   });
 
   it("text: a wide block and a plain (normal) field flag nothing", () => {
-    const wide = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 200 }), { label });
-    const normal = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0 }), { label });
+    const wide = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0, blockWidth: 200 }), pctx);
+    const normal = getEntry("text")!.preflight!(textLeaf({ content: "X", fontHeight: 30, fontWidth: 0 }), pctx);
     expect(wide).toEqual([]);
     expect(normal).toEqual([]);
   });
 
   it("barcode: a module below the min X-dimension flags barcodeTooSmall", () => {
     // moduleWidth 1 @ 8 dpmm = 0.125 mm < 0.25 mm.
-    const small = getEntry("code128")!.preflight!(bar(1), { label });
+    const small = getEntry("code128")!.preflight!(bar(1), pctx);
     expect(small).toEqual([{ kind: "barcodeTooSmall", detail: "0.13 mm (min 0.25 mm)" }]);
   });
 
   it("barcode: a module at/above the min X-dimension flags nothing", () => {
     // moduleWidth 2 @ 8 dpmm = 0.25 mm.
-    expect(getEntry("code128")!.preflight!(bar(2), { label })).toEqual([]);
+    expect(getEntry("code128")!.preflight!(bar(2), pctx)).toEqual([]);
   });
 
   it("computePreflight stamps objectId + severity from a producer finding", () => {
-    expect(computePreflight([bar(1)], ctx)).toContainEqual({
+    expect(computePreflight([bar(1)], ctx, "mm")).toContainEqual({
       objectId: "bc", kind: "barcodeTooSmall", severity: "warning", detail: "0.13 mm (min 0.25 mm)",
     });
   });
@@ -238,34 +240,43 @@ describe("per-type producers (registry preflight capability)", () => {
       ({ id: "q", type: "qrcode", x: 0, y: 0, rotation: 0,
          props: { content: "x", magnification, errorCorrection: "Q", model: 2, rotation: "N" } } as LabelObject as LeafObject);
     // magnification 1 @ 8 dpmm = 0.125 mm < 0.25; magnification 2 = 0.25 mm (ok).
-    expect(getEntry("qrcode")!.preflight!(qr(1), { label })).toEqual([
+    expect(getEntry("qrcode")!.preflight!(qr(1), pctx)).toEqual([
       { kind: "barcodeTooSmall", detail: "0.13 mm (min 0.25 mm)" },
     ]);
-    expect(getEntry("qrcode")!.preflight!(qr(2), { label })).toEqual([]);
+    expect(getEntry("qrcode")!.preflight!(qr(2), pctx)).toEqual([]);
+  });
+
+  it("renders the module detail in the active display unit", () => {
+    expect(getEntry("code128")!.preflight!(bar(1), { label, unit: "in" })).toEqual([
+      { kind: "barcodeTooSmall", detail: "0.005 in (min 0.010 in)" },
+    ]);
+    expect(getEntry("code128")!.preflight!(bar(1), { label, unit: "cm" })).toEqual([
+      { kind: "barcodeTooSmall", detail: "0.013 cm (min 0.025 cm)" },
+    ]);
   });
 
   it("text: ^FB content wrapping past the line cap flags textOverset", () => {
     const fb = textLeaf({ content: "AAA BBB CCC", fontHeight: 30, fontWidth: 0, blockWidth: 40, blockLines: 1 });
-    expect(getEntry("text")!.preflight!(fb, { label })).toEqual([{ kind: "textOverset" }]);
+    expect(getEntry("text")!.preflight!(fb, pctx)).toEqual([{ kind: "textOverset" }]);
   });
 
   it("text: ^TB content taller than the block height flags textOverset", () => {
     const tb = textLeaf({ content: "AAA", fontHeight: 30, fontWidth: 0, blockWidth: 200, blockHeight: 10, textMode: "tb" });
-    expect(getEntry("text")!.preflight!(tb, { label })).toEqual([{ kind: "textOverset" }]);
+    expect(getEntry("text")!.preflight!(tb, pctx)).toEqual([{ kind: "textOverset" }]);
   });
 
   it("text: a block with room to spare flags nothing", () => {
     const ok = textLeaf({ content: "AAA", fontHeight: 30, fontWidth: 0, blockWidth: 400, blockLines: 5 });
-    expect(getEntry("text")!.preflight!(ok, { label })).toEqual([]);
+    expect(getEntry("text")!.preflight!(ok, pctx)).toEqual([]);
   });
 
   it("image: no resolvable bytes flags imageMissing; rawGf resolves", () => {
     const img = (props: object): LeafObject =>
       ({ id: "i", type: "image", x: 0, y: 0, rotation: 0, props } as LabelObject as LeafObject);
-    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128 }), { label })).toEqual([
+    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128 }), pctx)).toEqual([
       { kind: "imageMissing" },
     ]);
-    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128, rawGf: "^GFA,1,1,1,00" }), { label })).toEqual([]);
+    expect(getEntry("image")!.preflight!(img({ imageId: "nope", widthDots: 200, threshold: 128, rawGf: "^GFA,1,1,1,00" }), pctx)).toEqual([]);
   });
 });
 
@@ -282,7 +293,7 @@ describe("computePreflight (suspicious-chars producer)", () => {
     }) as LabelObject as LeafObject;
 
   it("flags NBSP padding smuggled into barcode content", () => {
-    const findings = computePreflight([dm("a", "0104" + NBSP + NBSP)], ctx);
+    const findings = computePreflight([dm("a", "0104" + NBSP + NBSP)], ctx, "mm");
     expect(findings).toContainEqual({
       objectId: "a",
       kind: "suspiciousChars",
@@ -292,7 +303,7 @@ describe("computePreflight (suspicious-chars producer)", () => {
   });
 
   it("does not flag clean content", () => {
-    const findings = computePreflight([dm("a", "01042601194549961726013110")], ctx);
+    const findings = computePreflight([dm("a", "01042601194549961726013110")], ctx, "mm");
     expect(findings.some((f) => f.kind === "suspiciousChars")).toBe(false);
   });
 
@@ -305,7 +316,7 @@ describe("computePreflight (suspicious-chars producer)", () => {
       rotation: 0,
       props: { content: "Hi" + NBSP, fontHeight: 30, fontWidth: 0, rotation: "N" },
     } as LabelObject as LeafObject;
-    const findings = computePreflight([txt], ctx);
+    const findings = computePreflight([txt], ctx, "mm");
     expect(findings).toContainEqual({
       objectId: "t",
       kind: "suspiciousChars",
@@ -328,12 +339,12 @@ describe("computePreflight (suspicious-chars producer)", () => {
     }) as LabelObject as LeafObject;
 
   it("does not flag the GS separator in GS1 content", () => {
-    const findings = computePreflight([gs1Dm("10ABC" + GS + "21XYZ")], ctx);
+    const findings = computePreflight([gs1Dm("10ABC" + GS + "21XYZ")], ctx, "mm");
     expect(findings.some((f) => f.kind === "suspiciousChars")).toBe(false);
   });
 
   it("still flags a control char in a non-GS1 field", () => {
-    const findings = computePreflight([dm("a", "10ABC" + GS + "21XYZ")], ctx);
+    const findings = computePreflight([dm("a", "10ABC" + GS + "21XYZ")], ctx, "mm");
     expect(findings.some((f) => f.kind === "suspiciousChars")).toBe(true);
   });
 });

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -9,6 +9,7 @@ import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } 
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
 import { resolveTextMode } from "../registry/text";
 import type { CsvMapping, Variable } from "../types/Variable";
+import type { Unit } from "./units";
 import {
   PREFLIGHT_SEVERITY,
   type PreflightFinding,
@@ -191,6 +192,7 @@ export function markerValueFindings(
 export function computePreflight(
   leaves: readonly LeafObject[],
   ctx: ObjectBoundsCtx,
+  unit: Unit,
 ): PreflightFinding[] {
   const findings: PreflightFinding[] = [];
   for (const leaf of leaves) {
@@ -202,7 +204,7 @@ export function computePreflight(
 
     const produce = getEntry(leaf.type)?.preflight;
     if (produce) {
-      for (const r of produce(leaf, { label: ctx.label })) {
+      for (const r of produce(leaf, { label: ctx.label, unit })) {
         findings.push({ objectId: leaf.id, kind: r.kind, severity: PREFLIGHT_SEVERITY[r.kind], detail: r.detail });
       }
     }

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -12,6 +12,14 @@ export function unitToMm(value: number, unit: Unit): number {
   return value;
 }
 
+/** Unrounded mm→unit; mmToUnit's input-field rounding is too coarse for
+ *  sub-millimetre values (barcode modules). */
+export function mmToUnitExact(mm: number, unit: Unit): number {
+  if (unit === 'cm') return mm / 10;
+  if (unit === 'in') return mm / 25.4;
+  return mm;
+}
+
 export function unitLabel(unit: Unit): string {
   return unit;
 }

--- a/src/types/preflight.ts
+++ b/src/types/preflight.ts
@@ -1,4 +1,5 @@
 import type { LabelConfig } from './LabelConfig';
+import type { Unit } from '../lib/units';
 
 export type PreflightSeverity = 'error' | 'warning';
 
@@ -54,11 +55,14 @@ export const PREFLIGHT_SEVERITY: Record<PreflightKind, PreflightSeverity> = {
   emptyContent: 'warning',
 };
 
-/** What a per-type `preflight` producer receives. Minimal on purpose (just the
- *  label, for dpmm) so the registry capability stays free of the lib-layer
- *  ObjectBoundsCtx and its import cycle. */
+/** What a per-type `preflight` producer receives. Minimal on purpose (the
+ *  label for dpmm, the display unit for measurement details) so the registry
+ *  capability stays free of the lib-layer ObjectBoundsCtx and its import
+ *  cycle. */
 export interface PreflightCtx {
   label: LabelConfig;
+  /** Active display unit; measurement details render in it. */
+  unit: Unit;
 }
 
 /** A per-type producer's output: kind plus optional detail. computePreflight


### PR DESCRIPTION
…lay unit

The 'module too small' scannability warning hard-coded its detail in mm. Thread the active display unit (mm/cm/in) through PreflightCtx so the measured value and the min threshold render in the user's chosen unit, with per-unit precision for the sub-millimetre module sizes.