### PR TITLE
ci: gate Rust with fmt, clippy, and cargo test on PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,59 @@
+name: Rust
+
+# Rust lives in src-tauri and is only compiled during a release build, so its
+# unit tests, clippy, and fmt never gated a PR. This runs them on every change
+# that touches the crate. Path-filtered so pure-frontend PRs don't pay the
+# (heavy) Tauri dependency compile.
+on:
+  pull_request:
+    branches: [main, prod]
+    paths: ['src-tauri/**', '.github/workflows/rust.yml']
+  push:
+    branches: [main, prod]
+    paths: ['src-tauri/**', '.github/workflows/rust.yml']
+
+defaults:
+  run:
+    working-directory: ./src-tauri
+
+jobs:
+  # Format check is platform-independent (rustfmt parses, doesn't compile), so
+  # run it once instead of per matrix platform.
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy-test:
+    name: clippy-test (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Windows covers the winspool RAW path (#[cfg(windows)] in print.rs);
+        # Linux covers the libcups + Secret Service + USB ioctl paths.
+        platform: [ubuntu-24.04, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: install dependencies (ubuntu only)
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libcups2-dev libdbus-1-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
+
+      - run: cargo clippy --all-targets -- -D warnings
+
+      - run: cargo test

--- a/src-tauri/rustfmt.toml
+++ b/src-tauri/rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 2

--- a/src-tauri/src/credentials.rs
+++ b/src-tauri/src/credentials.rs
@@ -27,7 +27,9 @@ pub async fn credential_get(name: String) -> Result<Option<String>, String> {
 #[tauri::command]
 pub async fn credential_set(name: String, value: String) -> Result<(), String> {
   tokio::task::spawn_blocking(move || {
-    entry(&name)?.set_password(&value).map_err(|e| e.to_string())
+    entry(&name)?
+      .set_password(&value)
+      .map_err(|e| e.to_string())
   })
   .await
   .map_err(|e| e.to_string())?

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,19 +4,18 @@ mod usb;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  let builder = tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![
-      print::send_zpl_tcp,
-      print::query_zpl_tcp,
-      print::list_printers,
-      print::send_zpl_local,
-      usb::list_usb_printers,
-      usb::send_zpl_usb,
-      usb::setup_usb_access,
-      credentials::credential_get,
-      credentials::credential_set,
-      credentials::credential_delete
-    ]);
+  let builder = tauri::Builder::default().invoke_handler(tauri::generate_handler![
+    print::send_zpl_tcp,
+    print::query_zpl_tcp,
+    print::list_printers,
+    print::send_zpl_local,
+    usb::list_usb_printers,
+    usb::send_zpl_usb,
+    usb::setup_usb_access,
+    credentials::credential_get,
+    credentials::credential_set,
+    credentials::credential_delete
+  ]);
   // On the builder, not in setup(): config windows exist before the setup
   // closure runs, and window-state only restores/tracks via on_window_ready.
   #[cfg(desktop)]

--- a/src-tauri/src/print.rs
+++ b/src-tauri/src/print.rs
@@ -112,9 +112,13 @@ pub async fn query_zpl_tcp(host: String, port: u16, zpl: String) -> Result<TcpQu
     if tokio::time::Instant::now() >= deadline {
       return Err("read timed out".to_string());
     }
-    let wait = if body.is_empty() { FIRST_BYTE_TIMEOUT } else { IDLE_TIMEOUT };
+    let wait = if body.is_empty() {
+      FIRST_BYTE_TIMEOUT
+    } else {
+      IDLE_TIMEOUT
+    };
     match timeout(wait, stream.read(&mut buf)).await {
-      Ok(Ok(0)) => break,          // printer closed the connection
+      Ok(Ok(0)) => break, // printer closed the connection
       Ok(Ok(n)) => {
         if body.len() + n > MAX_RESPONSE_BYTES {
           return Err("response too large".to_string());
@@ -123,7 +127,7 @@ pub async fn query_zpl_tcp(host: String, port: u16, zpl: String) -> Result<TcpQu
       }
       Ok(Err(e)) => return Err(e.to_string()),
       Err(_) if body.is_empty() => return Err("no response from printer".to_string()),
-      Err(_) => break,             // idle gap after data = end of reply
+      Err(_) => break, // idle gap after data = end of reply
     }
   }
   // Covers a close-without-reply (read 0 on the first pass): print-only
@@ -132,7 +136,9 @@ pub async fn query_zpl_tcp(host: String, port: u16, zpl: String) -> Result<TcpQu
     return Err("no response from printer".to_string());
   }
   // ~DY payloads are ASCII (ZB64); lossy keeps any stray control bytes benign.
-  Ok(TcpQueryResult::Data { body: String::from_utf8_lossy(&body).into_owned() })
+  Ok(TcpQueryResult::Data {
+    body: String::from_utf8_lossy(&body).into_owned(),
+  })
 }
 
 /// One local OS print queue for the picker. driver_name/port_name let the UI
@@ -218,7 +224,10 @@ mod tests {
   }
 
   fn rt() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap()
+    tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .unwrap()
   }
 
   #[test]
@@ -229,10 +238,14 @@ mod tests {
       let server = tokio::spawn(async move {
         let (mut sock, _) = listener.accept().await.unwrap();
         let mut buf = Vec::new();
-        tokio::io::AsyncReadExt::read_to_end(&mut sock, &mut buf).await.unwrap();
+        tokio::io::AsyncReadExt::read_to_end(&mut sock, &mut buf)
+          .await
+          .unwrap();
         buf
       });
-      let res = send_zpl_tcp("127.0.0.1".into(), port, "^XA^FDx^FS^XZ".into()).await.unwrap();
+      let res = send_zpl_tcp("127.0.0.1".into(), port, "^XA^FDx^FS^XZ".into())
+        .await
+        .unwrap();
       assert!(matches!(res, TcpSendResult::Sent));
       assert_eq!(server.await.unwrap(), b"^XA^FDx^FS^XZ");
     });
@@ -247,11 +260,16 @@ mod tests {
         let (mut sock, _) = listener.accept().await.unwrap();
         let mut buf = [0u8; 1024];
         let _ = sock.read(&mut buf).await.unwrap();
-        sock.write_all(b"~DYPRE,A,G,4,2,:B64:gAE=:AAAA").await.unwrap();
+        sock
+          .write_all(b"~DYPRE,A,G,4,2,:B64:gAE=:AAAA")
+          .await
+          .unwrap();
         // Keep the socket open: the client must end on the idle gap, not FIN.
         tokio::time::sleep(Duration::from_secs(5)).await;
       });
-      let res = query_zpl_tcp("127.0.0.1".into(), port, "^XA^HYR:PRE.GRF^XZ".into()).await.unwrap();
+      let res = query_zpl_tcp("127.0.0.1".into(), port, "^XA^HYR:PRE.GRF^XZ".into())
+        .await
+        .unwrap();
       match res {
         TcpQueryResult::Data { body } => assert!(body.starts_with("~DYPRE,A,G,4,2,")),
         _ => panic!("expected data"),
@@ -282,7 +300,9 @@ mod tests {
       let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
       let port = listener.local_addr().unwrap().port();
       drop(listener);
-      let res = send_zpl_tcp("127.0.0.1".into(), port, "^XA^XZ".into()).await.unwrap();
+      let res = send_zpl_tcp("127.0.0.1".into(), port, "^XA^XZ".into())
+        .await
+        .unwrap();
       assert!(matches!(res, TcpSendResult::Refused));
     });
   }

--- a/src-tauri/src/usb.rs
+++ b/src-tauri/src/usb.rs
@@ -11,6 +11,9 @@ pub struct UsbPrinter {
   pub vendor_id: String, // lowercase hex, e.g. "0a5f"
 }
 
+// Linux-only: the usblp send is the sole producer, and non-Linux targets never
+// resolve a device, so the variants would read as dead code elsewhere.
+#[cfg(target_os = "linux")]
 #[derive(Debug, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum UsbSendResult {
@@ -27,7 +30,7 @@ pub async fn list_usb_printers() -> Result<Vec<UsbPrinter>, String> {
 
 #[cfg(not(target_os = "linux"))]
 #[tauri::command]
-pub async fn send_zpl_usb(_device: String, _zpl: String) -> Result<UsbSendResult, String> {
+pub async fn send_zpl_usb(_device: String, _zpl: String) -> Result<(), String> {
   Err("USB transport is Linux only".to_string())
 }
 
@@ -81,7 +84,9 @@ fn parse_printer(usb_dev_dir: &Path) -> Option<UsbPrinter> {
 // whose parent is the USB device carrying idVendor/idProduct/serial.
 #[cfg(target_os = "linux")]
 fn enumerate(usbmisc_root: &Path) -> Vec<(String, UsbPrinter)> {
-  let Ok(entries) = std::fs::read_dir(usbmisc_root) else { return Vec::new() };
+  let Ok(entries) = std::fs::read_dir(usbmisc_root) else {
+    return Vec::new();
+  };
   let mut out: Vec<(String, UsbPrinter)> = entries
     .flatten()
     .filter_map(|entry| {
@@ -92,13 +97,18 @@ fn enumerate(usbmisc_root: &Path) -> Vec<(String, UsbPrinter)> {
       // Attributes sit on the interface's parent device; fixtures flatten them
       // under "device", so probe there first, then the parent.
       let base = entry.path().join("device");
-      let dev_dir = if base.join("idVendor").exists() { base } else { base.join("..") };
+      let dev_dir = if base.join("idVendor").exists() {
+        base
+      } else {
+        base.join("..")
+      };
       parse_printer(&dev_dir).map(|p| (node, p))
     })
     .collect();
   // Zebra vendor first, then by name, so the label printer beats an office one.
   out.sort_by(|a, b| {
-    (a.1.vendor_id != ZEBRA_VENDOR_ID, &a.1.name).cmp(&(b.1.vendor_id != ZEBRA_VENDOR_ID, &b.1.name))
+    (a.1.vendor_id != ZEBRA_VENDOR_ID, &a.1.name)
+      .cmp(&(b.1.vendor_id != ZEBRA_VENDOR_ID, &b.1.name))
   });
   out
 }
@@ -146,7 +156,11 @@ pub async fn send_zpl_usb(device: String, zpl: String) -> Result<UsbSendResult, 
     return Err("payload too large".to_string());
   }
   tauri::async_runtime::spawn_blocking(move || {
-    let path = match resolve_node(Path::new("/sys/class/usbmisc"), Path::new("/dev/usb"), &device) {
+    let path = match resolve_node(
+      Path::new("/sys/class/usbmisc"),
+      Path::new("/dev/usb"),
+      &device,
+    ) {
       Ok(p) => p,
       Err(r) => return Ok(r),
     };
@@ -198,17 +212,19 @@ pub async fn setup_usb_access() -> Result<(), String> {
   .map_err(|e| e.to_string())?
 }
 
-#[cfg(test)]
+// The whole suite exercises the Linux usblp paths (enumerate/parse/resolve) and
+// the Linux-only UsbSendResult, so gate the module rather than each test.
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
   use super::*;
 
+  // Pins the wire format the frontend parses.
   #[test]
   fn send_result_serializes_with_kind_tag() {
     let json = serde_json::to_string(&UsbSendResult::PermissionDenied).unwrap();
     assert_eq!(json, r#"{"kind":"permission_denied"}"#);
   }
 
-  #[cfg(target_os = "linux")]
   #[test]
   fn enumerates_and_sorts_zebra_first() {
     use std::fs;
@@ -221,7 +237,13 @@ mod tests {
     ] {
       let dev = root.join(node).join("device");
       fs::create_dir_all(&dev).unwrap();
-      for (f, v) in [("idVendor", vid), ("idProduct", pid), ("serial", ser), ("manufacturer", man), ("product", prod)] {
+      for (f, v) in [
+        ("idVendor", vid),
+        ("idProduct", pid),
+        ("serial", ser),
+        ("manufacturer", man),
+        ("product", prod),
+      ] {
         fs::write(dev.join(f), format!("{v}\n")).unwrap();
       }
     }
@@ -232,14 +254,17 @@ mod tests {
     fs::remove_dir_all(&root).ok();
   }
 
-  #[cfg(target_os = "linux")]
   #[test]
   fn resolve_node_maps_missing_device_to_not_found() {
     use std::fs;
     let root = std::env::temp_dir().join(format!("zpl_resolve_{}", std::process::id()));
     let dev = root.join("lp0").join("device");
     fs::create_dir_all(&dev).unwrap();
-    for (f, v) in [("idVendor", "0a5f"), ("idProduct", "0166"), ("serial", "S2")] {
+    for (f, v) in [
+      ("idVendor", "0a5f"),
+      ("idProduct", "0166"),
+      ("serial", "S2"),
+    ] {
       fs::write(dev.join(f), format!("{v}\n")).unwrap();
     }
     let dev_root = root.join("dev");
@@ -253,7 +278,6 @@ mod tests {
     fs::remove_dir_all(&root).ok();
   }
 
-  #[cfg(target_os = "linux")]
   #[test]
   fn enumerates_via_device_parent_and_serialless_id() {
     use std::fs;
@@ -262,7 +286,12 @@ mod tests {
     // one level up (device/..) carries the attributes. Also omit serial.
     let node = root.join("lp0");
     fs::create_dir_all(node.join("device")).unwrap();
-    for (f, v) in [("idVendor", "0a5f"), ("idProduct", "0166"), ("manufacturer", "Zebra Technologies"), ("product", "ZD230")] {
+    for (f, v) in [
+      ("idVendor", "0a5f"),
+      ("idProduct", "0166"),
+      ("manufacturer", "Zebra Technologies"),
+      ("product", "ZD230"),
+    ] {
       fs::write(node.join(f), format!("{v}\n")).unwrap();
     }
     let out = enumerate(&root);
@@ -274,7 +303,6 @@ mod tests {
     fs::remove_dir_all(&root).ok();
   }
 
-  #[cfg(target_os = "linux")]
   #[test]
   fn empty_serial_falls_back_to_path_not_colliding_id() {
     use std::fs;
@@ -283,7 +311,11 @@ mod tests {
     fs::create_dir_all(&dev).unwrap();
     // A present-but-empty serial file must not yield "vid:pid:" (which would
     // collide across identical models); it falls back to the unique path.
-    for (f, v) in [("idVendor", "0a5f"), ("idProduct", "0166"), ("serial", "  \n")] {
+    for (f, v) in [
+      ("idVendor", "0a5f"),
+      ("idProduct", "0166"),
+      ("serial", "  \n"),
+    ] {
       fs::write(dev.join(f), v).unwrap();
     }
     let p = parse_printer(&dev).unwrap();
@@ -293,7 +325,6 @@ mod tests {
     fs::remove_dir_all(&dir).ok();
   }
 
-  #[cfg(target_os = "linux")]
   #[test]
   fn parses_printer_from_sysfs_dir() {
     use std::fs;


### PR DESCRIPTION
rustfmt.toml pins 2-space to match the existing style; usb: gate the Linux-only UsbSendResult so the winspool build has no dead variants.