### PR TITLE
feat(canvas): unfilled shapes hit only on their stroke

### DIFF
--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -16,7 +16,7 @@ import { applyBindingToObject } from "../../lib/variableBinding";
 import { usePreviewBinding } from "../../store/usePreviewBinding";
 import { ZPL_FONT_HEIGHT_TO_CSS_RATIO } from "../../lib/labelGeometry/textPositionTransforms";
 import { getTextRenderMetrics } from "../../lib/labelGeometry/textRenderMetrics";
-import { selectionHandlers, useBlankFieldWarns, CAPTURE_CHROME, PLACEHOLDER_DASH, PLACEHOLDER_STROKE_PX, type KonvaObjectProps } from "./konvaObjectProps";
+import { selectionHandlers, shapeHitProps, useBlankFieldWarns, CAPTURE_CHROME, PLACEHOLDER_DASH, PLACEHOLDER_STROKE_PX, type KonvaObjectProps } from "./konvaObjectProps";
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import { DEFAULT_GS_SYMBOL_META, GS_SYMBOLS } from "../../registry/symbol";
 import { GS_SYMBOL_PATHS, GS_VECTOR_CODES, type GsVectorCode } from "../../registry/gsSymbolPaths";
@@ -834,6 +834,7 @@ function KonvaObjectInner({
           fill={fill}
           cornerRadius={insetCornerRadius}
           globalCompositeOperation={globalCompositeOperation}
+          {...shapeHitProps(renderFilled, strokeWidth, isSelected)}
         />
         {isSelected && (
           <SelectionOverlay
@@ -884,6 +885,7 @@ function KonvaObjectInner({
           strokeScaleEnabled={false}
           fill={fill}
           globalCompositeOperation={globalCompositeOperation}
+          {...shapeHitProps(renderFilled, strokeWidth, isSelected)}
         />
         {isSelected && (
           <EllipseSelectionOverlay rx={rx} ry={ry} color={colors.selection} />

--- a/src/components/Canvas/LineObject.tsx
+++ b/src/components/Canvas/LineObject.tsx
@@ -11,7 +11,7 @@ import {
   type SnapRect,
 } from "../../lib/snapGuides";
 import { diagonalPolygonPoints } from "../../lib/shapeGeometry";
-import { selectionHandlers, type KonvaObjectProps } from "./konvaObjectProps";
+import { selectionHandlers, type KonvaObjectProps, MIN_HIT_STROKE_PX } from "./konvaObjectProps";
 
 const HANDLE_VISIBLE_SIZE = 7;
 const HANDLE_HIT_SIZE = 14;
@@ -389,7 +389,7 @@ export function LineObject({
           y2 + visualShiftY,
         ]}
         stroke="transparent"
-        strokeWidth={Math.max(lineStrokeWidth, 14)}
+        strokeWidth={Math.max(lineStrokeWidth, MIN_HIT_STROKE_PX)}
         draggable={!obj.locked}
         {...selectionHandlers(onSelect)}
         {...dragHandlers}

--- a/src/components/Canvas/hitTesting.test.ts
+++ b/src/components/Canvas/hitTesting.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type Konva from "konva";
+import { objectIdsAtPointForCycle } from "./hitTesting";
+import { nextCycleIndex, ALT_CYCLE_TOL_PX } from "./altClickCycle";
+
+// Stage double: getAllIntersections = hit graph, findOne/getClientRect = frame fallback.
+function fakeStage(
+  hitIds: string[],
+  rects: Record<string, { x: number; y: number; width: number; height: number }>,
+): Konva.Stage {
+  const nodeFor = (id: string): unknown => ({
+    id: () => id,
+    getParent: () => null,
+    getClientRect: () => rects[id],
+  });
+  return {
+    getAllIntersections: () => hitIds.map(nodeFor),
+    findOne: (sel: string) => {
+      const id = sel.slice(1);
+      return rects[id] ? nodeFor(id) : undefined;
+    },
+  } as unknown as Konva.Stage;
+}
+
+const point = { x: 50, y: 50 };
+const frameRect = { x: 0, y: 0, width: 100, height: 100 };
+
+describe("objectIdsAtPointForCycle", () => {
+  // Regression: an unselected frame is hit-transparent in its interior
+  // (shapeHitProps), but the alt-click cycle must still reach it.
+  it("includes a frame whose interior contains the point but misses the hit graph", () => {
+    const stage = fakeStage(["text1"], { box1: frameRect, text1: frameRect });
+    const objects = [
+      { id: "box1", type: "box" },
+      { id: "text1", type: "text" },
+    ];
+    expect(objectIdsAtPointForCycle(stage, point, objects)).toEqual(["text1", "box1"]);
+  });
+
+  it("keeps cycling frame and text alternately even as the hit graph changes", () => {
+    const objects = [
+      { id: "box1", type: "box" },
+      { id: "text1", type: "text" },
+    ];
+    // Frame selected: also in the hit graph.
+    const selected = fakeStage(["box1", "text1"], { box1: frameRect, text1: frameRect });
+    const hits1 = objectIdsAtPointForCycle(selected, point, objects);
+    const idx1 = nextCycleIndex(hits1, { ...point, id: "text1" }, point, ALT_CYCLE_TOL_PX);
+    expect(hits1[idx1]).toBe("box1");
+    // Frame now deselected, gone from the hit graph, but still cyclable.
+    const deselected = fakeStage(["text1"], { box1: frameRect, text1: frameRect });
+    const hits2 = objectIdsAtPointForCycle(deselected, point, objects);
+    const idx2 = nextCycleIndex(hits2, { ...point, id: "box1" }, point, ALT_CYCLE_TOL_PX);
+    expect(hits2[idx2]).toBe("text1");
+  });
+
+  it("does not add frames whose rect misses the point, nor non-frame types", () => {
+    const stage = fakeStage([], {
+      box1: { x: 200, y: 200, width: 50, height: 50 },
+      text1: frameRect,
+    });
+    const objects = [
+      { id: "box1", type: "box" },
+      { id: "text1", type: "text" },
+    ];
+    expect(objectIdsAtPointForCycle(stage, point, objects)).toEqual([]);
+  });
+});

--- a/src/components/Canvas/hitTesting.ts
+++ b/src/components/Canvas/hitTesting.ts
@@ -34,3 +34,31 @@ export function objectIdsAtPoint(
   }
   return hits;
 }
+
+/** {@link objectIdsAtPoint} for the alt-click cycle: its contract is every
+ *  object stacked at the point, so hit-transparent frame interiors
+ *  (shapeHitProps) fall back to a client-rect test. Top first. */
+export function objectIdsAtPointForCycle(
+  stage: Konva.Stage,
+  point: { x: number; y: number },
+  objects: readonly { id: string; type: string }[],
+): string[] {
+  const hitSet = new Set(objectIdsAtPoint(stage, point, new Set(objects.map((o) => o.id))));
+  const out: string[] = [];
+  for (let i = objects.length - 1; i >= 0; i--) {
+    const o = objects[i];
+    if (!o) continue;
+    if (hitSet.has(o.id)) {
+      out.push(o.id);
+      continue;
+    }
+    if (o.type !== "box" && o.type !== "ellipse") continue;
+    const node = stage.findOne(`#${o.id}`);
+    if (!node) continue;
+    const r = node.getClientRect({ relativeTo: stage });
+    if (point.x >= r.x && point.x <= r.x + r.width && point.y >= r.y && point.y <= r.y + r.height) {
+      out.push(o.id);
+    }
+  }
+  return out;
+}

--- a/src/components/Canvas/hitTesting.ts
+++ b/src/components/Canvas/hitTesting.ts
@@ -55,7 +55,9 @@ export function objectIdsAtPointForCycle(
     if (o.type !== "box" && o.type !== "ellipse") continue;
     const node = stage.findOne(`#${o.id}`);
     if (!node) continue;
-    const r = node.getClientRect({ relativeTo: stage });
+    // Absolute (container) coords, matching getAllIntersections' pointer
+    // space; relativeTo: stage would drop a stage-level transform.
+    const r = node.getClientRect();
     if (point.x >= r.x && point.x <= r.x + r.width && point.y >= r.y && point.y <= r.y + r.height) {
       out.push(o.id);
     }

--- a/src/components/Canvas/hooks/useAltClickCycle.ts
+++ b/src/components/Canvas/hooks/useAltClickCycle.ts
@@ -6,7 +6,7 @@ import {
   nextCycleIndex,
   type CycleAnchor,
 } from "../altClickCycle";
-import { objectIdsAtPoint } from "../hitTesting";
+import { objectIdsAtPointForCycle } from "../hitTesting";
 
 interface Options {
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -36,10 +36,9 @@ export function useAltClickCycle({ containerRef, stageRef, selectObject }: Optio
       const rect = el.getBoundingClientRect();
       const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
       // Konva's own hit-graph respects view rotation, pan offset,
-      // per-shape transforms and the listening flag, far cheaper than
-      // mirroring all of that in our own bbox math.
-      const objIds = new Set(getCurrentObjects().map((o) => o.id));
-      const hits = objectIdsAtPoint(stage, point, objIds);
+      // per-shape transforms and the listening flag; the cycle variant adds
+      // a client-rect fallback so frame interiors stay reachable.
+      const hits = objectIdsAtPointForCycle(stage, point, getCurrentObjects());
       if (hits.length === 0) return;
       e.stopPropagation();
       e.preventDefault();

--- a/src/components/Canvas/konvaObjectProps.test.ts
+++ b/src/components/Canvas/konvaObjectProps.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type Konva from "konva";
-import { selectionHandlers } from "./konvaObjectProps";
+import { selectionHandlers, shapeHitProps, MIN_HIT_STROKE_PX } from "./konvaObjectProps";
 
 const clickEvt = (evt: Partial<MouseEvent>) =>
   ({ evt } as Konva.KonvaEventObject<MouseEvent>);
@@ -33,5 +33,29 @@ describe("selectionHandlers", () => {
     const onSelect = vi.fn();
     selectionHandlers(onSelect).onTap();
     expect(onSelect).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("shapeHitProps", () => {
+  it("filled shapes keep the full-area hit", () => {
+    expect(shapeHitProps(true, 2, false)).toEqual({ fillEnabled: true });
+  });
+
+  it("unselected frames hit only on the stroke, widened for thin lines", () => {
+    expect(shapeHitProps(false, 2, false)).toEqual({
+      fillEnabled: false,
+      hitStrokeWidth: MIN_HIT_STROKE_PX,
+    });
+  });
+
+  it("thick frames keep their real stroke as the hit zone", () => {
+    expect(shapeHitProps(false, 20, false)).toEqual({ fillEnabled: false, hitStrokeWidth: 20 });
+  });
+
+  it("a selected frame hits on its full area so it can be dragged from the middle", () => {
+    expect(shapeHitProps(false, 2, true)).toEqual({
+      fillEnabled: true,
+      hitStrokeWidth: MIN_HIT_STROKE_PX,
+    });
   });
 });

--- a/src/components/Canvas/konvaObjectProps.ts
+++ b/src/components/Canvas/konvaObjectProps.ts
@@ -24,6 +24,24 @@ export function useBlankFieldWarns(objectId: string): boolean {
   return !pristine && objectId !== PALETTE_GHOST_ID;
 }
 
+/** Minimum grab width for stroke-only hit areas (shared with LineObject). */
+export const MIN_HIT_STROKE_PX = 14;
+
+/** An unselected frame hits only on its stroke so the enclosed area stays
+ *  click-through; thin strokes widen to MIN_HIT_STROKE_PX. Selected, the
+ *  full area hits so the frame drags from its middle. */
+export function shapeHitProps(
+  renderFilled: boolean,
+  strokeWidthPx: number,
+  isSelected: boolean,
+): { fillEnabled: boolean; hitStrokeWidth?: number } {
+  if (renderFilled) return { fillEnabled: true };
+  return {
+    fillEnabled: isSelected,
+    hitStrokeWidth: Math.max(strokeWidthPx, MIN_HIT_STROKE_PX),
+  };
+}
+
 /**
  * Click / tap handlers shared across every per-type renderer. Click reads
  * shift / ctrl / meta to toggle multi-select; tap (touch) is always a


### PR DESCRIPTION
A frame no longer swallows clicks meant for the objects it encloses; thin strokes widen to the line renderer's 14px hit minimum. Once selected, the full area hits again so the frame can be dragged from its middle.