### PR TITLE
feat(canvas): rotate a single image in 90-degree steps

### DIFF
--- a/src/components/Canvas/ImageObject.tsx
+++ b/src/components/Canvas/ImageObject.tsx
@@ -6,6 +6,8 @@ import { getImage } from "../../lib/imageCache";
 import { useColorScheme } from "../../hooks/useColorScheme";
 import { selectionHandlers, type KonvaObjectProps } from "./konvaObjectProps";
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
+import { rotatedGroupTransform } from "./rotatedGroupTransform";
+import { isAxisSwapped, objectRotation } from "../../registry/rotation";
 
 type ImageLabelObject = Extract<LabelObject, { type: "image" }>;
 type Props = Omit<KonvaObjectProps, "obj"> & { obj: ImageLabelObject };
@@ -38,10 +40,19 @@ export function ImageObject({
   const x = offsetX + dotsToPx(obj.x, scale, dpmm);
   const y = offsetY + dotsToPx(obj.y, scale, dpmm);
 
+  // Only inline cached (editable) images bake a rotation; rawGf verbatim and
+  // storedAs recall (^XG) can't turn, so they stay upright, matching the emit.
+  const rotatable = !!cached && !p.storedAs && !p.rawGf;
+  const rotation = rotatable ? objectRotation(p) : "N";
+  const swap = isAxisSwapped(rotation);
+
   // Publish the rendered footprint (dots) for align/distribute; height tracks
-  // the aspect-locked PNG size, not the stale heightDots prop.
-  const footprintWDots = pxToDots(w, scale, dpmm);
-  const footprintHDots = pxToDots(h, scale, dpmm);
+  // the aspect-locked PNG size, not the stale heightDots prop. Store the
+  // already-rotated footprint (axes swapped on R/B) so bounds/selection match.
+  const uprightWDots = pxToDots(w, scale, dpmm);
+  const uprightHDots = pxToDots(h, scale, dpmm);
+  const footprintWDots = swap ? uprightHDots : uprightWDots;
+  const footprintHDots = swap ? uprightWDots : uprightHDots;
   useEffect(() => {
     // Footprint dropped to zero (e.g. content cleared): drop the stale entry.
     if (footprintWDots <= 0 || footprintHDots <= 0) {
@@ -81,21 +92,31 @@ export function ImageObject({
   const handleDragEnd = dragHandlers?.onDragEnd;
 
   if (htmlImg && cached) {
+    // bwip-style rotation: the bitmap draws upright inside an inner Group whose
+    // rotatedGroupTransform places it for R/I/B; the outer Group keeps the
+    // object's x/y and interaction (matches BarcodeObject).
+    const innerTr = rotatedGroupTransform(rotation, w, h);
     return (
-      <KImage
+      <Group
         id={obj.id}
         x={x}
         y={y}
-        image={htmlImg}
-        width={w}
-        height={h}
-        stroke={isSelected ? colors.selection : undefined}
-        strokeWidth={isSelected ? 2 : 0}
         draggable={!obj.locked}
         {...selectionHandlers(onSelect)}
         onDragMove={handleDragMove}
         onDragEnd={handleDragEnd}
-      />
+      >
+        <Group x={innerTr.x} y={innerTr.y} rotation={innerTr.rotation}>
+          <KImage
+            image={htmlImg}
+            width={w}
+            height={h}
+            stroke={isSelected ? colors.selection : undefined}
+            strokeWidth={isSelected ? 2 : 0}
+            strokeScaleEnabled={false}
+          />
+        </Group>
+      </Group>
     );
   }
 

--- a/src/components/Canvas/ImageObject.tsx
+++ b/src/components/Canvas/ImageObject.tsx
@@ -40,8 +40,8 @@ export function ImageObject({
   const x = offsetX + dotsToPx(obj.x, scale, dpmm);
   const y = offsetY + dotsToPx(obj.y, scale, dpmm);
 
-  // Only inline cached (editable) images bake a rotation; rawGf verbatim and
-  // storedAs recall (^XG) can't turn, so they stay upright, matching the emit.
+  // Rotatable only for an inline cached bitmap (see isImageRotatable); reuse
+  // the `cached` lookup already made above.
   const rotatable = !!cached && !p.storedAs && !p.rawGf;
   const rotation = rotatable ? objectRotation(p) : "N";
   const swap = isAxisSwapped(rotation);

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -41,6 +41,7 @@ import { GuideLines } from "./GuideLines";
 import { Ruler, RULER_SIZE } from "./Ruler";
 import { SHAPE_PRIMITIVE_TYPES } from "../../registry";
 import type { LeafObject } from "../../registry";
+import { isImageRotatable, type ImageProps } from "../../registry/image";
 import { convertPositionType } from "../../lib/positionConvert";
 import { addableGroupsFor } from "../Palette/paletteGroups";
 import { resolveAddable, type AddableEntry } from "../../registry/palettePresets";
@@ -68,6 +69,7 @@ import { isShapeToggleable, canToggleShapeMode, oppositeShapeMode, toggleShapeMo
 import {
   getStepRotation,
   nextZplRotation,
+  objectRotation,
 } from "../../registry/rotation";
 import { CanvasContextMenu } from "./CanvasContextMenu";
 import { buildContextMenu, type MenuSection } from "./canvasActions";
@@ -836,7 +838,15 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const singleSelected = selectedIds.length === 1
     ? objects.find((o) => o.id === selectedIds[0]) ?? null
     : null;
-  const stepRotation = singleSelected ? getStepRotation(singleSelected) : null;
+  // Only an inline cached bitmap can actually turn (storedAs/rawGf emit and
+  // render upright), so gate the rotate affordance on that, not on the presence
+  // of a rotation prop: pre-feature saves omit it, and objectRotation defaults
+  // a rotatable image to 'N' so the button still shows.
+  const stepRotation = !singleSelected
+    ? null
+    : singleSelected.type === "image"
+      ? (isImageRotatable(singleSelected.props as ImageProps) ? objectRotation(singleSelected.props) : null)
+      : getStepRotation(singleSelected);
   // Shape primitives get the single-rotate button too, not only via a group.
   const singleShapeRotatable =
     !!singleSelected && !isGroup(singleSelected) && SHAPE_PRIMITIVE_TYPES.has(singleSelected.type);

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -838,10 +838,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const singleSelected = selectedIds.length === 1
     ? objects.find((o) => o.id === selectedIds[0]) ?? null
     : null;
-  // Only an inline cached bitmap can actually turn (storedAs/rawGf emit and
-  // render upright), so gate the rotate affordance on that, not on the presence
-  // of a rotation prop: pre-feature saves omit it, and objectRotation defaults
-  // a rotatable image to 'N' so the button still shows.
+  // Gate the image rotate button on isImageRotatable, not on a rotation prop:
+  // pre-feature saves omit it, and objectRotation defaults a rotatable image to
+  // 'N' so the button still shows.
   const stepRotation = !singleSelected
     ? null
     : singleSelected.type === "image"

--- a/src/lib/groupRotation.ts
+++ b/src/lib/groupRotation.ts
@@ -85,9 +85,11 @@ function leafChanges(
     return { x: r.x, y: r.y, props: { width: r.width, height: r.height } };
   }
 
-  // Symbol / image: footprint can't turn (Zebra rotates only the symbol glyph,
-  // images not at all), so keep w x h and just reposition by the centre. Odd
-  // dims can round here, but that's isolated, not a per-step accumulation.
+  // Symbol / image: footprint can't turn via a group here (symbol rotates only
+  // the glyph; image group-rotation is a follow-up), so keep w x h and just
+  // reposition by the centre. Symbol advances its glyph rotation; image keeps
+  // its own single-object rotation prop untouched. Odd dims can round here,
+  // but that's isolated, not a per-step accumulation.
   if (leaf.type === "symbol" || leaf.type === "image") {
     const b = objectBoundsDots(leaf, ctx);
     const centre = rotateAbout({ x: b.x + b.width / 2, y: b.y + b.height / 2 }, pivot, steps);

--- a/src/lib/imageToZpl.ts
+++ b/src/lib/imageToZpl.ts
@@ -2,87 +2,105 @@
  * Convert a raster image to ZPL ^GFA (Graphic Field ASCII hex) command.
  *
  * Process:
- * 1. Draw image into a canvas at the target dot resolution
+ * 1. Draw image into a canvas at the target dot resolution (rotation baked in)
  * 2. Convert to 1-bit monochrome (threshold)
  * 3. Encode as hex bytes (MSB first, left-to-right)
  * 4. Emit ^GFA,{totalBytes},{totalBytes},{bytesPerRow},{hexData}
  */
+import { isAxisSwapped, type ZplRotation } from '../registry/rotation';
 
 export interface GfaResult {
   /** Complete ^GFA command string */
   zpl: string;
-  /** Width in dots */
+  /** Emitted (byte-padded) width in dots */
   widthDots: number;
-  /** Height in dots */
+  /** Emitted height in dots */
   heightDots: number;
+}
+
+/** Draw a loaded raster into a mono ^GFA. The single encoder shared by the sync
+ *  (toZPL) and async (panel) paths so their pixel/threshold/packing logic can't
+ *  drift. `^GF` has no orientation letter, so a rotated image ships rotated
+ *  bytes: the draw is turned into a canvas whose axes swap on R/B, matching the
+ *  Konva rotatedGroupTransform the canvas shows. */
+export function rasterToGfa(
+  img: CanvasImageSource & { naturalWidth: number; naturalHeight: number },
+  widthDots: number,
+  threshold: number,
+  rotation: ZplRotation = 'N',
+): GfaResult {
+  const aspect = img.naturalHeight / img.naturalWidth;
+  const uprightH = Math.max(1, Math.round(widthDots * aspect));
+  const swap = isAxisSwapped(rotation);
+  const outW = swap ? uprightH : widthDots;
+  const outH = swap ? widthDots : uprightH;
+
+  const bytesPerRow = Math.ceil(outW / 8);
+  const paddedWidth = bytesPerRow * 8;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = paddedWidth;
+  canvas.height = outH;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not get 2d context');
+
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, paddedWidth, outH);
+
+  ctx.save();
+  switch (rotation) {
+    case 'R': ctx.translate(uprightH, 0); ctx.rotate(Math.PI / 2); break;
+    case 'I': ctx.translate(widthDots, uprightH); ctx.rotate(Math.PI); break;
+    case 'B': ctx.translate(0, widthDots); ctx.rotate(-Math.PI / 2); break;
+  }
+  ctx.drawImage(img, 0, 0, widthDots, uprightH);
+  ctx.restore();
+
+  const pixels = ctx.getImageData(0, 0, paddedWidth, outH).data;
+  const totalBytes = bytesPerRow * outH;
+  const hexChars: string[] = [];
+  for (let row = 0; row < outH; row++) {
+    for (let byteIdx = 0; byteIdx < bytesPerRow; byteIdx++) {
+      let byte = 0;
+      for (let bit = 0; bit < 8; bit++) {
+        const px = byteIdx * 8 + bit;
+        const idx = (row * paddedWidth + px) * 4;
+        // Luminance (BT.601); 1 = black dot in ZPL. Padding stays white.
+        const lum = 0.299 * (pixels[idx] ?? 255) + 0.587 * (pixels[idx + 1] ?? 255) + 0.114 * (pixels[idx + 2] ?? 255);
+        if (lum < threshold) byte |= 0x80 >> bit;
+      }
+      hexChars.push(byte.toString(16).toUpperCase().padStart(2, '0'));
+    }
+  }
+
+  return {
+    zpl: `^GFA,${totalBytes},${totalBytes},${bytesPerRow},${hexChars.join('')}`,
+    widthDots: paddedWidth,
+    heightDots: outH,
+  };
 }
 
 /**
  * @param dataUrl   The image as a data-URL
  * @param widthDots Target width in dots (height derived from aspect ratio)
- * @param threshold Luminance threshold 0–255 for black (default 128)
+ * @param threshold Luminance threshold 0-255 for black (default 128)
+ * @param rotation  Baked-in orientation (default 'N')
  */
 export function imageToGFA(
   dataUrl: string,
   widthDots: number,
   threshold = 128,
+  rotation: ZplRotation = 'N',
 ): Promise<GfaResult> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => {
-      const aspect = img.naturalHeight / img.naturalWidth;
-      const heightDots = Math.max(1, Math.round(widthDots * aspect));
-
-      // bytesPerRow must be a whole number (width padded to 8-bit boundary)
-      const bytesPerRow = Math.ceil(widthDots / 8);
-      const paddedWidth = bytesPerRow * 8;
-
-      const canvas = document.createElement("canvas");
-      canvas.width = paddedWidth;
-      canvas.height = heightDots;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) throw new Error("Could not get 2d context");
-
-      // White background (ZPL: 0 = white)
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(0, 0, paddedWidth, heightDots);
-
-      // Draw image scaled to target size
-      ctx.drawImage(img, 0, 0, widthDots, heightDots);
-
-      const imageData = ctx.getImageData(0, 0, paddedWidth, heightDots);
-      const pixels = imageData.data; // RGBA
-
-      const totalBytes = bytesPerRow * heightDots;
-      const hexChars: string[] = [];
-
-      for (let row = 0; row < heightDots; row++) {
-        for (let byteIdx = 0; byteIdx < bytesPerRow; byteIdx++) {
-          let byte = 0;
-          for (let bit = 0; bit < 8; bit++) {
-            const px = byteIdx * 8 + bit;
-            const idx = (row * paddedWidth + px) * 4;
-            const r = pixels[idx] ?? 0;
-            const g = pixels[idx + 1] ?? 0;
-            const b = pixels[idx + 2] ?? 0;
-            // Luminance (BT.601)
-            const lum = 0.299 * r + 0.587 * g + 0.114 * b;
-            // In ZPL: 1 = black dot, 0 = white
-            if (lum < threshold) {
-              byte |= 0x80 >> bit;
-            }
-          }
-          hexChars.push(byte.toString(16).toUpperCase().padStart(2, "0"));
-        }
-      }
-
-      const hexData = hexChars.join("");
-      const zpl = `^GFA,${totalBytes},${totalBytes},${bytesPerRow},${hexData}`;
-
-      resolve({ zpl, widthDots: paddedWidth, heightDots });
+      // A 0-dimension decode that still fires onload would make aspect NaN and
+      // blow up the canvas; treat it like a load failure (gfaSync guards too).
+      if (!img.naturalWidth) { reject(new Error('Image decoded with zero width')); return; }
+      resolve(rasterToGfa(img, widthDots, threshold, rotation));
     };
-    img.onerror = () =>
-      reject(new Error("Failed to load image for GFA conversion"));
+    img.onerror = () => reject(new Error('Failed to load image for GFA conversion'));
     img.src = dataUrl;
   });
 }

--- a/src/lib/objectBounds.test.ts
+++ b/src/lib/objectBounds.test.ts
@@ -43,6 +43,20 @@ describe("objectBoundsDots", () => {
     expect(objectBoundsDots(cached, ctx(measured))).toEqual({ x: 1, y: 1, width: 120, height: 40 });
   });
 
+  it("image: a rotated field swaps the footprint axes (no measured)", () => {
+    const up = leaf("image", 0, 0, { imageId: "a", widthDots: 200, heightDots: 100, threshold: 128 } as never);
+    const rot = leaf("image", 0, 0, { imageId: "a", widthDots: 200, heightDots: 100, threshold: 128, rotation: "R" } as never);
+    expect(objectBoundsDots(up, ctx())).toEqual({ x: 0, y: 0, width: 200, height: 100 });
+    expect(objectBoundsDots(rot, ctx())).toEqual({ x: 0, y: 0, width: 100, height: 200 });
+  });
+
+  it("image: storedAs/rawGf ignore rotation (emit upright, so bounds don't swap)", () => {
+    const stored = leaf("image", 0, 0, { imageId: "a", widthDots: 200, heightDots: 100, threshold: 128, rotation: "R", storedAs: { device: "R", name: "L" } } as never);
+    const raw = leaf("image", 0, 0, { imageId: "a", widthDots: 200, heightDots: 100, threshold: 128, rotation: "R", rawGf: "^GFA,0,0,0," } as never);
+    expect(objectBoundsDots(stored, ctx())).toEqual({ x: 0, y: 0, width: 200, height: 100 });
+    expect(objectBoundsDots(raw, ctx())).toEqual({ x: 0, y: 0, width: 200, height: 100 });
+  });
+
   it("line: horizontal bbox uses thickness on thin axis", () => {
     const ln = leaf("line", 10, 50, { angle: 0, length: 200, thickness: 4, color: "B" });
     expect(objectBoundsDots(ln, ctx())).toEqual({ x: 10, y: 50, width: 200, height: 4 });

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -180,14 +180,16 @@ export function objectBoundsDots(obj: LabelObject, ctx: ObjectBoundsCtx): Boundi
     case "image": {
       const p = obj.props;
       // Cached PNGs derive height from aspect at render, so consult the measured
-      // cache first; fall back to heightDots, then a square from the width.
+      // cache first (already the rotated footprint the renderer published). The
+      // fallback rotates the upright prop dims itself for R/B.
       const m = ctx.measured?.get(obj.id);
-      return {
-        x: obj.x,
-        y: obj.y,
-        width: m?.width ?? p.widthDots,
-        height: m?.height ?? p.heightDots ?? p.widthDots,
-      };
+      if (m) return { x: obj.x, y: obj.y, width: m.width, height: m.height };
+      // storedAs/rawGf emit upright (can't re-encode), so don't swap their
+      // fallback footprint; only bakeable cached images turn. (Pure path: no
+      // cache check here, but a no-cache image is empty and inconsequential.)
+      const rot = p.storedAs || p.rawGf ? "N" : objectRotation(p);
+      const fp = rotatedFootprint(p.widthDots, p.heightDots ?? p.widthDots, rot);
+      return { x: obj.x, y: obj.y, width: fp.width, height: fp.height };
     }
     case "line":
       return lineBounds(obj);

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -184,9 +184,9 @@ export function objectBoundsDots(obj: LabelObject, ctx: ObjectBoundsCtx): Boundi
       // fallback rotates the upright prop dims itself for R/B.
       const m = ctx.measured?.get(obj.id);
       if (m) return { x: obj.x, y: obj.y, width: m.width, height: m.height };
-      // storedAs/rawGf emit upright (can't re-encode), so don't swap their
-      // fallback footprint; only bakeable cached images turn. (Pure path: no
-      // cache check here, but a no-cache image is empty and inconsequential.)
+      // storedAs/rawGf stay upright (rot='N'), so their fallback footprint isn't
+      // swapped. (Pure path: no cache check, but a no-cache image is empty and
+      // inconsequential.)
       const rot = p.storedAs || p.rawGf ? "N" : objectRotation(p);
       const fp = rotatedFootprint(p.widthDots, p.heightDots ?? p.widthDots, rot);
       return { x: obj.x, y: obj.y, width: fp.width, height: fp.height };

--- a/src/lib/spawn.test.ts
+++ b/src/lib/spawn.test.ts
@@ -11,16 +11,18 @@ describe('spawnRotationOverride', () => {
     expect(spawnRotationOverride('text', undefined, 90)).toEqual({ rotation: 'B' });
     expect(spawnRotationOverride('qrcode', undefined, 180)).toEqual({ rotation: 'I' });
     expect(spawnRotationOverride('text', undefined, 270)).toEqual({ rotation: 'R' });
+    // image is a step-rotation type too (bitmap baked), so it lands upright in
+    // a rotated view like the others.
+    expect(spawnRotationOverride('image', undefined, 90)).toEqual({ rotation: 'B' });
   });
 
   it('is a no-op in the unrotated view', () => {
     expect(spawnRotationOverride('text', undefined, 0)).toBeUndefined();
   });
 
-  it('leaves types without a reading direction alone', () => {
+  it('leaves shapes without a rotation prop alone', () => {
     expect(spawnRotationOverride('box', undefined, 90)).toBeUndefined();
     expect(spawnRotationOverride('line', undefined, 90)).toBeUndefined();
-    expect(spawnRotationOverride('image', undefined, 90)).toBeUndefined();
   });
 
   it('yields to an explicit rotation override', () => {

--- a/src/lib/spawn.ts
+++ b/src/lib/spawn.ts
@@ -5,10 +5,10 @@ import type { LabelConfig } from '../types/LabelConfig';
 import type { LabelObject } from '../types/Group';
 
 /** Props patch so a palette spawn lands upright in a rotated canvas view.
- *  Only step-rotation types (text, symbol, barcodes) qualify; shapes/lines/
- *  images have no reading direction. An explicit rotation in the caller's override wins.
- *  Shared by the store spawn and the drag ghost so the preview matches the
- *  dropped object. */
+ *  Only step-rotation types (text, symbol, barcodes, image) qualify; box/
+ *  ellipse/line have no rotation prop. An explicit rotation in the caller's
+ *  override wins. Shared by the store spawn and the drag ghost so the preview
+ *  matches the dropped object. */
 export function spawnRotationOverride(
   type: string,
   propsOverride: object | undefined,

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -1816,6 +1816,17 @@ describe('generateZPL — ^FT graphic anchors (bottom corner, spec p.205)', () =
     expect(zpl).not.toContain('^FT50,1069'); // not 70 + stale 999
   });
 
+  it('cached image ^FT: a 0-width (malformed) cache falls back, no Infinity anchor', () => {
+    // A malformed 0-width decode would make widthDots*(h/0) Infinity; the emit
+    // path must fall back to heightDots like the render path does.
+    putImage({ id: 'imgZero', name: 'z', dataUrl: 'data:,', width: 0, height: 50 });
+    const zpl = generateZPL(BASE_LABEL, mk('image',
+      { imageId: 'imgZero', widthDots: 120, heightDots: 80, threshold: 128, _gfaCache: '^GFA1,1,1,00' }));
+    expect(zpl).toContain('^FT50,150'); // 70 + heightDots 80
+    expect(zpl).not.toContain('Infinity');
+    expect(zpl).not.toContain('NaN');
+  });
+
   it('keeps a hand-authored ^FT reverse box + ^FR text as two FT objects and round-trips them', () => {
     // Spec-true reverse: the filled ^FT ^GB stays its own box and the ^FR text
     // stays a separate reverse text; neither is collapsed or rewritten to ^FO,

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -425,10 +425,9 @@ function shiftObjectsByHome(
       const b = objectBoundsDots(obj, ctx);
       let w = b.width;
       let h = b.height;
-      // Images emit a byte-padded ^GF width and an aspect-derived height (axes
-      // swapped on a baked R/B rotation); match toZPL via the shared helper so
-      // neither edge is dropped over the difference. Other graphics emit their
-      // footprint verbatim.
+      // Image emit dims differ from the footprint (byte-padded width, aspect
+      // height, R/B axis swap), so key the drop check off imageEmitDims like
+      // toZPL. Other graphics emit their footprint verbatim.
       if (obj.type === 'image') {
         const d = imageEmitDims(obj.props);
         w = d.width;

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -21,7 +21,7 @@ import { isGroup, walkObjects, type LabelObject, type LeafObject, type Page } fr
 import { isOverlayConsistent } from './zplOverlay/overlay';
 import { objectBoundsDots, type ObjectBoundsCtx } from './objectBounds';
 import { formatFontDownloadFromPath } from './customFonts';
-import { gfByteWidth, imageEmitHeight, type ImageProps } from '../registry/image';
+import { imageEmitDims, type ImageProps } from '../registry/image';
 import { formatStoragePath } from './storagePath';
 
 function formatDownloadObject(m: CustomFontMapping): string | undefined {
@@ -425,12 +425,14 @@ function shiftObjectsByHome(
       const b = objectBoundsDots(obj, ctx);
       let w = b.width;
       let h = b.height;
-      // Images emit a byte-padded ^GF width and an aspect-derived height; match
-      // those (the generator has no measured cache) so neither edge is dropped
-      // over the difference. Other graphics emit their footprint verbatim.
+      // Images emit a byte-padded ^GF width and an aspect-derived height (axes
+      // swapped on a baked R/B rotation); match toZPL via the shared helper so
+      // neither edge is dropped over the difference. Other graphics emit their
+      // footprint verbatim.
       if (obj.type === 'image') {
-        w = gfByteWidth(obj.props.widthDots);
-        h = imageEmitHeight(obj.props);
+        const d = imageEmitDims(obj.props);
+        w = d.width;
+        h = d.height;
       }
       const anchorX = (obj.fieldJustify === 'R' ? b.x + w : b.x) - homeX;
       const anchorY = b.y + h - homeY - top;

--- a/src/registry/image.panel.tsx
+++ b/src/registry/image.panel.tsx
@@ -16,6 +16,7 @@ import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 import { Tooltip } from '../components/ui/Tooltip';
 import { SectionCard, StaticSectionCard } from '../components/Properties/SectionCard';
 import { UnitNumberInput } from '../components/Properties/UnitNumberInput';
+import { RotationSelect } from '../components/Properties/RotationSelect';
 import { FieldLabel, ZplCmd } from '../components/Properties/ZplCmd';
 import { Select } from '../components/ui/Select';
 import type { ImageProps } from './image';
@@ -184,6 +185,17 @@ export const imagePanel: ObjectTypeUi<ImageProps> = {
             />
             <span className="text-[10px] text-muted font-mono text-right">{p.threshold}</span>
           </div>
+
+          {/* Rotation only for inline cached bitmaps: ^GF has no orientation
+              letter, so it's baked into the emitted bytes. storedAs (^XG recall)
+              and opaque rawGf can't be re-encoded, so the control is hidden. */}
+          {cached && !p.storedAs && (
+            <RotationSelect
+              value={p.rotation ?? 'N'}
+              onChange={(rotation) => onChange({ rotation })}
+              zplCmd="^GF"
+            />
+          )}
 
           {/* Printer storage (~DY + ^XG). Section label + info icon are
               always visible so the feature is discoverable in both states;

--- a/src/registry/image.panel.tsx
+++ b/src/registry/image.panel.tsx
@@ -19,7 +19,7 @@ import { UnitNumberInput } from '../components/Properties/UnitNumberInput';
 import { RotationSelect } from '../components/Properties/RotationSelect';
 import { FieldLabel, ZplCmd } from '../components/Properties/ZplCmd';
 import { Select } from '../components/ui/Select';
-import type { ImageProps } from './image';
+import { isImageRotatable, type ImageProps } from './image';
 
 export const imagePanel: ObjectTypeUi<ImageProps> = {
   PropertiesPanel: ({ obj, onChange }) => {
@@ -186,10 +186,9 @@ export const imagePanel: ObjectTypeUi<ImageProps> = {
             <span className="text-[10px] text-muted font-mono text-right">{p.threshold}</span>
           </div>
 
-          {/* Rotation only for inline cached bitmaps: ^GF has no orientation
-              letter, so it's baked into the emitted bytes. storedAs (^XG recall)
-              and opaque rawGf can't be re-encoded, so the control is hidden. */}
-          {cached && !p.storedAs && (
+          {/* Rotation control only for a rotatable inline bitmap; storedAs/rawGf
+              emit upright (isImageRotatable is the single gate). */}
+          {isImageRotatable(p) && (
             <RotationSelect
               value={p.rotation ?? 'N'}
               onChange={(rotation) => onChange({ rotation })}

--- a/src/registry/image.ts
+++ b/src/registry/image.ts
@@ -2,6 +2,8 @@ import type { ObjectTypeCore } from '../types/ObjectType';
 import { graphicFieldPos } from './zplHelpers';
 import { getImage } from '../lib/imageCache';
 import { formatStoragePath } from '../lib/storagePath';
+import { rasterToGfa } from '../lib/imageToZpl';
+import { isAxisSwapped, objectRotation, type ZplRotation } from './rotation';
 
 /** ^GF rows are byte-packed, so the emitted (and re-parsed) width is the next
  *  multiple of 8. Shared by the emitter and the home-shift drop check so a
@@ -16,14 +18,39 @@ export function gfByteWidth(widthDots: number): number {
  *  the emitter and the home-shift drop check so the ^FT bottom anchor agrees. */
 export function imageEmitHeight(p: ImageProps): number {
   const cached = getImage(p.imageId);
+  // max(1,…) mirrors rasterToGfa's clamp so the anchor footprint can't diverge
+  // from the emitted GRF at an extreme aspect (widthDots*aspect rounding to 0).
   return cached
-    ? Math.round(p.widthDots * (cached.height / cached.width))
+    ? Math.max(1, Math.round(p.widthDots * (cached.height / cached.width)))
     : p.heightDots ?? p.widthDots;
+}
+
+/** An image rotates only when it's an inline cached bitmap: ^XG recall and
+ *  opaque rawGf can't be re-encoded. The single predicate for "this instance
+ *  turns", so the rotate button, emit footprint, and canvas can't disagree. */
+export function isImageRotatable(p: ImageProps): boolean {
+  return !!getImage(p.imageId) && !p.storedAs && !p.rawGf;
+}
+
+/** Emitted (byte-padded) footprint of the image field, axes swapped on a baked
+ *  R/B rotation. Shared by toZPL and the generator's home-shift drop check so
+ *  the two can't disagree on the anchor footprint. */
+export function imageEmitDims(p: ImageProps): { width: number; height: number } {
+  if (isImageRotatable(p) && isAxisSwapped(objectRotation(p))) {
+    return { width: gfByteWidth(imageEmitHeight(p)), height: p.widthDots };
+  }
+  return { width: gfByteWidth(p.widthDots), height: imageEmitHeight(p) };
 }
 
 export interface ImageProps {
   /** ID into the image cache */
   imageId: string;
+  /** 90-degree orientation. `^GF` has no orientation letter, so a non-N
+   *  rotation is baked into the emitted bitmap (see toZPL); the canvas shows it
+   *  via rotatedGroupTransform. Only cached (editable) images honour it.
+   *  Optional: designs saved before image rotation existed omit it (read as
+   *  'N' via objectRotation). New images seed it from defaultProps. */
+  rotation?: ZplRotation;
   /** Target width in dots (height derived from aspect ratio when a cached
    *  PNG is available; falls back to `heightDots` for recall-only
    *  placeholders). */
@@ -58,46 +85,14 @@ export interface ImageProps {
   };
 }
 
-/** Synchronously generate ^GFA using a blocking canvas (for toZPL). */
-function gfaSync(dataUrl: string, widthDots: number, threshold: number): string {
+/** Synchronously generate ^GFA using a blocking canvas (for toZPL), rotation
+ *  baked in. Shares the encoder with the async panel path via rasterToGfa. */
+function gfaSync(dataUrl: string, widthDots: number, threshold: number, rotation: ZplRotation): string {
   const img = new Image();
   // data-URL loads are synchronous on a freshly-created Image.
   img.src = dataUrl;
   if (!img.complete || !img.naturalWidth) return '';
-
-  const aspect = img.naturalHeight / img.naturalWidth;
-  const heightDots = Math.max(1, Math.round(widthDots * aspect));
-  const bytesPerRow = Math.ceil(widthDots / 8);
-  const paddedWidth = bytesPerRow * 8;
-
-  const canvas = document.createElement('canvas');
-  canvas.width = paddedWidth;
-  canvas.height = heightDots;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) throw new Error('Could not get 2d context');
-
-  ctx.fillStyle = '#ffffff';
-  ctx.fillRect(0, 0, paddedWidth, heightDots);
-  ctx.drawImage(img, 0, 0, widthDots, heightDots);
-
-  const pixels = ctx.getImageData(0, 0, paddedWidth, heightDots).data;
-  const totalBytes = bytesPerRow * heightDots;
-  const hexChars: string[] = [];
-
-  for (let row = 0; row < heightDots; row++) {
-    for (let byteIdx = 0; byteIdx < bytesPerRow; byteIdx++) {
-      let byte = 0;
-      for (let bit = 0; bit < 8; bit++) {
-        const px = byteIdx * 8 + bit;
-        const idx = (row * paddedWidth + px) * 4;
-        const lum = 0.299 * (pixels[idx] ?? 255) + 0.587 * (pixels[idx + 1] ?? 255) + 0.114 * (pixels[idx + 2] ?? 255);
-        if (lum < threshold) byte |= (0x80 >> bit);
-      }
-      hexChars.push(byte.toString(16).toUpperCase().padStart(2, '0'));
-    }
-  }
-
-  return `^GFA,${totalBytes},${totalBytes},${bytesPerRow},${hexChars.join('')}`;
+  return rasterToGfa(img, widthDots, threshold, rotation).zpl;
 }
 
 export const image: ObjectTypeCore<ImageProps> = {
@@ -109,6 +104,7 @@ export const image: ObjectTypeCore<ImageProps> = {
     imageId: '',
     widthDots: 200,
     threshold: 128,
+    rotation: 'N',
   },
   defaultSize: { width: 200, height: 200 },
 
@@ -159,9 +155,11 @@ export const image: ObjectTypeCore<ImageProps> = {
     const p = obj.props;
     const cached = getImage(p.imageId);
     // ^FT anchors the graphic's bottom-left (spec p.205); right-justified ^FT
-    // keys its x off the byte-padded ^GF width. Both via shared helpers so the
-    // home-shift drop check agrees. ^FO ignores the footprint.
-    const anchor = graphicFieldPos(obj, gfByteWidth(p.widthDots), imageEmitHeight(p));
+    // keys its x off the byte-padded ^GF width. imageEmitDims applies the R/B
+    // axis swap (cached only), and the same helper feeds the home-shift drop
+    // check so the two agree. ^FO ignores the footprint.
+    const d = imageEmitDims(p);
+    const anchor = graphicFieldPos(obj, d.width, d.height);
     // Opaque graphic: re-emit the original ^GF verbatim at the (possibly moved)
     // field position. The bytes were never decoded, so there's nothing to regen.
     if (p.rawGf) return `${anchor}${p.rawGf}^FS`;
@@ -173,8 +171,12 @@ export const image: ObjectTypeCore<ImageProps> = {
       return `${anchor}^XG${formatStoragePath(p.storedAs, true)},1,1^FS`;
     }
     if (!cached) return `${anchor}^FD^FS`;
-    // Use cached GFA if available, otherwise generate synchronously
-    const gfa = p._gfaCache || gfaSync(cached.dataUrl, p.widthDots, p.threshold);
+    // Cached: bake the rotation into the bytes (^GF has no orientation letter).
+    // The cache is always upright, so a rotated field regenerates fresh here.
+    const rot = objectRotation(p);
+    const gfa = rot === 'N'
+      ? (p._gfaCache || gfaSync(cached.dataUrl, p.widthDots, p.threshold, 'N'))
+      : gfaSync(cached.dataUrl, p.widthDots, p.threshold, rot);
     return `${anchor}${gfa}^FS`;
   },
 };

--- a/src/registry/image.ts
+++ b/src/registry/image.ts
@@ -20,7 +20,8 @@ export function imageEmitHeight(p: ImageProps): number {
   const cached = getImage(p.imageId);
   // max(1,…) mirrors rasterToGfa's clamp so the anchor footprint can't diverge
   // from the emitted GRF at an extreme aspect (widthDots*aspect rounding to 0).
-  return cached
+  // width>0 guards a malformed 0-width decode, matching the render path.
+  return cached && cached.width > 0
     ? Math.max(1, Math.round(p.widthDots * (cached.height / cached.width)))
     : p.heightDots ?? p.widthDots;
 }
@@ -171,8 +172,8 @@ export const image: ObjectTypeCore<ImageProps> = {
       return `${anchor}^XG${formatStoragePath(p.storedAs, true)},1,1^FS`;
     }
     if (!cached) return `${anchor}^FD^FS`;
-    // Cached: bake the rotation into the bytes (^GF has no orientation letter).
-    // The cache is always upright, so a rotated field regenerates fresh here.
+    // _gfaCache holds the upright bytes, so a rotated field regenerates fresh
+    // (rasterToGfa bakes the rotation in).
     const rot = objectRotation(p);
     const gfa = rot === 'N'
       ? (p._gfaCache || gfaSync(cached.dataUrl, p.widthDots, p.threshold, 'N'))

--- a/src/registry/rotation.ts
+++ b/src/registry/rotation.ts
@@ -52,8 +52,8 @@ export function nextZplRotation(r: ZplRotation): ZplRotation {
 
 /**
  * Returns the object's step-rotation if it has one, else `null`. Step-rotation
- * objects (text, all barcodes) declare a `rotation: 'N'|'R'|'I'|'B'`
- * prop; box/ellipse/line/image do not, and groups carry no `props`
+ * objects (text, symbol, all barcodes, image) declare a `rotation:
+ * 'N'|'R'|'I'|'B'` prop; box/ellipse/line do not, and groups carry no `props`
  * at all (so the type-string check filters them out first). Lets callers
  * gate UI affordances (e.g. the canvas quick-rotate button) without
  * inspecting `props` shapes themselves.


### PR DESCRIPTION
Image joins the step-rotation types (rotation prop, rotate button + properties control). ^GF has no orientation letter, so the rotation is baked into the emitted bitmap via a shared rasterToGfa encoder (dedups gfaSync/imageToGFA); the canvas shows it via rotatedGroupTransform like barcodes. Only inline cached images rotate (isImageRotatable gates the button, emit footprint, canvas and bounds consistently); storedAs/rawGf stay upright. Group rotation of an image stays repositioning-only (follow-up).