### PR TITLE
feat(print): OS-native raw printing via the local spooler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils libcups2-dev
 
       - uses: pnpm/action-setup@v6
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2326,6 +2326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "printers"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9973d6bf0ed339da9230a83eccbd7c2564f392bdc80246853645e9a60efb38b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4821,6 +4830,7 @@ dependencies = [
 name = "zebra-print-lab"
 version = "0.1.0"
 dependencies = [
+ "printers",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ tauri = { version = "2.11.3", features = [] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["net", "time", "io-util"] }
+# OS-native raw printing: winspool RAW on Windows, libcups on macOS/Linux.
+# Sole transitive dep is libc. Linux CI needs libcups2-dev to link.
+printers = "2.3.0"
 
 [dev-dependencies]
 # rt only: the macros feature would pull tokio-macros, which lags tokio

--- a/src-tauri/THIRD-PARTY-LICENSES-RUST.html
+++ b/src-tauri/THIRD-PARTY-LICENSES-RUST.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (339)</li>
+            <li><a href="#MIT">MIT License</a> (340)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (5)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (5)</li>
@@ -927,6 +927,36 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 The files under third-party/chromium are licensed as described in
 third-party/chromium/LICENSE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/talesluna/rust-printers ">printers 2.3.0</a></li>
+                </ul>
+                <pre class="license-text">(The MIT License)
+
+Copyright (c) 2022 Tales Luna &lt;tales.ferreira.luna@gmail.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&#x27;Software&#x27;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &#x27;AS IS&#x27;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,11 @@ mod print;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let builder = tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![print::send_zpl_tcp]);
+    .invoke_handler(tauri::generate_handler![
+      print::send_zpl_tcp,
+      print::list_printers,
+      print::send_zpl_local
+    ]);
   // On the builder, not in setup(): config windows exist before the setup
   // closure runs, and window-state only restores/tracks via on_window_ready.
   #[cfg(desktop)]

--- a/src-tauri/src/print.rs
+++ b/src-tauri/src/print.rs
@@ -20,13 +20,13 @@ const MAX_ZPL_BYTES: usize = 16 * 1024 * 1024;
 
 fn validate(host: &str, port: u16, zpl_len: usize) -> Result<(), String> {
   if host.is_empty() || host.contains('/') || host.contains(char::is_whitespace) {
-    return Err("invalid host".into());
+    return Err("invalid host".to_string());
   }
   if port == 0 {
-    return Err("invalid port".into());
+    return Err("invalid port".to_string());
   }
   if zpl_len > MAX_ZPL_BYTES {
-    return Err("payload too large".into());
+    return Err("payload too large".to_string());
   }
   Ok(())
 }
@@ -53,6 +53,68 @@ pub async fn send_zpl_tcp(host: String, port: u16, zpl: String) -> Result<TcpSen
     Ok(Err(e)) => Err(e.to_string()),
     Err(_) => Err("write timed out".to_string()),
   }
+}
+
+/// One local OS print queue for the picker. driver_name/port_name let the UI
+/// hint which queues are likely Zebra/raw-capable (never for filtering).
+#[derive(serde::Serialize)]
+pub struct LocalPrinter {
+  system_name: String,
+  name: String,
+  driver_name: String,
+  port_name: String,
+}
+
+// Windows winspool defaults pDatatype to RAW; passing a CUPS MIME there would
+// set an invalid datatype. CUPS needs the explicit raw format to bypass filters.
+#[cfg(windows)]
+const RAW_PROPS: &[(&str, &str)] = &[];
+#[cfg(not(windows))]
+const RAW_PROPS: &[(&str, &str)] = &[("document-format", "application/vnd.cups-raw")];
+
+#[tauri::command]
+pub async fn list_printers() -> Result<Vec<LocalPrinter>, String> {
+  tauri::async_runtime::spawn_blocking(|| {
+    // No default-printer lookup: printers::get_default_printer() has a Windows
+    // dangling-deref when no default is set, and the UI sorts Zebra-first anyway.
+    printers::get_printers()
+      .into_iter()
+      .map(|p| LocalPrinter {
+        system_name: p.system_name,
+        name: p.name,
+        driver_name: p.driver_name,
+        port_name: p.port_name,
+      })
+      .collect::<Vec<_>>()
+  })
+  .await
+  .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn send_zpl_local(printer: String, zpl: String) -> Result<(), String> {
+  if zpl.len() > MAX_ZPL_BYTES {
+    return Err("payload too large".to_string());
+  }
+  tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
+    // Allowlist the caller's string against enumerated queues; never hand an
+    // arbitrary name to the spooler.
+    let target = printers::get_printers()
+      .into_iter()
+      .find(|p| p.system_name == printer)
+      .ok_or_else(|| "unknown printer".to_string())?;
+    let opts = printers::common::base::job::PrinterJobOptions {
+      name: Some("zpl-designer"),
+      raw_properties: RAW_PROPS,
+      ..printers::common::base::job::PrinterJobOptions::none()
+    };
+    target
+      .print(zpl.as_bytes(), opts)
+      .map(|_| ())
+      .map_err(|e| e.message)
+  })
+  .await
+  .map_err(|e| e.to_string())?
 }
 
 #[cfg(test)]

--- a/src/components/Output/PrintToZebraDialog.tsx
+++ b/src/components/Output/PrintToZebraDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { XMarkIcon } from "@heroicons/react/16/solid";
 import { useT } from "../../hooks/useT";
 import { DialogShell } from "../ui/DialogShell";
@@ -9,12 +9,15 @@ import {
   sendViaNetwork,
   type BrowserPrintDevice,
 } from "../../lib/zebraPrint";
+import { isDesktopShell } from "../../lib/platform";
+import { listLocalPrinters, sendZplLocal, isLikelyZebra, type LocalPrinter } from "../../lib/localPrint";
 
 const LS_IP = "zebra_print_ip";
 const LS_PORT = "zebra_print_port";
 const LS_PRINTER_UID = "zebra_print_uid";
+const LS_LOCAL_PRINTER = "zebra_print_local";
 
-type Tab = "network" | "browserprint";
+type Tab = "network" | "browserprint" | "local";
 interface Status { type: "idle" | "sending" | "success" | "error"; message?: string }
 
 function StatusMessage({ status }: { status: Status }) {
@@ -47,6 +50,41 @@ export function PrintToZebraDialog({ zpl, onClose }: Props) {
   );
   const [bpStatus, setBpStatus] = useState<Status>({ type: "idle" });
   const [discovering, setDiscovering] = useState(false);
+
+  // Local printer (OS spooler) tab state; desktop shell only.
+  const [localPrinters, setLocalPrinters] = useState<LocalPrinter[]>([]);
+  const [selectedLocal, setSelectedLocal] = useState<string>(
+    () => localStorage.getItem(LS_LOCAL_PRINTER) ?? "",
+  );
+  const [localStatus, setLocalStatus] = useState<Status>({ type: "idle" });
+  // Starts loading on desktop (the effect enumerates on mount); false on web.
+  const [loadingLocal, setLoadingLocal] = useState(isDesktopShell);
+
+  // Enumerate OS print queues once on mount; the web build has no spooler.
+  useEffect(() => {
+    if (!isDesktopShell) return;
+    let cancelled = false;
+    listLocalPrinters()
+      .then((printers) => {
+        if (cancelled) return;
+        setLocalPrinters(printers);
+        setSelectedLocal((cur) =>
+          cur && printers.some((p) => p.system_name === cur) ? cur : printers[0]?.system_name ?? "",
+        );
+      })
+      .catch((e: unknown) => {
+        // A failed enumeration must be visible, not a silent empty list.
+        if (!cancelled) {
+          setLocalStatus({ type: "error", message: e instanceof Error ? e.message : String(e) });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingLocal(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   function persistNetwork() {
     localStorage.setItem(LS_IP, ip);
@@ -129,6 +167,18 @@ export function PrintToZebraDialog({ zpl, onClose }: Props) {
     }
   }
 
+  async function handleLocalSend() {
+    if (!selectedLocal) return;
+    localStorage.setItem(LS_LOCAL_PRINTER, selectedLocal);
+    setLocalStatus({ type: "sending" });
+    const result = await sendZplLocal(selectedLocal, zpl);
+    if (result.kind === "sent") {
+      setLocalStatus({ type: "success", message: t.zebraPrint.success });
+    } else {
+      setLocalStatus({ type: "error", message: result.message || t.zebraPrint.errorGeneric });
+    }
+  }
+
   const tabClass = (active: boolean) =>
     `px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest transition-colors ${
       active
@@ -167,6 +217,11 @@ export function PrintToZebraDialog({ zpl, onClose }: Props) {
         >
           {t.zebraPrint.tabBrowserPrint}
         </button>
+        {isDesktopShell && (
+          <button className={tabClass(tab === "local")} onClick={() => setTab("local")}>
+            {t.zebraPrint.tabLocal}
+          </button>
+        )}
       </div>
 
       {/* Network tab */}
@@ -265,6 +320,54 @@ export function PrintToZebraDialog({ zpl, onClose }: Props) {
           </button>
 
           <StatusMessage status={bpStatus} />
+        </div>
+      )}
+
+      {/* Local printer tab (OS spooler, desktop shell only) */}
+      {tab === "local" && (
+        <div className="flex flex-col gap-3 p-4">
+          <div className="flex flex-col gap-1">
+            <label className="font-mono text-[10px] text-muted uppercase tracking-widest">
+              {t.zebraPrint.printer}
+            </label>
+            <Select<string>
+              value={selectedLocal}
+              onChange={(name) => {
+                setSelectedLocal(name);
+                localStorage.setItem(LS_LOCAL_PRINTER, name);
+              }}
+              disabled={localPrinters.length === 0}
+              groups={[
+                {
+                  options:
+                    localPrinters.length === 0
+                      ? [
+                          {
+                            value: "",
+                            label: loadingLocal ? t.zebraPrint.discovering : t.zebraPrint.noPrinters,
+                          },
+                        ]
+                      : localPrinters.map((p) => ({
+                          value: p.system_name,
+                          label: isLikelyZebra(p) ? `${p.name} · ZPL?` : p.name,
+                        })),
+                },
+              ]}
+            />
+          </div>
+          <button
+            onClick={handleLocalSend}
+            disabled={
+              !selectedLocal ||
+              localPrinters.length === 0 ||
+              loadingLocal ||
+              localStatus.type === "sending"
+            }
+            className="self-end px-3 py-1.5 text-xs font-mono rounded bg-accent text-bg hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+          >
+            {localStatus.type === "sending" ? t.zebraPrint.sending : t.zebraPrint.send}
+          </button>
+          <StatusMessage status={localStatus} />
         </div>
       )}
     </DialogShell>

--- a/src/lib/localPrint.ts
+++ b/src/lib/localPrint.ts
@@ -1,0 +1,41 @@
+import { isDesktopShell } from "./platform";
+
+/** Mirrors the Rust LocalPrinter DTO (one OS print queue). */
+export interface LocalPrinter {
+  system_name: string;
+  name: string;
+  driver_name: string;
+  port_name: string;
+}
+
+export type LocalPrintResult = { kind: "sent" } | { kind: "error"; message: string };
+
+/** Hint only (sorting/labels), never filtering: a ZDesigner/ZPL driver or a USB
+ *  port strongly suggests a raw-ZPL-capable queue. */
+export function isLikelyZebra(p: LocalPrinter): boolean {
+  const d = p.driver_name.toLowerCase();
+  return d.includes("zdesigner") || d.includes("zpl") || d.includes("zebra") || p.port_name.toUpperCase().startsWith("USB");
+}
+
+/** Desktop shell only: enumerates OS print queues via the Rust command; the web
+ *  build has no spooler access, so it returns nothing. */
+export async function listLocalPrinters(): Promise<LocalPrinter[]> {
+  if (!isDesktopShell) return [];
+  const { invoke } = await import("@tauri-apps/api/core");
+  const printers = await invoke<LocalPrinter[]>("list_printers");
+  // Likely-Zebra first, then by name (no OS-default: an office printer is a
+  // worse pick than the label printer for this app).
+  return [...printers].sort(
+    (a, b) => Number(isLikelyZebra(b)) - Number(isLikelyZebra(a)) || a.name.localeCompare(b.name),
+  );
+}
+
+export async function sendZplLocal(systemName: string, zpl: string): Promise<LocalPrintResult> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  try {
+    await invoke("send_zpl_local", { printer: systemName, zpl });
+    return { kind: "sent" };
+  } catch (e) {
+    return { kind: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -1338,6 +1338,7 @@ const ar = {
     heading: 'إرسال إلى طابعة Zebra',
     tabNetwork: 'الشبكة (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'طابعة محلية',
     ipAddress: 'عنوان IP',
     port: 'المنفذ',
     send: 'إرسال ZPL',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -1338,6 +1338,7 @@ const bg = {
     heading: 'Изпрати към принтер Zebra',
     tabNetwork: 'Мрежа (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Локален принтер',
     ipAddress: 'IP адрес',
     port: 'Порт',
     send: 'Изпрати ZPL',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -1338,6 +1338,7 @@ const cs = {
     heading: 'Odeslat na tiskárnu Zebra',
     tabNetwork: 'Síť (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Místní tiskárna',
     ipAddress: 'IP adresa',
     port: 'Port',
     send: 'Odeslat ZPL',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -1338,6 +1338,7 @@ const da = {
     heading: 'Send til Zebra-printer',
     tabNetwork: 'Netværk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokal printer',
     ipAddress: 'IP-adresse',
     port: 'Port',
     send: 'Send ZPL',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -742,6 +742,7 @@ const de = {
     heading: 'An Zebra-Drucker senden',
     tabNetwork: 'Netzwerk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokaler Drucker',
     ipAddress: 'IP-Adresse',
     port: 'Port',
     send: 'ZPL senden',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -1338,6 +1338,7 @@ const el = {
     heading: 'Αποστολή σε εκτυπωτή Zebra',
     tabNetwork: 'Δίκτυο (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Τοπικός εκτυπωτής',
     ipAddress: 'Διεύθυνση IP',
     port: 'Θύρα',
     send: 'Αποστολή ZPL',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -742,6 +742,7 @@ const en = {
     heading: 'Send to Zebra Printer',
     tabNetwork: 'Network (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Local printer',
     ipAddress: 'IP Address',
     port: 'Port',
     send: 'Send ZPL',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1338,6 +1338,7 @@ const es = {
     heading: 'Enviar a impresora Zebra',
     tabNetwork: 'Red (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Impresora local',
     ipAddress: 'Dirección IP',
     port: 'Puerto',
     send: 'Enviar ZPL',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -1338,6 +1338,7 @@ const et = {
     heading: 'Saada Zebra printerile',
     tabNetwork: 'Võrk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Kohalik printer',
     ipAddress: 'IP-aadress',
     port: 'Port',
     send: 'Saada ZPL',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -1338,6 +1338,7 @@ const fa = {
     heading: 'ارسال به چاپگر Zebra',
     tabNetwork: 'شبکه (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'چاپگر محلی',
     ipAddress: 'آدرس IP',
     port: 'پورت',
     send: 'ارسال ZPL',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -1338,6 +1338,7 @@ const fi = {
     heading: 'Lähetä Zebra-tulostimelle',
     tabNetwork: 'Verkko (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Paikallinen tulostin',
     ipAddress: 'IP-osoite',
     port: 'Portti',
     send: 'Lähetä ZPL',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1338,6 +1338,7 @@ const fr = {
     heading: 'Envoyer à l’imprimante Zebra',
     tabNetwork: 'Réseau (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Imprimante locale',
     ipAddress: 'Adresse IP',
     port: 'Port',
     send: 'Envoyer ZPL',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -1338,6 +1338,7 @@ const he = {
     heading: 'שלח למדפסת Zebra',
     tabNetwork: 'רשת (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'מדפסת מקומית',
     ipAddress: 'כתובת IP',
     port: 'פורט',
     send: 'שלח ZPL',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -1338,6 +1338,7 @@ const hr = {
     heading: 'Pošalji na Zebra pisač',
     tabNetwork: 'Mreža (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokalni pisač',
     ipAddress: 'IP adresa',
     port: 'Port',
     send: 'Pošalji ZPL',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -1338,6 +1338,7 @@ const hu = {
     heading: 'Küldés Zebra nyomtatóra',
     tabNetwork: 'Hálózat (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Helyi nyomtató',
     ipAddress: 'IP-cím',
     port: 'Port',
     send: 'ZPL küldése',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -1338,6 +1338,7 @@ const it = {
     heading: 'Invia a stampante Zebra',
     tabNetwork: 'Rete (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Stampante locale',
     ipAddress: 'Indirizzo IP',
     port: 'Porta',
     send: 'Invia ZPL',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -1338,6 +1338,7 @@ const ja = {
     heading: 'Zebra プリンターへ送信',
     tabNetwork: 'ネットワーク (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'ローカルプリンター',
     ipAddress: 'IP アドレス',
     port: 'ポート',
     send: 'ZPL を送信',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -1338,6 +1338,7 @@ const ko = {
     heading: 'Zebra 프린터로 전송',
     tabNetwork: '네트워크 (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: '로컬 프린터',
     ipAddress: 'IP 주소',
     port: '포트',
     send: 'ZPL 전송',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -1338,6 +1338,7 @@ const lt = {
     heading: 'Siųsti į Zebra spausdintuvą',
     tabNetwork: 'Tinklas (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Vietinis spausdintuvas',
     ipAddress: 'IP adresas',
     port: 'Prievadas',
     send: 'Siųsti ZPL',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -1338,6 +1338,7 @@ const lv = {
     heading: 'Sūtīt uz Zebra printeri',
     tabNetwork: 'Tīkls (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Vietējais printeris',
     ipAddress: 'IP adrese',
     port: 'Ports',
     send: 'Sūtīt ZPL',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1338,6 +1338,7 @@ const nl = {
     heading: 'Verzenden naar Zebra-printer',
     tabNetwork: 'Netwerk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokale printer',
     ipAddress: 'IP-adres',
     port: 'Poort',
     send: 'ZPL verzenden',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -1338,6 +1338,7 @@ const no = {
     heading: 'Send til Zebra-skriver',
     tabNetwork: 'Nettverk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokal skriver',
     ipAddress: 'IP-adresse',
     port: 'Port',
     send: 'Send ZPL',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -1338,6 +1338,7 @@ const pl = {
     heading: 'Wyślij do drukarki Zebra',
     tabNetwork: 'Sieć (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Drukarka lokalna',
     ipAddress: 'Adres IP',
     port: 'Port',
     send: 'Wyślij ZPL',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -1338,6 +1338,7 @@ const pt = {
     heading: 'Enviar para impressora Zebra',
     tabNetwork: 'Rede (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Impressora local',
     ipAddress: 'Endereço IP',
     port: 'Porta',
     send: 'Enviar ZPL',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -1338,6 +1338,7 @@ const ro = {
     heading: 'Trimite la imprimanta Zebra',
     tabNetwork: 'Rețea (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Imprimantă locală',
     ipAddress: 'Adresă IP',
     port: 'Port',
     send: 'Trimite ZPL',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -1338,6 +1338,7 @@ const sk = {
     heading: 'Odoslať na tlačiareň Zebra',
     tabNetwork: 'Sieť (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Miestna tlačiareň',
     ipAddress: 'IP adresa',
     port: 'Port',
     send: 'Odoslať ZPL',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -1338,6 +1338,7 @@ const sl = {
     heading: 'Pošlji na tiskalnik Zebra',
     tabNetwork: 'Omrežje (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokalni tiskalnik',
     ipAddress: 'IP naslov',
     port: 'Vrata',
     send: 'Pošlji ZPL',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -1338,6 +1338,7 @@ const sr = {
     heading: 'Пошаљи на Zebra штампач',
     tabNetwork: 'Мрежа (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Локални штампач',
     ipAddress: 'IP adresa',
     port: 'Port',
     send: 'Pošalji ZPL',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -1338,6 +1338,7 @@ const sv = {
     heading: 'Skicka till Zebra-skrivare',
     tabNetwork: 'Nätverk (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Lokal skrivare',
     ipAddress: 'IP-adress',
     port: 'Port',
     send: 'Skicka ZPL',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -1338,6 +1338,7 @@ const tr = {
     heading: 'Zebra yazıcıya gönder',
     tabNetwork: 'Ağ (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: 'Yerel yazıcı',
     ipAddress: 'IP Adresi',
     port: 'Port',
     send: 'ZPL Gönder',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -1338,6 +1338,7 @@ const zhHans = {
     heading: '发送到 Zebra 打印机',
     tabNetwork: '网络 (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: '本地打印机',
     ipAddress: 'IP 地址',
     port: '端口',
     send: '发送 ZPL',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -1338,6 +1338,7 @@ const zhHant = {
     heading: '傳送至 Zebra 印表機',
     tabNetwork: '網路 (IP)',
     tabBrowserPrint: 'Zebra Browser Print',
+    tabLocal: '本機印表機',
     ipAddress: 'IP 位址',
     port: '連接埠',
     send: '傳送 ZPL',


### PR DESCRIPTION
list_printers + send_zpl_local (printers crate: winspool RAW on Windows, libcups elsewhere), new 'Local printer' tab (desktop-gated). Windows hardware-verified against a USB ZD230; macOS/Linux compile + CI-build but runtime-unverified.