### PR TITLE
fix(zpl): arm ^FE/^FC on each template field, not in the header

### DIFF
--- a/src/lib/zplForSelection.ts
+++ b/src/lib/zplForSelection.ts
@@ -5,9 +5,10 @@ import { planFieldEmission } from "./zplGenerator";
 
 /** Just the field commands for the selected objects (no ^XA / label config /
  *  ^XZ): the page's top-level objects that are selected, a group counting when
- *  it or any descendant leaf is. Includes the template/clock header (^FE/^FN/
- *  ^SO/^FC) the bodies depend on, so a selection using variables stays valid;
- *  it stays empty for plain objects. Empty string when nothing is selected. */
+ *  it or any descendant leaf is. Includes the template header (^FN/^SO) the
+ *  bodies depend on, so a selection using variables stays valid (the ^FE/^FC
+ *  armings ride on each field, not here); it stays empty for plain objects.
+ *  Empty string when nothing is selected. */
 export function zplForSelection(
   label: LabelConfig,
   pageObjects: readonly LabelObject[],

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -899,7 +899,7 @@ describe('generateZPL — ^TB text block', () => {
       ^CI28
       ^FN7^FDL7^FS
       ^FO10,15^A0N,30,0^FN1^FDDEF^FS
-      ^FO10,55^A0N,30,0^FD#1#-#7#^FS
+      ^FO10,55^A0N,30,0^FE#^FD#1#-#7#^FS
       ^XZ"
     `);
   });
@@ -913,6 +913,43 @@ describe('generateZPL — ^TB text block', () => {
     const out = generateZPL(BASE_LABEL, [byContent], vars);
     expect(out).toContain('^FN1^FDDEF^FS');
     expect(out.match(/\^FN1/g)?.length).toBe(1); // inline only, never also in header
+  });
+
+  // ZD230-verified (2026-07-10, ^IS/^HY firmware renders): without a ^FE
+  // immediately before the ^FD, #n# embeds print LITERALLY even for the
+  // default char (spec p.191); same for ^FC clock tokens (spec p.189). The
+  // armings must ride on each field, not sit in the header.
+  it('arms ^FE directly before a template ^FD, even for the default char', () => {
+    const vars = [
+      { id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' },
+      { id: 'v2', name: 'lot', fnNumber: 7, defaultValue: 'L7' },
+    ];
+    const template = {
+      id: 'b', type: 'text', x: 10, y: 50, rotation: 0,
+      props: { content: '«sku»-«lot»', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [template], vars);
+    expect(zpl).toContain('^FE#^FD#1#-#7#^FS');
+  });
+
+  it('arms ^FC directly before a clock ^FD, even for default chars', () => {
+    const obj = {
+      id: 'c', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: '«clock:Y»', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [obj]);
+    expect(zpl).toMatch(/\^FC%,\{,#\^FD%Y\^FS/);
+  });
+
+  it('arms ^FC then ^FE when a field mixes clock tokens and embeds', () => {
+    // Order is firmware-verified: ^FC%^FE#^FD expands both (check 07 field 1).
+    const vars = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const obj = {
+      id: 'm', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: '«sku» «clock:Y»', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [obj], vars);
+    expect(zpl).toMatch(/\^FC%,\{,#\^FE#\^FD#1# %Y\^FS/);
   });
 
   it('round-trips a reverse ^TB (bare ^FR, no box, even h < fontHeight)', () => {
@@ -1215,9 +1252,9 @@ describe('generateZPL — parse/generate roundtrip', () => {
     const reparsed = parseZPL(regenerated, 8);
     const text = defined(reparsed.objects.find((o) => o.type === 'text'));
     expect(props(text).content).toBe('«clock:d»/«clock:m»/«clock:Y» «clock:H»:«clock:M»');
-    // No ^FC line when defaults work; payload has no `%` `{` or `#`
-    // literals beyond the token positions.
-    expect(regenerated).not.toMatch(/\^FC/);
+    // ^FC must arm each clock field even for default chars (ZD230: %Y prints
+    // literally without it), riding directly on the ^FD.
+    expect(regenerated).toMatch(/\^FC%,\{,#\^FD/);
   });
 
   it('resets ^FC and ^FE state between sibling ^XA blocks', () => {
@@ -1243,6 +1280,30 @@ describe('generateZPL — parse/generate roundtrip', () => {
     const original = parseZPL(src, 8);
     const regenerated = generateZPL(BASE_LABEL, original.objects);
     expect(regenerated).toMatch(/\^FC\$/);
+  });
+
+  // Per-field ^FE/^FC arming (firmware scoping) must not desync the parser's
+  // block-state model: a non-default delimiter also rides in the header so a
+  // literal before the first armed field round-trips instead of mis-decoding.
+  it('round-trips a literal #n# before a template field (non-default embed char)', () => {
+    const vars = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'A#B' }];
+    const literal = { id: 'a', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: 'lane #1# here', fontHeight: 30, fontWidth: 0, rotation: 'N' } } as unknown as LabelObject;
+    const template = { id: 'b', type: 'text', x: 10, y: 50, rotation: 0,
+      props: { content: '«sku» end', fontHeight: 30, fontWidth: 0, rotation: 'N' } } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [literal, template], vars);
+    const back = parseZPL(zpl, 8);
+    expect(props(defined(back.objects[0])).content).toBe('lane #1# here');
+  });
+
+  it('round-trips a literal %Y before a clock field (non-default clock char)', () => {
+    const literal = { id: 'a', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: 'year %Y now', fontHeight: 30, fontWidth: 0, rotation: 'N' } } as unknown as LabelObject;
+    const clock = { id: 'b', type: 'text', x: 10, y: 50, rotation: 0,
+      props: { content: '«clock:Y» 100% done', fontHeight: 30, fontWidth: 0, rotation: 'N' } } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [literal, clock]);
+    const back = parseZPL(zpl, 8);
+    expect(props(defined(back.objects[0])).content).toBe('year %Y now');
   });
 
   it('round-trips ^SO2 offsets via labelConfig.secondaryClockOffset', () => {

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -917,8 +917,7 @@ describe('generateZPL — ^TB text block', () => {
 
   // ZD230-verified (2026-07-10, ^IS/^HY firmware renders): without a ^FE
   // immediately before the ^FD, #n# embeds print LITERALLY even for the
-  // default char (spec p.191); same for ^FC clock tokens (spec p.189). The
-  // armings must ride on each field, not sit in the header.
+  // default char (spec p.191); same for ^FC clock tokens (spec p.189).
   it('arms ^FE directly before a template ^FD, even for the default char', () => {
     const vars = [
       { id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' },

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -103,11 +103,8 @@ export function planTemplateHeader(
   const emitCtx: ZplEmitContext = { label, variables };
 
   if (pickedEmbedChar !== null) {
-    // A non-default delimiter also goes in the header so re-import parses a
-    // literal `#n#` in any field emitted before the first armed field as
-    // literal: the parser tracks the delimiter as block state, while firmware
-    // only honours the per-field arming fdFieldFor adds. (Default `#` is the
-    // parser's own default, so no header line is needed for it.)
+    // Default `#` is the parser's own default; only a non-default delimiter
+    // needs the header ^FE (the block-state note on planTemplateHeader).
     if (pickedEmbedChar !== '#') headerLines.push(`^FE${pickedEmbedChar}`);
     for (const [fn, v] of [...templateVarsByFn].sort(([a], [b]) => a - b)) {
       if (singleBindFns.has(fn)) continue;
@@ -127,8 +124,8 @@ export function planTemplateHeader(
       const so3 = formatSetOffset(3, label.tertiaryClockOffset);
       if (so2) headerLines.push(so2);
       if (so3) headerLines.push(so3);
-      // Same block-state reason as ^FE: a non-default clock char goes in the
-      // header for parse fidelity of literals before the first armed field.
+      // Non-default clock chars need the header ^FC for the same block-state
+      // reason as ^FE above.
       if (!isDefaultClockChars(picked)) {
         headerLines.push(`^FC${picked.date},${picked.time},${picked.tertiary}`);
       }

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -49,9 +49,12 @@ function flattenObjects(objects: LabelObject[]): LabelObject[] {
   return out;
 }
 
-/** Plan `^FE` + header `^FN` declarations for inline-embed templates,
- *  plus the emit context. embedChar is only set when a safe char exists,
- *  which fdFieldFor uses as the "templates allowed" gate. */
+/** Plan header `^FN` declarations (+ `^SO` clock offsets) for inline-embed
+ *  templates, plus the emit context. embedChar is only set when a safe char
+ *  exists, which fdFieldFor uses as the "templates allowed" gate. Firmware
+ *  honours ^FE/^FC only per ^FD, so fdFieldFor arms them on each consuming
+ *  field; the header additionally declares a NON-default delimiter as block
+ *  state so re-import decodes literals before the first armed field correctly. */
 export function planTemplateHeader(
   shifted: LabelObject[],
   label: LabelConfig,
@@ -100,6 +103,11 @@ export function planTemplateHeader(
   const emitCtx: ZplEmitContext = { label, variables };
 
   if (pickedEmbedChar !== null) {
+    // A non-default delimiter also goes in the header so re-import parses a
+    // literal `#n#` in any field emitted before the first armed field as
+    // literal: the parser tracks the delimiter as block state, while firmware
+    // only honours the per-field arming fdFieldFor adds. (Default `#` is the
+    // parser's own default, so no header line is needed for it.)
     if (pickedEmbedChar !== '#') headerLines.push(`^FE${pickedEmbedChar}`);
     for (const [fn, v] of [...templateVarsByFn].sort(([a], [b]) => a - b)) {
       if (singleBindFns.has(fn)) continue;
@@ -108,18 +116,19 @@ export function planTemplateHeader(
     emitCtx.embedChar = pickedEmbedChar;
   }
 
-  // Same fail-safe as ^FE: emit only when non-default and safe.
   if (clockPayloads.length > 0) {
     const picked = pickClockChars(clockPayloads);
     if (picked) {
-      // ^SO precedes ^FC so the offsets are armed when the firmware
-      // activates the secondary/tertiary clock chars. ^SO is session-
-      // scoped; emitting on every label that uses these channels
+      // ^SO precedes the per-field ^FC armings so the offsets are set when
+      // the firmware activates the secondary/tertiary clock chars. ^SO is
+      // session-scoped; emitting on every label that uses these channels
       // overwrites any stale state from a prior label.
       const so2 = formatSetOffset(2, label.secondaryClockOffset);
       const so3 = formatSetOffset(3, label.tertiaryClockOffset);
       if (so2) headerLines.push(so2);
       if (so3) headerLines.push(so3);
+      // Same block-state reason as ^FE: a non-default clock char goes in the
+      // header for parse fidelity of literals before the first armed field.
       if (!isDefaultClockChars(picked)) {
         headerLines.push(`^FC${picked.date},${picked.time},${picked.tertiary}`);
       }

--- a/src/registry/zplHelpers.ts
+++ b/src/registry/zplHelpers.ts
@@ -196,20 +196,18 @@ export function fdFieldFor(
       return `^FN${v.fnNumber}${fdField(transform(encodeDefault(v.defaultValue)))}`;
     }
   }
-  // Template path: ^FE embeds first then ^FC clock; absent ctx delim signals
-  // "templates not emittable" and the content stays literal. Firmware scopes
-  // both armings to the one ^FD they precede and skips them otherwise, even
-  // for the default chars (spec p.189/p.191; ZD230-verified: without them,
-  // embeds and clock tokens print literally). So they ride on this field,
-  // ^FC first, ^FE flush against ^FD.
+  // Template path: arm ^FE/^FC on this field (absent ctx delim = templates not
+  // emittable, so content stays literal). Firmware scopes both armings to the
+  // ^FD they precede, even for default chars (spec p.189/191; ZD230-verified:
+  // without them embeds and clock tokens print literally).
   let payload = content;
   let arm = '';
   if (ctx?.variables && ctx.embedChar && hasTemplateMarkers(payload)) {
     // Arm ^FE only when a marker actually became an embed: hasTemplateMarkers
     // also matches non-variable «...» spans (e.g. clock markers), which
     // markersToEmbeds leaves untouched.
-    const next = markersToEmbeds(payload, ctx.variables, ctx.embedChar).payload;
-    if (next !== payload) arm = `^FE${ctx.embedChar}`;
+    const { payload: next, referencedFnNumbers } = markersToEmbeds(payload, ctx.variables, ctx.embedChar);
+    if (referencedFnNumbers.size > 0) arm = `^FE${ctx.embedChar}`;
     payload = next;
   }
   if (ctx?.clockChars && hasClockMarkers(payload)) {

--- a/src/registry/zplHelpers.ts
+++ b/src/registry/zplHelpers.ts
@@ -163,11 +163,14 @@ function hex(ch: string): string {
   );
 }
 
-/** Hex-escape ^/~ via ^FH_ (and _ itself) so user content can't smuggle commands. */
-export function fdField(payload: string): string {
-  if (!NEEDS_FH.test(payload)) return `^FD${payload}^FS`;
+/** Hex-escape ^/~ via ^FH_ (and _ itself) so user content can't smuggle commands.
+ *  `arm` carries per-field ^FC/^FE armings; it sits after a ^FH but flush
+ *  against ^FD, because ^FE only applies when it immediately precedes its ^FD
+ *  (spec p.191). */
+export function fdField(payload: string, arm = ''): string {
+  if (!NEEDS_FH.test(payload)) return `${arm}^FD${payload}^FS`;
   const escaped = payload.replace(/[\^~_]/g, hex);
-  return `^FH${FH_DELIM}^FD${escaped}^FS`;
+  return `^FH${FH_DELIM}${arm}^FD${escaped}^FS`;
 }
 
 /** Single-bind content (`«name»`) emits `^FN{n}` + default; a template expands
@@ -194,13 +197,24 @@ export function fdFieldFor(
     }
   }
   // Template path: ^FE embeds first then ^FC clock; absent ctx delim signals
-  // "templates not emittable" and the content stays literal.
+  // "templates not emittable" and the content stays literal. Firmware scopes
+  // both armings to the one ^FD they precede and skips them otherwise, even
+  // for the default chars (spec p.189/p.191; ZD230-verified: without them,
+  // embeds and clock tokens print literally). So they ride on this field,
+  // ^FC first, ^FE flush against ^FD.
   let payload = content;
+  let arm = '';
   if (ctx?.variables && ctx.embedChar && hasTemplateMarkers(payload)) {
-    payload = markersToEmbeds(payload, ctx.variables, ctx.embedChar).payload;
+    // Arm ^FE only when a marker actually became an embed: hasTemplateMarkers
+    // also matches non-variable «...» spans (e.g. clock markers), which
+    // markersToEmbeds leaves untouched.
+    const next = markersToEmbeds(payload, ctx.variables, ctx.embedChar).payload;
+    if (next !== payload) arm = `^FE${ctx.embedChar}`;
+    payload = next;
   }
   if (ctx?.clockChars && hasClockMarkers(payload)) {
     payload = markersToTokens(payload, ctx.clockChars);
+    arm = `^FC${ctx.clockChars.date},${ctx.clockChars.time},${ctx.clockChars.tertiary}${arm}`;
   }
-  return fdField(transform(payload));
+  return fdField(transform(payload), arm);
 }


### PR DESCRIPTION
Firmware scopes both to the single ^FD they immediately precede and skips them otherwise, even for default chars (spec p.189/p.191; ZD230-verified via ^IS/^HY renders: embeds and clock tokens printed literally, breaking direct-print templates and the ^DF batch template). fdFieldFor now emits ^FC then ^FE flush against ^FD, after any ^FH. A non-default delimiter still rides in the header as parser block-state so a literal before the first armed field round-trips.