### PR TITLE
fix(canvas): center selection chrome on the empty-text placeholder

### DIFF
--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -20,7 +20,7 @@ import { selectionHandlers, useBlankFieldWarns, CAPTURE_CHROME, PLACEHOLDER_DASH
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import { DEFAULT_GS_SYMBOL_META, GS_SYMBOLS } from "../../registry/symbol";
 import { GS_SYMBOL_PATHS, GS_VECTOR_CODES, type GsVectorCode } from "../../registry/gsSymbolPaths";
-import { blockBoundsDots, blockJustifyWordPositions, blockLineStartDots, blockLineStepDots, tbBoundsDots, tbLineStepDots, wrapBlockLines, zebraAlignOffsetDots, zebraHangingIndentOffsetDots, zebraJustifyGapDots, zebraLineWidthDots, type ZplRotation } from "../../lib/zebraTextLayout";
+import { blockBoundsDots, blockJustifyWordPositions, blockLineStartDots, blockLineStepDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, tbBoundsDots, tbLineStepDots, wrapBlockLines, zebraAlignOffsetDots, zebraHangingIndentOffsetDots, zebraJustifyGapDots, zebraLineWidthDots, type ZplRotation } from "../../lib/zebraTextLayout";
 import { resolveTextMode } from "../../registry/text";
 import { isAxisSwapped } from "../../registry/rotation";
 import type { LeafObject } from "../../registry";
@@ -119,10 +119,6 @@ interface BaseTextProps {
  *  A0 advances and drifts noticeably on centred blocks. */
 type TextFieldObj = LeafObject & { type: "text"; props: TextProps };
 
-/** Approx width of an empty single-line placeholder, expressed as
- *  fontHeight multiples (Glyph-row aspect ratio). */
-const EMPTY_TEXT_PLACEHOLDER_GLYPHS = 4;
-
 function PlaceholderRect({
   x, y, width, height, rotation, color, fontVersion,
 }: {
@@ -184,7 +180,7 @@ function TextFieldContent({
   if (mode === "normal" || !blockWidth) {
     // Single-line text has no spec-defined min width, so only empty
     // content triggers the placeholder (block also covers too-narrow).
-    if (content.trim().length === 0) {
+    if (isBlankText(content)) {
       return (
         <PlaceholderRect
           fontVersion={fontVersion}
@@ -215,7 +211,7 @@ function TextFieldContent({
   const tooNarrow =
     firstChar !== "" &&
     dotsToPx(blockWidth, scale, dpmm) < measureLinePx(firstChar);
-  const emptyContent = content.trim().length === 0;
+  const emptyContent = isBlankText(content);
   if (tooNarrow || emptyContent) {
     const bounds =
       mode === "tb"
@@ -553,12 +549,16 @@ function KonvaObjectInner({
     obj.type === "text" && !!textMetrics && resolveTextMode(obj.props) === "normal";
   const inkWidthDots = textMetrics?.inkWidthDots ?? 0;
   const fontHeightDots = obj.type === "text" ? obj.props.fontHeight : 0;
+  // Whitespace-only content has a non-zero ink advance but draws the placeholder,
+  // so gate on the same blank test the placeholder does, not on inkWidth alone.
+  const blankSingleLine = isSingleLineText && isBlankText(textMetrics?.content ?? "");
   const rotation = obj.type === "text" ? obj.props.rotation : "N";
   const isQuarterTurn = isAxisSwapped(rotation);
   useEffect(() => {
     if (!isSingleLineText) return;
-    // Footprint dropped to zero (e.g. content cleared): drop the stale entry.
-    if (inkWidthDots <= 0 || fontHeightDots <= 0) {
+    // Blank (empty or whitespace) or zero-height: drop the measured entry so
+    // objectBounds falls to the placeholder footprint the canvas draws.
+    if (blankSingleLine || inkWidthDots <= 0 || fontHeightDots <= 0) {
       clearMeasuredBounds(obj.id);
       return;
     }
@@ -566,7 +566,7 @@ function KonvaObjectInner({
       width: isQuarterTurn ? fontHeightDots : inkWidthDots,
       height: isQuarterTurn ? inkWidthDots : fontHeightDots,
     });
-  }, [obj.id, isSingleLineText, inkWidthDots, fontHeightDots, isQuarterTurn]);
+  }, [obj.id, isSingleLineText, blankSingleLine, inkWidthDots, fontHeightDots, isQuarterTurn]);
   useEffect(() => {
     if (!isSingleLineText) return;
     return () => clearMeasuredBounds(obj.id);

--- a/src/lib/objectBounds.test.ts
+++ b/src/lib/objectBounds.test.ts
@@ -72,6 +72,20 @@ describe("objectBoundsDots", () => {
     expect(objectBoundsDots(s, ctx())).toEqual({ x: 7, y: 9, width: 40, height: 30 });
   });
 
+  it("text single-line, empty content: placeholder footprint, not zero width", () => {
+    // The canvas draws a 4-glyph placeholder rect for blank text; the bounds
+    // must match it so the action bar centers on what is drawn.
+    const t = leaf("text", 50, 30, { content: "", fontHeight: 40, fontWidth: 0, rotation: "N" });
+    expect(objectBoundsDots(t, ctx())).toEqual({ x: 50, y: 30, width: 160, height: 40 });
+  });
+
+  it("text single-line, empty content (R): placeholder footprint swaps axes", () => {
+    const t = leaf("text", 50, 30, { content: "  ", fontHeight: 40, fontWidth: 0, rotation: "R" });
+    const b = objectBoundsDots(t, ctx());
+    expect(b.width).toBe(40);
+    expect(b.height).toBe(160);
+  });
+
   it("text ^FB block (N): blockBoundsDots footprint shifted to model space", () => {
     // lineStep = 40 + 10 = 50; linesExtent = (3-1)*50 + 40 = 140.
     const t = leaf("text", 50, 30, {

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -17,7 +17,7 @@ import { BARCODE_1D_TYPES, STACKED_2D_TYPES, getEntry } from "../registry";
 import type { LabelConfig } from "../types/LabelConfig";
 import { isAxisSwapped, objectRotation, type ZplRotation } from "../registry/rotation";
 import { resolveTextMode } from "../registry/text";
-import { blockBoundsDots, rotatedLineOffset, tbBoundsDots, zebraLineWidthDots } from "./zebraTextLayout";
+import { blockBoundsDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, rotatedLineOffset, tbBoundsDots, zebraLineWidthDots } from "./zebraTextLayout";
 import { resolveDefaultSizeDots } from "./resolveDefaultSize";
 import { mmToDots } from "./coordinates";
 import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "./bwipConstants";
@@ -74,12 +74,16 @@ function fallbackSizeDots(
 
 /** Single-line text/serial footprint estimate from props when no measured
  *  size exists. Width is the Font-0 calibrated advance sum; height is the
- *  font height. Rotation swaps the axes. */
+ *  font height. Rotation swaps the axes. Empty content takes the canvas
+ *  placeholder's footprint, else the selection chrome (action bar, align,
+ *  snap) would center on a zero-width box left of what is drawn. */
 function singleLineEstimate(
   obj: LeafObject & { props: { content: string; fontHeight: number; fontWidth: number; rotation: ZplRotation } },
 ): { width: number; height: number } {
   const { content, fontHeight, fontWidth, rotation } = obj.props;
-  const width = zebraLineWidthDots(content, fontHeight, fontWidth);
+  const width = isBlankText(content)
+    ? fontHeight * EMPTY_TEXT_PLACEHOLDER_GLYPHS
+    : zebraLineWidthDots(content, fontHeight, fontWidth);
   return rotatedFootprint(width, fontHeight, rotation);
 }
 

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -108,6 +108,20 @@ describe("computePreflight (off-label producer)", () => {
     ]);
   });
 
+  it("does not flag a blank text field off-label (placeholder is drawn, not printed)", () => {
+    // Empty single-line text near the right edge: objectBounds returns the
+    // placeholder footprint (4*fontHeight wide) so the action bar centers, but
+    // an empty ^FD prints nothing, so off-label must stay silent. Only the
+    // emptyContent signal fires.
+    const blank = {
+      id: "t", type: "text", x: 780, y: 10, rotation: 0, positionType: "FO",
+      props: { content: "", fontHeight: 40, fontWidth: 0, rotation: "N" },
+    } as LabelObject as LeafObject;
+    expect(computePreflight([blank], ctx, "mm")).toEqual([
+      { objectId: "t", kind: "emptyContent", severity: "warning" },
+    ]);
+  });
+
   it("reports one finding per offending leaf and skips the inside one", () => {
     const findings = computePreflight(
       [box("in", 10, 10, 50, 50), box("clip", 760, 10, 80, 50), box("out", -200, 0, 50, 50)],

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -8,6 +8,7 @@ import { extractTemplateRefs, hasTemplateMarkers } from "./fnTemplate";
 import { isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
+import { isBlankText } from "./zebraTextLayout";
 import { resolveTextMode } from "../registry/text";
 import type { CsvMapping, Variable } from "../types/Variable";
 import type { Unit } from "./units";
@@ -197,11 +198,18 @@ export function computePreflight(
 ): PreflightFinding[] {
   const findings: PreflightFinding[] = [];
   for (const leaf of leaves) {
+    const content = getObjectStringContent(leaf);
     const box = objectBoundsDots(leaf, ctx);
-    const placement = offLabelPlacement(emittedAnchorDots(leaf, ctx, box), box, ctx.label);
-    const kind =
-      placement === "outside" ? "offLabelOutside" : placement === "clipped" ? "offLabelClipped" : null;
-    if (kind) findings.push({ objectId: leaf.id, kind, severity: PREFLIGHT_SEVERITY[kind] });
+    // A blank text field draws a placeholder (its bounds) but emits an empty
+    // ^FD, so it prints nothing: skip off-label here, the emptyContent check
+    // below owns the blank-field signal.
+    const blankText = leaf.type === "text" && content !== undefined && isBlankText(content);
+    if (!blankText) {
+      const placement = offLabelPlacement(emittedAnchorDots(leaf, ctx, box), box, ctx.label);
+      const kind =
+        placement === "outside" ? "offLabelOutside" : placement === "clipped" ? "offLabelClipped" : null;
+      if (kind) findings.push({ objectId: leaf.id, kind, severity: PREFLIGHT_SEVERITY[kind] });
+    }
 
     const produce = getEntry(leaf.type)?.preflight;
     if (produce) {
@@ -213,7 +221,6 @@ export function computePreflight(
     // Cross-cutting: any content-bearing field (text, every barcode) can carry
     // invisible/ambiguous chars smuggled in via scan or foreign-tool import, so
     // check here once instead of duplicating the producer across every type.
-    const content = getObjectStringContent(leaf);
     if (content !== undefined) {
       // GS1 fields carry a structural GS separator (0x1D) between chained AIs;
       // it's intentional, not smuggled, so drop it before the scan.

--- a/src/lib/zebraTextLayout.ts
+++ b/src/lib/zebraTextLayout.ts
@@ -256,6 +256,18 @@ export function blockLineStepDots(fontHeight: number, blockLineSpacing: number):
   return fontHeight + blockLineSpacing;
 }
 
+/** Width of the empty single-line text placeholder, in fontHeight multiples.
+ *  Shared by the canvas placeholder rect and objectBounds so the selection
+ *  chrome (action bar, align, snap) centers on what is actually drawn. */
+export const EMPTY_TEXT_PLACEHOLDER_GLYPHS = 4;
+
+/** A field with no printable content: the canvas draws the placeholder rect and
+ *  emit writes an empty ^FD. Single source for the render / bounds / measured
+ *  gate so they can't drift on what counts as blank (whitespace trims away). */
+export function isBlankText(content: string): boolean {
+  return content.trim() === "";
+}
+
 /** ^TB line pitch ratio. Unlike ^FB (pitch = fontHeight), ^TB spaces lines at
  *  ~1.25x fontHeight (calibrated against Labelary for the default font). */
 export const TB_LINE_HEIGHT_RATIO = 1.25;


### PR DESCRIPTION
objectBounds estimated blank single-line text at zero width, so the action bar centered left of the drawn placeholder; share its 4-glyph footprint, cover whitespace, and skip off-label for blank text (empty ^FD prints nothing).