### PR TITLE
fix(canvas): 2D-code resize under view rotation

### DIFF
--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -18,10 +18,9 @@ import {
   activeEdgesFromAnchorName,
   applyHeightSnap,
   applyModuleWidthSnap,
-  applyUniformModuleSnap,
   barcodeHeightReflowGeometry,
   barcodeMwReflowGeometry,
-  computeNewModules,
+  uniformReflowGeometry,
   pinAnchoredEdge,
   pinInactiveEdges,
   positionDidMove,
@@ -32,7 +31,9 @@ import {
   type BarcodeMwReflowStart,
   type BoundingBox,
   type TransformAnchor,
+  type UniformReflowStart,
 } from "../transformerGeometry";
+import { naturalRect, parentRect, stageRect } from "../nodeRect";
 import {
   committedUprightBarDots,
   modelPositionFromRenderedTopLeft,
@@ -52,75 +53,6 @@ import {
  *  this the user is presumed to have flicked past the object and we keep the
  *  previous box rather than collapsing it to a sliver. */
 const MIN_RESIZE_BOX_PX = 10;
-
-interface UniformResizeArgs {
-  obj: LeafObject;
-  spec: { name: string; min: number; max: number };
-  anchor: { nodeSize: number; modules: number; edges: ActiveEdgeFlags } | null;
-  startRect: { x: number; y: number; width: number; height: number } | null;
-  fallbackPos: { x: number; y: number };
-  sx: number;
-  sy: number;
-  objectsOffsetX: number;
-  labelOffsetY: number;
-  scale: number;
-  dpmm: number;
-}
-
-/** Pin the user-fixed corner via startRect + edges so the round-to-
- *  integer-modules on commit doesn't walk the anchor. */
-function commitUniformModuleResize({
-  obj,
-  spec,
-  anchor,
-  startRect,
-  fallbackPos,
-  sx,
-  sy,
-  objectsOffsetX,
-  labelOffsetY,
-  scale,
-  dpmm,
-}: UniformResizeArgs): ObjectChanges {
-  const current = (obj.props as unknown as Record<string, number>)[spec.name];
-  if (typeof current !== "number" || !(current > 0))
-    return { ...fallbackPos, props: {} };
-  const newModules = computeNewModules(
-    current,
-    Math.min(sx, sy),
-    spec.min,
-    spec.max,
-  );
-  const props = { [spec.name]: newModules };
-  if (!anchor || !startRect) return { ...fallbackPos, props };
-  const sizeRatio = newModules / current;
-  const newW = startRect.width * sizeRatio;
-  const newH = startRect.height * sizeRatio;
-  const renderedX = anchor.edges.left
-    ? startRect.x + startRect.width - newW
-    : startRect.x;
-  const renderedY = anchor.edges.top
-    ? startRect.y + startRect.height - newH
-    : startRect.y;
-  // Uniform resize scales both axes by sizeRatio (clamped via newModules), so an
-  // FT barcode's anchor inversion uses the committed post-resize bar size. For a
-  // QR the firmware shift scales with magnification, so pass the committed value
-  // (newModules) too, else the inverse uses the old shift and the code jumps.
-  // Pass undefined (not 0) when a dim isn't cached so the downstream nullish
-  // fallback applies instead of being defeated by a 0.
-  const cache = getMeasuredSnapshot().get(obj.id);
-  const uprightW = cache?.uprightBarWDots;
-  const uprightH = cache?.uprightBarHDots;
-  const model = modelPositionFromRenderedTopLeft(
-    obj,
-    pxToDots(renderedX - objectsOffsetX, scale, dpmm),
-    pxToDots(renderedY - labelOffsetY, scale, dpmm),
-    uprightW !== undefined ? uprightW * sizeRatio : undefined,
-    uprightH !== undefined ? uprightH * sizeRatio : undefined,
-    newModules,
-  );
-  return { x: model.x, y: model.y, props };
-}
 
 /** Pack a Konva clientRect into the SnapRect shape used by snap helpers. */
 function toSnapRect(
@@ -144,12 +76,7 @@ function captureOtherRects(
     if (o.id === excludeId) continue;
     const n = stage.findOne<Konva.Node>(`#${o.id}`);
     if (!n) continue;
-    const cr = n.getClientRect({
-      skipShadow: true,
-      skipStroke: true,
-      relativeTo: stage,
-    });
-    result.push(toSnapRect(o.id, cr));
+    result.push(toSnapRect(o.id, stageRect(n, stage)));
   }
   return result;
 }
@@ -263,14 +190,6 @@ export function useKonvaTransformer({
   // Snapshot of the other objects' bboxes at transform start. Other objects
   // can't move during a resize, so we avoid re-querying Konva on every tick.
   const othersSnapshotRef = useRef<SnapRect[]>([]);
-  // Stage-frame node rect at uniform-2D drag start; commit uses it to
-  // pin the anchor corner under rotated view too.
-  const uniformStartRectRef = useRef<{
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  } | null>(null);
   // Anchor name at drag start; commit skips grid-snap on inactive axes
   // so the opposite corner stays put.
   const activeEdgesRef = useRef<ActiveEdgeFlags | null>(null);
@@ -312,10 +231,10 @@ export function useKonvaTransformer({
     changed: boolean;
   } | null>(null);
 
-  // 1D barcode live reflow, both resize axes: the moduleWidth axis re-renders
-  // on each integer module crossing, the bar-height axis on each integer dot,
-  // so bars, HRI and text zone always draw at their true size instead of
-  // stretching the old bitmap until release.
+  // Barcode live reflow: re-renders on each integer crossing (module width,
+  // height dot, or magnification, per mode) so the bitmap always draws at its
+  // true size instead of stretching until release. The per-tick pin also
+  // stands in for boundBoxFunc's band snap, which breaks under rotation.
   const barcodeReflowRef = useRef<
     | (BarcodeMwReflowStart & {
         mode: "mw";
@@ -328,6 +247,17 @@ export function useKonvaTransformer({
         mode: "height";
         uprightW0: number;
         snapshot: { x: number; y: number; height: number };
+        changed: boolean;
+      })
+    | (UniformReflowStart & {
+        mode: "uniform";
+        propName: string;
+        // Captured at arm time like the 1D modes: the cache updates after each
+        // crossing's re-render, so a fresh read times the start-relative ratio
+        // would double-count from the second crossing on.
+        uprightW0?: number;
+        uprightH0?: number;
+        snapshot: { x: number; y: number; modules: number };
         changed: boolean;
       })
     | null
@@ -494,7 +424,6 @@ export function useKonvaTransformer({
     transformAnchorRef.current = null;
     transformStartBboxRef.current = null;
     othersSnapshotRef.current = [];
-    uniformStartRectRef.current = null;
     activeEdgesRef.current = null;
     liveReflowRef.current = null;
     shapeReflowRef.current = null;
@@ -544,11 +473,7 @@ export function useKonvaTransformer({
         // Group .height/.width return their attrs (0); without the rect
         // read the snap guards early-return on 0 and the drag drifts on
         // commit.
-        const rect = node.getClientRect({
-          skipTransform: true,
-          skipStroke: true,
-          skipShadow: true,
-        });
+        const rect = naturalRect(node);
         return {
           kind: "row",
           nodeHeight: rect.height,
@@ -559,50 +484,13 @@ export function useKonvaTransformer({
           rotation: objectRotation(obj.props),
         };
       }
-      const uniformProp = getEntry(obj.type)?.uniformScaleProp;
-      if (uniformProp) {
-        const rect = node.getClientRect({
-          skipTransform: true,
-          skipStroke: true,
-          skipShadow: true,
-        });
-        const modules = (obj.props as unknown as Record<string, number>)[
-          uniformProp.name
-        ];
-        const edges = activeEdgesRef.current;
-        if (
-          typeof modules === "number" &&
-          modules > 0 &&
-          rect.width > 0 &&
-          edges
-        ) {
-          uniformStartRectRef.current = node.getClientRect({
-            skipShadow: true,
-            skipStroke: true,
-            relativeTo: stageRef.current ?? undefined,
-          });
-          return {
-            kind: "uniformModule",
-            nodeSize: rect.width,
-            nodeHeight: rect.height,
-            modules,
-            min: uniformProp.min,
-            max: uniformProp.max,
-            edges,
-          };
-        }
-      }
       // Live moduleWidth snap for 1D barcodes, all rotations: quantise the
       // moduleWidth axis (screen width for N/I, screen height for R/B) so
       // overshoot is blocked and the anchored edge stays put, like N.
       if (BARCODE_1D_TYPES.has(obj.type)) {
         // Konva Group .width() returns its attr (0 here); the visible
         // bbox comes from the children via getClientRect.
-        const rect = node.getClientRect({
-          skipTransform: true,
-          skipStroke: true,
-          skipShadow: true,
-        });
+        const rect = naturalRect(node);
         return {
           kind: "moduleWidth",
           nodeWidth: rect.width,
@@ -686,11 +574,7 @@ export function useKonvaTransformer({
       } else if (!frameMode && (bp.blockWidth ?? 0) > 0 && viewRotation === 0) {
         // Glyph mode bakes on end: capture the start rect so commit can re-pin
         // the stable point after the font re-justifies.
-        glyphBlockStartRectRef.current = node.getClientRect({
-          relativeTo: stageRef.current ?? undefined,
-          skipStroke: true,
-          skipShadow: true,
-        });
+        glyphBlockStartRectRef.current = stageRect(node, stageRef.current);
       }
     }
     // Free-resize shapes reflow live (see onTransform): pause undo so the
@@ -760,6 +644,34 @@ export function useKonvaTransformer({
           };
           useLabelStore.temporal.getState().pause();
         }
+      }
+    }
+    // Uniform 2D (QR/Aztec/DataMatrix): arm the reflow so the per-tick pin,
+    // not boundBoxFunc, drives quantise and aspect (see the bail below).
+    const uniformProp = obj && !isGroup(obj) ? getEntry(obj.type)?.uniformScaleProp : undefined;
+    if (obj && uniformProp) {
+      const edges = activeEdgesRef.current;
+      const modules = (obj.props as unknown as Record<string, number>)[uniformProp.name];
+      const box = parentRect(node);
+      if (edges && typeof modules === "number" && modules > 0 && box.width > 0 && box.height > 0) {
+        const cache = getMeasuredSnapshot().get(singleId);
+        barcodeReflowRef.current = {
+          mode: "uniform",
+          edges,
+          modules0: modules,
+          min: uniformProp.min,
+          max: uniformProp.max,
+          leftX: box.x,
+          topY: box.y,
+          rightX: box.x + box.width,
+          bottomY: box.y + box.height,
+          propName: uniformProp.name,
+          uprightW0: cache?.uprightBarWDots,
+          uprightH0: cache?.uprightBarHDots,
+          snapshot: { x: obj.x, y: obj.y, modules },
+          changed: false,
+        };
+        useLabelStore.temporal.getState().pause();
       }
     }
   };
@@ -837,12 +749,48 @@ export function useKonvaTransformer({
     // adjacent module widths render at the same pixel width.
     const br = barcodeReflowRef.current;
     if (br) {
+      const natural = naturalRect(node);
+      // The FT anchor and QR firmware shift both scale with magnification, so
+      // the same inversion as the 1D modes keeps them consistent with the
+      // render.
+      if (br.mode === "uniform") {
+        const geo = uniformReflowGeometry(br, natural.width * sx, natural.height * sy);
+        if (!geo) return;
+        const modCurrent = (cur.props as unknown as Record<string, number>)[br.propName];
+        if (typeof modCurrent !== "number" || !(modCurrent > 0)) return;
+        const crossed = geo.modules !== modCurrent;
+        if (crossed) {
+          const ratio = geo.modules / br.modules0;
+          const model = modelPositionFromRenderedTopLeft(
+            cur,
+            pxToDots(geo.targetXPx - objectsOffsetX, scale, dpmm),
+            pxToDots(geo.targetYPx - labelOffsetY, scale, dpmm),
+            br.uprightW0 !== undefined ? br.uprightW0 * ratio : undefined,
+            br.uprightH0 !== undefined ? br.uprightH0 * ratio : undefined,
+            geo.modules,
+          );
+          flushSync(() => {
+            updateObject(id, {
+              x: model.x,
+              y: model.y,
+              props: { [br.propName]: geo.modules },
+            });
+          });
+          br.changed = true;
+        }
+        // Pin every tick; subtract the child render offset (QR draws off the
+        // group origin) so the rendered top-left lands on the target.
+        const rendered = crossed ? naturalRect(node) : natural;
+        const rx = rendered.width > 0 ? geo.linearW / rendered.width : 1;
+        const ry = rendered.height > 0 ? geo.linearH / rendered.height : 1;
+        node.scaleX(rx);
+        node.scaleY(ry);
+        node.x(geo.targetXPx - rendered.x * rx);
+        node.y(geo.targetYPx - rendered.y * ry);
+        transformerRef.current?.forceUpdate();
+        return;
+      }
       const swapped = isAxisSwapped(br.rotation);
-      const natural = node.getClientRect({
-        skipTransform: true,
-        skipStroke: true,
-        skipShadow: true,
-      });
       if (br.mode === "mw") {
         const mwCurrent = (cur.props as { moduleWidth?: number }).moduleWidth;
         if (typeof mwCurrent !== "number" || !(mwCurrent > 0)) return;
@@ -877,9 +825,7 @@ export function useKonvaTransformer({
         // The residual fits the re-rendered content into the linear frame (1
         // when pixels-per-module are exact). Only a crossing re-renders, so
         // mid-band `natural` is still the current rect.
-        const rendered = crossed
-          ? node.getClientRect({ skipTransform: true, skipStroke: true, skipShadow: true })
-          : natural;
+        const rendered = crossed ? naturalRect(node) : natural;
         const renderedExtent = swapped ? rendered.height : rendered.width;
         const residual = renderedExtent > 0 ? geo.linearExtentPx / renderedExtent : 1;
         node.scaleX(swapped ? 1 : residual);
@@ -978,6 +924,11 @@ export function useKonvaTransformer({
     // The text-block reflow re-pins from its own captured edges, so the snap /
     // inactive-edge pin below would fight it; skip entirely.
     if (liveReflowRef.current) return newBox;
+    // Uniform 2D bails too, INCLUDING forceAspectBox: its moved-edge inference
+    // reads the box position in the transformer frame, so it re-anchors on the
+    // wrong axis under view rotation (the mid-drag sideways walk). The per-tick
+    // pin is the sole aspect and band snap.
+    if (barcodeReflowRef.current?.mode === "uniform") return newBox;
     // Locked-circle reflow needs forceAspectBox so Konva keeps sx==sy; node and
     // reflow only agree when the bbox keeps its aspect. Snap/pin below is free-axis only.
     if (shapeReflowRef.current && isUniformScale) {
@@ -1018,7 +969,6 @@ export function useKonvaTransformer({
       transformAnchorRef.current,
     );
     bbox = applyModuleWidthSnap(oldBox, bbox, transformAnchorRef.current);
-    bbox = applyUniformModuleSnap(oldBox, bbox, transformAnchorRef.current);
     // Quantised types skip object-snap: a sub-module neighbour-pixel
     // alignment breaks the integer-module commit and the post-render
     // bitmap drifts off the anchor.
@@ -1081,6 +1031,22 @@ export function useKonvaTransformer({
       return;
     }
     const br = barcodeReflowRef.current;
+    if (br && br.mode === "uniform") {
+      const id = selectedIds[0];
+      const cur = id ? findObjectById(getCurrentObjects(), id) : undefined;
+      let commit: ReflowCommit = null;
+      if (br.changed && id && cur && !isGroup(cur)) {
+        // Per-tick writes already went through computeNewModules, so the final
+        // value is clamped; re-commit it as the single tracked change.
+        const modules = (cur.props as unknown as Record<string, number>)[br.propName];
+        commit = {
+          restore: { x: br.snapshot.x, y: br.snapshot.y, props: { [br.propName]: br.snapshot.modules } },
+          final: { x: cur.x, y: cur.y, props: { [br.propName]: modules } },
+        };
+      }
+      collapseReflowToOneEntry(id, commit);
+      return;
+    }
     if (br) {
       const id = selectedIds[0];
       const cur = id ? findObjectById(getCurrentObjects(), id) : undefined;
@@ -1214,42 +1180,14 @@ export function useKonvaTransformer({
     };
     const pos = { x: snapAxis("x"), y: snapAxis("y") };
     const entry = getEntry(obj.type);
-    if (entry?.uniformScaleProp) {
-      const uniformAnchor =
-        transformAnchorRef.current?.kind === "uniformModule"
-          ? transformAnchorRef.current
-          : null;
-      const update = commitUniformModuleResize({
-        obj,
-        spec: entry.uniformScaleProp,
-        anchor: uniformAnchor,
-        startRect: uniformStartRectRef.current,
-        fallbackPos: pos,
-        sx,
-        sy,
-        objectsOffsetX,
-        labelOffsetY,
-        scale,
-        dpmm,
-      });
-      updateObject(singleId, update);
-      cleanupTransformState();
-      return;
-    }
     const commit = entry?.commitTransform;
     if (commit) {
-      // uniformModule anchors short-circuit above; the row/moduleWidth
-      // commit context only narrows those two kinds.
-      const ctxAnchor =
-        transformAnchorRef.current?.kind === "uniformModule"
-          ? null
-          : transformAnchorRef.current;
       const propChanges = commit(obj, {
         sx,
         sy,
         snap,
         nodeHeight,
-        anchor: ctxAnchor,
+        anchor: transformAnchorRef.current,
         resizeMode: blockResizeModeRef.current,
       });
       const start = glyphBlockStartRectRef.current;
@@ -1278,11 +1216,7 @@ export function useKonvaTransformer({
           node.x(objectsOffsetX + dotsToPx(obj.x, scale, dpmm));
           node.y(labelOffsetY + dotsToPx(obj.y, scale, dpmm));
           flushSync(() => updateObject(singleId, { props: propChanges }));
-          const newRect = node.getClientRect({
-            relativeTo: stageRef.current ?? undefined,
-            skipStroke: true,
-            skipShadow: true,
-          });
+          const newRect = stageRect(node, stageRef.current);
           const edges = activeEdgesRef.current;
           const justify = fp.blockJustify ?? "L";
           const anchorArgs = { rotation: fp.rotation, justify, edges, centeredStacking: centeredScaling };

--- a/src/components/Canvas/nodeRect.test.ts
+++ b/src/components/Canvas/nodeRect.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import Konva from "konva";
+import { parentRect } from "./nodeRect";
+
+/** Mirrors the canvas structure: a rotation group (pivot at label center)
+ *  containing the object node, whose child renders at a local offset (like
+ *  QR's shift). Commit math runs in the rotation group's frame, so parentRect
+ *  must match that frame at every view rotation. */
+function buildTree(viewRotation: number) {
+  const cx = 200;
+  const cy = 150;
+  const root = new Konva.Group();
+  const rotationGroup = new Konva.Group({
+    x: cx,
+    y: cy,
+    offsetX: cx,
+    offsetY: cy,
+    rotation: viewRotation,
+  });
+  root.add(rotationGroup);
+  const node = new Konva.Group({ x: 80, y: 60 });
+  node.add(new Konva.Rect({ x: 0, y: 10, width: 40, height: 30 }));
+  rotationGroup.add(node);
+  return node;
+}
+
+const PARENT_FRAME_RECT = { x: 80, y: 70, width: 40, height: 30 };
+
+describe("parentRect", () => {
+  it("captures the node bbox in the parent frame at view rotation 0", () => {
+    expect(parentRect(buildTree(0))).toEqual(PARENT_FRAME_RECT);
+  });
+
+  it.each([90, 180, 270])(
+    "is invariant under view rotation %d (regression: rotated capture walked the 2D-code anchor)",
+    (rotation) => {
+      expect(parentRect(buildTree(rotation))).toEqual(PARENT_FRAME_RECT);
+    },
+  );
+});

--- a/src/components/Canvas/nodeRect.ts
+++ b/src/components/Canvas/nodeRect.ts
@@ -1,0 +1,37 @@
+import type Konva from "konva";
+
+/** Frame-named getClientRect wrappers: mixing frames is how the rotated-view
+ *  2D-resize anchor walked, so each capture names its coordinate frame. */
+
+export interface NodeRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Local-frame bbox (transform skipped), so it is independent of the live
+ *  drag scale. */
+export function naturalRect(node: Konva.Node): NodeRect {
+  return node.getClientRect({ skipTransform: true, skipStroke: true, skipShadow: true });
+}
+
+/** Parent-frame bbox: the frame node.x()/y() and the label offsets live in,
+ *  so commit/pin math is view-rotation-proof. */
+export function parentRect(node: Konva.Node): NodeRect {
+  return node.getClientRect({
+    skipShadow: true,
+    skipStroke: true,
+    relativeTo: node.getParent() ?? undefined,
+  });
+}
+
+/** Stage-frame bbox. Equals the parent frame only at view rotation 0, so
+ *  every consumer must be rotation-gated (or use parentRect). */
+export function stageRect(node: Konva.Node, stage: Konva.Stage | null): NodeRect {
+  return node.getClientRect({
+    skipShadow: true,
+    skipStroke: true,
+    relativeTo: stage ?? undefined,
+  });
+}

--- a/src/components/Canvas/transformerGeometry.test.ts
+++ b/src/components/Canvas/transformerGeometry.test.ts
@@ -5,9 +5,9 @@ import {
   forceAspectBox,
   applyHeightSnap,
   applyModuleWidthSnap,
-  applyUniformModuleSnap,
   barcodeHeightReflowGeometry,
   barcodeMwReflowGeometry,
+  uniformReflowGeometry,
   pinInactiveEdges,
   computeNewModules,
   activeEdgesFromAnchorName,
@@ -442,63 +442,72 @@ describe("applyModuleWidthSnap", () => {
   });
 });
 
-describe("applyUniformModuleSnap", () => {
-  const anchor = (edges: { left: boolean; right: boolean; top: boolean; bottom: boolean }) => ({
-    kind: "uniformModule" as const,
-    nodeSize: 100,
-    nodeHeight: 100,
-    modules: 4,
+describe("uniformReflowGeometry", () => {
+  const start = (edges: { left: boolean; right: boolean; top: boolean; bottom: boolean }) => ({
+    edges,
+    modules0: 4,
     min: 1,
     max: 10,
-    edges,
+    leftX: 50,
+    topY: 50,
+    rightX: 150,
+    bottomY: 150,
   });
-  const oldBox: BoundingBox = { x: 50, y: 50, width: 100, height: 100, rotation: 0 };
+  const E = (left: boolean, top: boolean) => ({ left, right: !left, top, bottom: !top });
 
-  it("snaps to whole-module square (bottom-right grab keeps top-left)", () => {
-    const a = anchor({ left: false, right: true, top: false, bottom: true });
-    const out = applyUniformModuleSnap(oldBox, { ...oldBox, width: 140, height: 140 }, a);
-    expect(out.width).toBe(150);
-    expect(out.height).toBe(150);
-    expect(out.x).toBe(50);
-    expect(out.y).toBe(50);
+  it("quantises to whole modules and keeps top-left on a bottom-right grab", () => {
+    const geo = uniformReflowGeometry(start(E(false, false)), 140, 140);
+    expect(geo).toEqual({ modules: 6, targetXPx: 50, targetYPx: 50, linearW: 150, linearH: 150 });
   });
 
   it("pins bottom-right when top-left was grabbed", () => {
-    const a = anchor({ left: true, right: false, top: true, bottom: false });
-    const out = applyUniformModuleSnap(
-      oldBox,
-      { x: 10, y: 10, width: 140, height: 140, rotation: 0 },
-      a,
+    const geo = uniformReflowGeometry(start(E(true, true)), 140, 140);
+    expect(geo?.targetXPx).toBe(150 - 150);
+    expect(geo?.targetYPx).toBe(150 - 150);
+    expect((geo?.targetXPx ?? 0) + (geo?.linearW ?? 0)).toBe(150);
+    expect((geo?.targetYPx ?? 0) + (geo?.linearH ?? 0)).toBe(150);
+  });
+
+  // Regression: at 90 degree view rotation the visual right handles are the
+  // node-frame TOP anchors; the pin must hold the node-frame bottom edge.
+  it("pins the bottom edge on a top-edge grab (visual right side at 90deg)", () => {
+    const geo = uniformReflowGeometry(start(E(false, true)), 250, 250);
+    expect(geo?.modules).toBe(10);
+    expect(geo?.targetXPx).toBe(50);
+    expect((geo?.targetYPx ?? 0) + (geo?.linearH ?? 0)).toBe(150);
+  });
+
+  // Regression: total-extent quantise is reset-invariant. After baking modules
+  // 5 and re-basing the scale, 137% must still map to 5, not oscillate back to
+  // 4 (the mid-drag flicker).
+  it("is stable across crossings (total extent, not incremental scale)", () => {
+    const s = start(E(false, false));
+    expect(uniformReflowGeometry(s, 125, 125)?.modules).toBe(5);
+    expect(uniformReflowGeometry(s, 137, 137)?.modules).toBe(5);
+    expect(uniformReflowGeometry(s, 137.5, 137.5)?.modules).toBe(6);
+  });
+
+  it("clamps to min on a collapse and to max on an overshoot", () => {
+    expect(uniformReflowGeometry(start(E(false, false)), 1, 1)?.modules).toBe(1);
+    expect(uniformReflowGeometry(start(E(false, false)), 900, 900)?.modules).toBe(10);
+  });
+
+  it("scales a rectangular start box by the same module factor", () => {
+    // 8x18 DMRE at dimension 4: bbox 180x80. One module step up -> x1.25.
+    const geo = uniformReflowGeometry(
+      { edges: E(false, false), modules0: 4, min: 1, max: 10, leftX: 50, topY: 50, rightX: 230, bottomY: 130 },
+      228.6,
+      101.6,
     );
-    expect(out.width).toBe(150);
-    expect(out.x + out.width).toBe(oldBox.x + oldBox.width);
-    expect(out.y + out.height).toBe(oldBox.y + oldBox.height);
+    expect(geo?.modules).toBe(5);
+    expect(geo?.linearW).toBe(225);
+    expect(geo?.linearH).toBe(100);
+    expect(geo?.targetXPx).toBe(50);
+    expect(geo?.targetYPx).toBe(50);
   });
 
-  it("clamps to anchor min", () => {
-    const a = anchor({ left: false, right: true, top: false, bottom: true });
-    const out = applyUniformModuleSnap(oldBox, { ...oldBox, width: 5, height: 5 }, a);
-    expect(out.width).toBe(25);
-  });
-
-  it("no-ops on a non-uniform-2D anchor", () => {
-    const out = applyUniformModuleSnap(oldBox, { ...oldBox, width: 140 }, null);
-    expect(out.width).toBe(140);
-  });
-
-  it("scales a rectangular node's height by the same module factor", () => {
-    // 8×18 DMRE at dimension 4: bbox 180×80. One module step up → ×1.25.
-    const a = {
-      kind: "uniformModule" as const,
-      nodeSize: 180, nodeHeight: 80, modules: 4, min: 1, max: 10,
-      edges: { left: false, right: true, top: false, bottom: true },
-    };
-    const rectOld: BoundingBox = { x: 50, y: 50, width: 180, height: 80, rotation: 0 };
-    const out = applyUniformModuleSnap(rectOld, { ...rectOld, width: 230, height: 102 }, a);
-    expect(out.width).toBe(225);
-    expect(out.height).toBe(100);
-    expect(out.x).toBe(50);
-    expect(out.y).toBe(50);
+  it("returns null for a degenerate start box", () => {
+    expect(uniformReflowGeometry({ ...start(E(false, false)), rightX: 50 }, 140, 140)).toBeNull();
   });
 });
 

--- a/src/components/Canvas/transformerGeometry.ts
+++ b/src/components/Canvas/transformerGeometry.ts
@@ -169,20 +169,48 @@ export interface ModuleWidthAnchor {
   rotation: "N" | "R" | "I" | "B";
 }
 
-/** Uniform 2D (QR/Aztec/DataMatrix) anchor; `edges` from Konva's active
- *  anchor name so the pin survives rotated-view where bbox-diff doesn't.
- *  Width and height are carried separately for rectangular DataMatrix. */
-export interface UniformModuleAnchor {
-  kind: "uniformModule";
-  nodeSize: number;
-  nodeHeight: number;
-  modules: number;
+/** Start-of-drag frame for the uniform-module (2D code) reflow: rendered bbox
+ *  in parent px plus the module range. The per-tick pin from it replaces
+ *  boundBoxFunc's snap/aspect, which is frame-wrong under view rotation. */
+export interface UniformReflowStart {
+  edges: ActiveEdgeFlags;
+  modules0: number;
   min: number;
   max: number;
-  edges: ActiveEdgeFlags;
+  leftX: number;
+  topY: number;
+  rightX: number;
+  bottomY: number;
 }
 
-export type TransformAnchor = RowAnchor | ModuleWidthAnchor | UniformModuleAnchor;
+/** Per-tick geometry of the uniform-module reflow. Quantises the TOTAL frame
+ *  extent (not incremental scale) to integer modules: the per-tick scale reset
+ *  re-bases on the re-rendered bitmap, so incremental quantising would
+ *  oscillate across crossings. Both axes scale by the smaller axis's ratio. */
+export function uniformReflowGeometry(
+  start: UniformReflowStart,
+  frameWPx: number,
+  frameHPx: number,
+): { modules: number; targetXPx: number; targetYPx: number; linearW: number; linearH: number } | null {
+  const startW = start.rightX - start.leftX;
+  const startH = start.bottomY - start.topY;
+  if (!(start.modules0 > 0) || !(startW > 0) || !(startH > 0)) return null;
+  if (!(frameWPx > 0) || !(frameHPx > 0)) return null;
+  const scale = Math.min(frameWPx / startW, frameHPx / startH);
+  const modules = computeNewModules(start.modules0, scale, start.min, start.max);
+  const factor = modules / start.modules0;
+  const linearW = startW * factor;
+  const linearH = startH * factor;
+  return {
+    modules,
+    targetXPx: start.edges.left ? start.rightX - linearW : start.leftX,
+    targetYPx: start.edges.top ? start.bottomY - linearH : start.topY,
+    linearW,
+    linearH,
+  };
+}
+
+export type TransformAnchor = RowAnchor | ModuleWidthAnchor;
 
 /** Single source of truth for module-step rounding shared by the
  *  in-drag snap and the on-release commit so they cannot diverge. */
@@ -265,25 +293,6 @@ export function applyModuleWidthSnap(
     min,
   );
   return pinSnappedAxis(oldBox, newBox, swapped ? "y" : "x", snapped, HANDLE_MOVE_EPS);
-}
-
-/** Assumes forceAspectBox has run; pins the corner formed by anchor.edges. */
-export function applyUniformModuleSnap(
-  oldBox: BoundingBox,
-  newBox: BoundingBox,
-  anchor: TransformAnchor | null,
-): BoundingBox {
-  if (anchor?.kind !== "uniformModule" || !(anchor.nodeSize > 0) || !(anchor.modules > 0)) {
-    return newBox;
-  }
-  const scale = newBox.width / anchor.nodeSize;
-  const nextModules = computeNewModules(anchor.modules, scale, anchor.min, anchor.max);
-  const factor = nextModules / anchor.modules;
-  const width = anchor.nodeSize * factor;
-  const height = (anchor.nodeHeight > 0 ? anchor.nodeHeight : anchor.nodeSize) * factor;
-  const x = anchor.edges.left ? oldBox.x + oldBox.width - width : oldBox.x;
-  const y = anchor.edges.top ? oldBox.y + oldBox.height - height : oldBox.y;
-  return { ...newBox, x, y, width, height };
 }
 
 /** Pin the anchored side of a resize: a grabbed min edge (left/top) shifts the

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -114,6 +114,8 @@ function createFakeCanvas() {
       return _imageData ?? new FakeImageData(w, h);
     },
     fillRect(): void { /* noop */ },
+    // Konva probes the hit canvas (getHitColor) on Shape construction.
+    clearRect(): void { /* noop */ },
     drawImage(): void { /* noop */ },
     set fillStyle(_v: string) { /* noop */ },
   };


### PR DESCRIPTION
Live per-tick reflow in the parent frame (quantise magnification, pin the anchored corner) replaces the bake-on-end commit plus boundBoxFunc aspect/snap, whose box math re-anchored on the wrong axis under rotation. getClientRect wrappers are named by coordinate frame to prevent that frame mixing.