### PR TITLE
fix(builder): give content and GS1 builder modals a stable height

### DIFF
--- a/src/components/Barcode/BarcodeContentModalShell.tsx
+++ b/src/components/Barcode/BarcodeContentModalShell.tsx
@@ -35,7 +35,10 @@ export function BarcodeContentModalShell({
       labelledBy={titleId}
       describedBy={subtitleId}
       onClose={onClose}
-      boxClassName="bg-surface border border-border rounded-lg shadow-2xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden"
+      // Fixed height so switching content types (1 field for url, 7 for vcard)
+      // and toggling the preview scroll inside the body instead of resizing the
+      // whole box; max-h caps it on short viewports.
+      boxClassName="bg-surface border border-border rounded-lg shadow-2xl w-[640px] max-w-[95vw] h-[620px] max-h-[85vh] flex flex-col overflow-hidden"
     >
       <DialogHeader
         titleId={titleId}

--- a/src/components/Barcode/Gs1ContentModal.tsx
+++ b/src/components/Barcode/Gs1ContentModal.tsx
@@ -199,7 +199,9 @@ function Gs1Builder({ objectId }: { objectId: string }) {
       labelledBy={titleId}
       describedBy={subtitleId}
       onClose={closeGs1Builder}
-      boxClassName="bg-surface border border-border rounded-lg shadow-2xl w-[900px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden"
+      // Fixed height so the palette's query-driven row count (curated set vs full
+      // catalog) scrolls inside the aside instead of resizing the whole box.
+      boxClassName="bg-surface border border-border rounded-lg shadow-2xl w-[900px] max-w-[95vw] h-[85vh] flex flex-col overflow-hidden"
     >
       <DialogHeader
         titleId={titleId}


### PR DESCRIPTION
Fixed frame height so type/search-driven content changes scroll inside the existing body regions instead of resizing the whole modal.