### PR TITLE
feat(canvas): multi-select resize

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -50,7 +50,7 @@ import { useColorScheme } from "../../hooks/useColorScheme";
 import { useT } from "../../hooks/useT";
 import { useCanvasPanZoom } from "./hooks/useCanvasPanZoom";
 import { useCanvasLasso } from "./hooks/useCanvasLasso";
-import { useKonvaTransformer } from "./hooks/useKonvaTransformer";
+import { useKonvaTransformer, MULTI_RESIZE_PROXY_ID } from "./hooks/useKonvaTransformer";
 import { useKonvaDragController } from "./hooks/useKonvaDragController";
 import { useSnapBypassRef } from "./hooks/useSnapBypassRef";
 import { PaginationControl } from "./PaginationControl";
@@ -355,6 +355,8 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       if (isEditableTarget(e.target as HTMLElement)) return;
       // Preview is a frozen snapshot; editing would drift the comparison.
       if (selectPreviewLocksEditor(useLabelStore.getState())) return;
+      // Deleting mid-resize would destroy the nodes under the active gesture.
+      if (transformActiveRef.current) return;
       const { selectedIds: ids } = useLabelStore.getState();
       if (ids.length === 0) return;
       e.preventDefault();
@@ -558,6 +560,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   // part (follows the drag) and a static part (locked, stays put) so the chrome
   // reflects the real union, not a rigid translate.
   const selectionFrameRef = useRef<Konva.Rect>(null);
+  const multiResizeProxyRef = useRef<Konva.Rect>(null);
   // Movable group sub-outlines share one drag offset.
   const subOutlineGroupRef = useRef<Konva.Group>(null);
   const isMultiFrame = attachableIds.length > 1;
@@ -586,7 +589,14 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   // (single drags too), so compute them for any selection.
   const hasSelection = visibleSelIds.length > 0;
   const selectionFrameBase = isMultiFrame ? toFramePx(selectionUnionDots(objects, visibleSelIds, frameCtx)) : null;
-  const movableFrameBase = hasSelection ? toFramePx(selectionUnionDots(objects, movableSelIds, frameCtx)) : null;
+  const movableUnionDots = hasSelection ? selectionUnionDots(objects, movableSelIds, frameCtx) : null;
+  // Needs >1 visible movable leaf (attachableIds counts hidden ones) and no
+  // locked member; either would break the projected union.
+  const multiResizeBboxDots =
+    movableSelIds.length > 1 && staticSelIds.length === 0 && !previewLocks
+      ? movableUnionDots
+      : null;
+  const movableFrameBase = toFramePx(movableUnionDots);
   const staticFrameBase = hasSelection ? toFramePx(selectionUnionDots(objects, staticSelIds, frameCtx)) : null;
   // Preflight runs over the EXPORTABLE leaves (includeInExport), not the visible
   // ones, so a hidden-but-exported object is still warned and a visible-but-not-
@@ -720,6 +730,11 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       if (!live) return;
       selectionFrameRef.current?.position({ x: live.x, y: live.y });
       selectionFrameRef.current?.size({ width: live.width, height: live.height });
+      // Proxy follows the drag so the transformer chrome tracks live (the
+      // controller already forceUpdates the transformer each tick).
+      if (multiResizeBboxDots && moved) {
+        multiResizeProxyRef.current?.position({ x: moved.x, y: moved.y });
+      }
       // Movable sub-outlines follow the drag (reset to 0 on end).
       subOutlineGroupRef.current?.position({ x: dx, y: dy });
       // Shared clamp/flip policy; measure the bar lazily since a drag that selects
@@ -895,6 +910,8 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     labelOffsetY,
     snap,
     updateObject,
+    updateObjects,
+    multiResizeBboxDots,
     labelRect: transformerSnapLabelRect,
     objectSnapEnabled: smartSnapActive,
     snapBypassRef,
@@ -1583,7 +1600,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
 
               {/* Multi-select/group frame from model bounds (matches snap borders);
                   positioned imperatively in useLayoutEffect + the drag onDelta. */}
-              {!previewLocks && selectionFrameBase && (
+              {!previewLocks && selectionFrameBase && !multiResizeBboxDots && (
                 <Rect
                   ref={selectionFrameRef}
                   name={CAPTURE_CHROME}
@@ -1591,6 +1608,18 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
                   strokeWidth={1.5}
                   dash={isMultiSelection || allSelectedLocked ? [6, 4] : undefined}
                   listening={false}
+                />
+              )}
+
+              {/* Multi-resize proxy; geometry synced by the transformer hook. */}
+              {!previewLocks && multiResizeBboxDots && (
+                <Rect
+                  ref={multiResizeProxyRef}
+                  id={MULTI_RESIZE_PROXY_ID}
+                  name={CAPTURE_CHROME}
+                  listening={false}
+                  fillEnabled={false}
+                  strokeEnabled={false}
                 />
               )}
 
@@ -1654,6 +1683,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
             {!previewLocks && (
               <Transformer
                 ref={transformerRef}
+                borderDash={isMultiSelection && multiResizeBboxDots ? [6, 4] : undefined}
                 rotateEnabled={rotateEnabled}
                 resizeEnabled={resizeEnabled}
                 enabledAnchors={enabledAnchors}

--- a/src/components/Canvas/LineObject.tsx
+++ b/src/components/Canvas/LineObject.tsx
@@ -11,7 +11,8 @@ import {
   type SnapRect,
 } from "../../lib/snapGuides";
 import { diagonalPolygonPoints } from "../../lib/shapeGeometry";
-import { selectionHandlers, type KonvaObjectProps, MIN_HIT_STROKE_PX } from "./konvaObjectProps";
+import { selectionHandlers, type KonvaObjectProps, MIN_HIT_STROKE_PX, lineHandlesNodeId, lineRootNodeId } from "./konvaObjectProps";
+
 
 const HANDLE_VISIBLE_SIZE = 7;
 const HANDLE_HIT_SIZE = 14;
@@ -329,7 +330,7 @@ export function LineObject({
     lineCenterY + (isHorizontal ? lineStrokeWidth : 0);
 
   return (
-    <Group>
+    <Group id={lineRootNodeId(obj.id)}>
       {isAxisAligned ? (
         <>
           <KLine
@@ -341,6 +342,7 @@ export function LineObject({
             ]}
             stroke={strokeColor}
             strokeWidth={lineStrokeWidth}
+            strokeScaleEnabled={false}
             lineCap="butt"
             listening={false}
             globalCompositeOperation={isReverse ? "difference" : "source-over"}
@@ -390,12 +392,13 @@ export function LineObject({
         ]}
         stroke="transparent"
         strokeWidth={Math.max(lineStrokeWidth, MIN_HIT_STROKE_PX)}
+        strokeScaleEnabled={false}
         draggable={!obj.locked}
         {...selectionHandlers(onSelect)}
         {...dragHandlers}
       />
       {isSelected && (
-        <>
+        <Group id={lineHandlesNodeId(obj.id)}>
           {/* Start point: dragging moves origin; end stays fixed. */}
           <Rect
             x={(livePt1?.x ?? x1 + dx) - HANDLE_HIT_SIZE / 2}
@@ -586,7 +589,7 @@ export function LineObject({
             strokeWidth={1}
             listening={false}
           />
-        </>
+        </Group>
       )}
     </Group>
   );

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -1,10 +1,11 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useLayoutEffect } from "react";
 import { flushSync } from "react-dom";
 import type Konva from "konva";
 import { dotsToPx, pxToDots } from "../../../lib/coordinates";
 import { blockBoundsDots, blockGlyphAnchorPoint, blockReflowGeometry, tbBoundsDots, tbReflowGeometry, type BlockJustify, type ZplRotation } from "../../../lib/zebraTextLayout";
 import { getCurrentObjects, useLabelStore } from "../../../store/labelStore";
 import {
+  SHAPE_PRIMITIVE_TYPES,
   BARCODE_1D_TYPES,
   STACKED_2D_TYPES,
   getEntry,
@@ -39,7 +40,9 @@ import {
   modelPositionFromRenderedTopLeft,
   renderedTopLeftFromModel,
 } from "../transformPosition";
-import { isBarcode } from "../../../lib/objectBounds";
+import { isBarcode, type BoundingBoxDots } from "../../../lib/objectBounds";
+import { projectMultiResize } from "../../../lib/multiResize";
+import { lineHandlesNodeId, lineRootNodeId } from "../konvaObjectProps";
 import { isAxisSwapped, objectRotation } from "../../../registry/rotation";
 import { getMeasuredSnapshot } from "../measuredBoundsCache";
 import {
@@ -114,6 +117,10 @@ function applyResizeObjectSnap(
   };
 }
 
+/** Invisible rect at the selection's model union; the transformer attaches to
+ *  it for multi-resize so member nodes never stretch live. */
+export const MULTI_RESIZE_PROXY_ID = "multi-resize-proxy";
+
 interface Options {
   transformerRef: React.RefObject<Konva.Transformer | null>;
   stageRef: React.RefObject<Konva.Stage | null>;
@@ -125,6 +132,10 @@ interface Options {
   labelOffsetY: number;
   snap: (dots: number) => number;
   updateObject: (id: string, changes: ObjectChanges) => void;
+  updateObjects: (updates: { id: string; changes: ObjectChanges }[]) => void;
+  /** Model union bbox of the selection when every member is movable; null
+   *  disables multi-resize (locked member, or single selection). */
+  multiResizeBboxDots: BoundingBoxDots | null;
   /** Label rect in stage-screen space, used as a snap target. */
   labelRect: SnapRect;
   /** True when grid-snap is OFF; object-snap during resize mirrors drag. */
@@ -172,6 +183,8 @@ export function useKonvaTransformer({
   labelOffsetY,
   snap,
   updateObject,
+  updateObjects,
+  multiResizeBboxDots,
   labelRect,
   objectSnapEnabled,
   snapBypassRef,
@@ -263,11 +276,31 @@ export function useKonvaTransformer({
     | null
   >(null);
 
+  const multiResizeRef = useRef<{
+    proxy: Konva.Node;
+    bboxDots: BoundingBoxDots;
+    start: { x: number; y: number };
+    nodes: {
+      node: Konva.Node;
+      startX: number;
+      startY: number;
+      anchorPxX: number;
+      anchorPxY: number;
+      scales: boolean;
+      uniform: boolean;
+      hide?: Konva.Node;
+    }[];
+    ids: string[];
+  } | null>(null);
+
   // True while any live reflow (text block, shape, or barcode) owns the drag.
   const anyReflowActive = () =>
     liveReflowRef.current !== null ||
     shapeReflowRef.current !== null ||
     barcodeReflowRef.current !== null;
+
+  // Same indirection as anyReflowActive, for the React Compiler.
+  const multiResizeActive = () => multiResizeRef.current !== null;
 
   // Block resize mode resolved once at drag start (panel mode + Alt). Reused at
   // commit so toggling Alt mid-drag can't make start and end disagree.
@@ -324,12 +357,13 @@ export function useKonvaTransformer({
   // transformer must re-measure even though no object prop changed.
   const blockDragMode = useLabelStore((s) => s.blockDragMode);
 
-  useEffect(() => {
+  // Layout effect: sync before paint or the border flashes for one frame.
+  useLayoutEffect(() => {
     if (!transformerRef.current || !stageRef.current) return;
     // During a live reflow the per-tick store update re-runs this effect;
     // re-attaching (.nodes()) mid-drag aborts the gesture, so skip it. The
     // reflow handler keeps the transformer in sync via forceUpdate().
-    if (anyReflowActive()) return;
+    if (anyReflowActive() || multiResizeActive()) return;
     if (selectedIds.length === 0) {
       transformerRef.current.nodes([]);
       return;
@@ -343,11 +377,24 @@ export function useKonvaTransformer({
         : null;
       transformerRef.current.nodes(node ? [node] : []);
     } else {
-      // Multi-select has no resize/rotate anchors and its frame is drawn from
-      // selectionUnionDots (model bounds) to match the snap borders. Detach the
-      // transformer so it doesn't also draw a disagreeing client-rect frame
-      // (fat diagonals, barcode HRI, etc.).
-      transformerRef.current.nodes([]);
+      // Attach to the proxy at the model union (client rects disagree for
+      // fat diagonals / HRI); synced here, outside any gesture.
+      const proxy = multiResizeBboxDots
+        ? stageRef.current.findOne<Konva.Node>(`#${MULTI_RESIZE_PROXY_ID}`)
+        : null;
+      if (proxy && multiResizeBboxDots) {
+        proxy.setAttrs({
+          x: objectsOffsetX + dotsToPx(multiResizeBboxDots.x, scale, dpmm),
+          y: labelOffsetY + dotsToPx(multiResizeBboxDots.y, scale, dpmm),
+          width: dotsToPx(multiResizeBboxDots.width, scale, dpmm),
+          height: dotsToPx(multiResizeBboxDots.height, scale, dpmm),
+          scaleX: 1,
+          scaleY: 1,
+        });
+        transformerRef.current.nodes([proxy]);
+      } else {
+        transformerRef.current.nodes([]);
+      }
     }
     // Force a re-measure: after commitTransform the node's getClientRect has
     // changed but the transformer caches its bounds from the last interaction.
@@ -367,13 +414,24 @@ export function useKonvaTransformer({
     stageRef,
     transformerRef,
     previewLocks,
+    multiResizeBboxDots?.x,
+    multiResizeBboxDots?.y,
+    multiResizeBboxDots?.width,
+    multiResizeBboxDots?.height,
+    scale,
+    dpmm,
+    objectsOffsetX,
+    labelOffsetY,
   ]);
 
   const singleSelected =
     selectedIds.length === 1
       ? objects.find((o) => o.id === selectedIds[0])
       : undefined;
-  const resizeEnabled = selectedIds.length <= 1 && !singleSelected?.locked;
+  const resizeEnabled =
+    selectedIds.length > 1
+      ? multiResizeBboxDots != null
+      : selectedIds.length === 1 && !singleSelected?.locked;
   const singleType = singleSelected?.type ?? "";
   const typeEntry = getEntry(singleType);
   const uniformScaleDef = typeEntry?.uniformScale;
@@ -389,7 +447,7 @@ export function useKonvaTransformer({
       : !!uniformScaleDef);
   const enabledAnchors: string[] | undefined =
     selectedIds.length > 1
-      ? []
+      ? undefined
       : getEntry(singleType)?.heightLocked
         ? []
         : BARCODE_1D_TYPES.has(singleType)
@@ -421,6 +479,7 @@ export function useKonvaTransformer({
 
   /** Reset all transform-time state. Idempotent; safe to call from any exit path. */
   function cleanupTransformState() {
+    multiResizeRef.current = null;
     transformAnchorRef.current = null;
     transformStartBboxRef.current = null;
     othersSnapshotRef.current = [];
@@ -459,6 +518,49 @@ export function useKonvaTransformer({
   }
 
   const onTransformStart = () => {
+    if (selectedIds.length > 1) {
+      const stage = stageRef.current;
+      const proxy = stage?.findOne<Konva.Node>(`#${MULTI_RESIZE_PROXY_ID}`);
+      if (!stage || !proxy || !multiResizeBboxDots) return;
+      const nodes = selectedIds.flatMap((id) => {
+        const leaf = objects.find((o) => o.id === id);
+        if (!leaf) return [];
+        // Lines are flat: transform their root group so body, hit line and
+        // selection chrome all follow; other types transform their own node.
+        const node = stage.findOne<Konva.Node>(
+          leaf.type === "line" ? `#${lineRootNodeId(id)}` : `#${id}`,
+        );
+        if (!node) return [];
+        // Grips would deform under the group scale; hide for the gesture.
+        const hide = leaf.type === "line" ? stage.findOne<Konva.Node>(`#${lineHandlesNodeId(id)}`) : null;
+        hide?.visible(false);
+        return [
+          {
+            node,
+            startX: node.x(),
+            startY: node.y(),
+            // Commit and live both project the MODEL anchor; render-offset
+            // nodes (^FT bar base, ^BQ shift) would jump by off*(f-1) else.
+            anchorPxX: objectsOffsetX + dotsToPx(leaf.x, scale, dpmm),
+            anchorPxY: labelOffsetY + dotsToPx(leaf.y, scale, dpmm),
+            scales: SHAPE_PRIMITIVE_TYPES.has(leaf.type),
+            // lockAspect commits min(fx, fy); live must match or it snaps back.
+            uniform:
+              leaf.type === "ellipse" &&
+              (leaf.props as { lockAspect?: boolean }).lockAspect === true,
+            hide: hide ?? undefined,
+          },
+        ];
+      });
+      multiResizeRef.current = {
+        proxy,
+        bboxDots: multiResizeBboxDots,
+        start: { x: proxy.x(), y: proxy.y() },
+        nodes,
+        ids: [...selectedIds],
+      };
+      return;
+    }
     const singleId = selectedIds[0];
     if (!singleId || !stageRef.current) return;
     const node = stageRef.current.findOne<Konva.Node>(`#${singleId}`);
@@ -681,6 +783,32 @@ export function useKonvaTransformer({
   // the scale, re-pin the anchored edge, and re-baseline the handles. Keeps
   // glyphs constant and justify correct because the content actually re-renders.
   const onTransform = () => {
+    const mr = multiResizeRef.current;
+    if (mr) {
+      const fx = mr.proxy.scaleX();
+      const fy = mr.proxy.scaleY();
+      const px = mr.proxy.x();
+      const py = mr.proxy.y();
+      for (const n of mr.nodes) {
+        if (n.scales) {
+          // Scaling nodes hold the anchor in their scaled children (line roots
+          // at 0, shape groups at the anchor): the position projects linearly.
+          n.node.position({
+            x: px + (n.startX - mr.start.x) * fx,
+            y: py + (n.startY - mr.start.y) * fy,
+          });
+          const u = Math.min(fx, fy);
+          n.node.scale(n.uniform ? { x: u, y: u } : { x: fx, y: fy });
+        } else {
+          // Anchor projects, the render offset rides along unscaled.
+          n.node.position({
+            x: px + (n.anchorPxX - mr.start.x) * fx + (n.startX - n.anchorPxX),
+            y: py + (n.anchorPxY - mr.start.y) * fy + (n.startY - n.anchorPxY),
+          });
+        }
+      }
+      return;
+    }
     if (selectedIds.length !== 1 || !stageRef.current) return;
     const id = selectedIds[0];
     if (!id) return;
@@ -920,6 +1048,11 @@ export function useKonvaTransformer({
     oldBox: BoundingBox,
     newBox: BoundingBox,
   ): BoundingBox => {
+    // No axis pin / band snap; only the shrink floor, so a union already
+    // thinner than the floor stays resizable on the other axis.
+    if (multiResizeRef.current) {
+      return shrinkingBelowFloor(oldBox, newBox, MIN_RESIZE_BOX_PX) ? oldBox : newBox;
+    }
     if (shrinkingBelowFloor(oldBox, newBox, MIN_RESIZE_BOX_PX)) return oldBox;
     // The text-block reflow re-pins from its own captured edges, so the snap /
     // inactive-edge pin below would fight it; skip entirely.
@@ -1109,6 +1242,77 @@ export function useKonvaTransformer({
         };
       }
       collapseReflowToOneEntry(id, commit);
+      return;
+    }
+    const mr = multiResizeRef.current;
+    if (mr) {
+      const fx = mr.proxy.scaleX();
+      const fy = mr.proxy.scaleY();
+      // Left/top anchors move the proxy origin (the opposite edge is pinned);
+      // capture it before the reset so the commit keeps that translation.
+      const endX = mr.proxy.x();
+      const endY = mr.proxy.y();
+      // Restore pre-gesture transforms; the commit re-render applies the new
+      // model. Line bodies have no x/y props, react-konva keeps live offsets.
+      for (const n of mr.nodes) {
+        n.node.position({ x: n.startX, y: n.startY });
+        if (n.scales) n.node.scale({ x: 1, y: 1 });
+        n.hide?.visible(true);
+      }
+      let committed = false;
+      if (fx !== 1 || fy !== 1) {
+        // Visible leaves only, matching the drag gesture (which skips hidden
+        // members); `objects` also carries the cascaded lock.
+        const leafById = new Map(objects.map((o) => [o.id, o]));
+        const leafs = mr.ids.flatMap((id) => {
+          const l = leafById.get(id);
+          return l ? [l] : [];
+        });
+        const origin = {
+          x: mr.bboxDots.x + pxToDots(endX - mr.start.x, scale, dpmm),
+          y: mr.bboxDots.y + pxToDots(endY - mr.start.y, scale, dpmm),
+        };
+        // Drop no-op entries so a sub-dot jiggle records no undo step.
+        const changes = projectMultiResize(leafs, mr.bboxDots, origin, fx, fy, snap).filter(
+          (c) => {
+            const l = leafById.get(c.id);
+            if (!l) return false;
+            if (c.x !== l.x || c.y !== l.y) return true;
+            const lp = l.props as unknown as Record<string, number>;
+            return !!c.props && Object.entries(c.props).some(([k, v]) => lp[k] !== v);
+          },
+        );
+        if (changes.length > 0) {
+          committed = true;
+          updateObjects(
+            changes.map((c) => ({
+              id: c.id,
+              changes: { x: c.x, y: c.y, ...(c.props ? { props: c.props } : {}) },
+            })),
+          );
+        }
+      }
+      // Committed: park on the end geometry (no flash before the sync effect
+      // re-measures). No commit: restore the start, nothing will re-sync.
+      if (committed) {
+        mr.proxy.setAttrs({
+          scaleX: 1,
+          scaleY: 1,
+          width: mr.proxy.width() * fx,
+          height: mr.proxy.height() * fy,
+        });
+      } else {
+        mr.proxy.setAttrs({
+          scaleX: 1,
+          scaleY: 1,
+          x: mr.start.x,
+          y: mr.start.y,
+        });
+      }
+      // A mid-gesture delete destroyed the proxy; do not hold ghost anchors.
+      if (!mr.proxy.getStage()) transformerRef.current?.nodes([]);
+      transformerRef.current?.forceUpdate();
+      cleanupTransformState();
       return;
     }
     if (selectedIds.length !== 1 || !selectedIds[0] || !stageRef.current) {

--- a/src/components/Canvas/konvaObjectProps.ts
+++ b/src/components/Canvas/konvaObjectProps.ts
@@ -27,6 +27,14 @@ export function useBlankFieldWarns(objectId: string): boolean {
 /** Minimum grab width for stroke-only hit areas (shared with LineObject). */
 export const MIN_HIT_STROKE_PX = 14;
 
+/** Line root group id: the multi-resize live projection transforms the whole
+ *  group (body, hit, chrome) since line children are flat points. */
+export const lineRootNodeId = (id: string): string => `${id}:line-root`;
+
+/** Endpoint/thickness grips of a line; hidden during a multi-resize gesture
+ *  because the root-group scale would deform their squares. */
+export const lineHandlesNodeId = (id: string): string => `${id}:line-handles`;
+
 /** An unselected frame hits only on its stroke so the enclosed area stays
  *  click-through; thin strokes widen to MIN_HIT_STROKE_PX. Selected, the
  *  full area hits so the frame drags from its middle. */

--- a/src/lib/lineConstrain.ts
+++ b/src/lib/lineConstrain.ts
@@ -28,7 +28,7 @@ export interface LineGeometry {
   dy: number;
 }
 
-function makeFree(dxDots: number, dyDots: number): LineGeometry {
+export function makeFree(dxDots: number, dyDots: number): LineGeometry {
   const length = Math.max(
     1,
     Math.round(Math.sqrt(dxDots * dxDots + dyDots * dyDots)),

--- a/src/lib/multiResize.test.ts
+++ b/src/lib/multiResize.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { projectMultiResize } from "./multiResize";
+import type { LeafObject } from "../registry";
+
+const ident = (v: number) => v;
+const bbox = { x: 100, y: 100, width: 200, height: 100 };
+
+function leaf(id: string, type: string, x: number, y: number, props: object): LeafObject {
+  return { id, type, x, y, rotation: 0, props } as unknown as LeafObject;
+}
+
+describe("projectMultiResize", () => {
+  it("reprojects positions linearly to the new bbox", () => {
+    // Anchor at 25% / 50% of the bbox stays at 25% / 50% after scaling.
+    const changes = projectMultiResize(
+      [leaf("t1", "text", 150, 150, { content: "x" })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      2,
+      0.5,
+      ident,
+    );
+    expect(changes).toEqual([{ id: "t1", x: 200, y: 125 }]);
+  });
+
+  it("keeps a barcode's props untouched (position only)", () => {
+    const changes = projectMultiResize(
+      [leaf("b1", "code128", 300, 100, { content: "1", moduleWidth: 3, height: 80 })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      1.5,
+      1,
+      ident,
+    );
+    expect(changes).toEqual([{ id: "b1", x: 400, y: 100 }]);
+  });
+
+  it("scales box geometry through its registry commit (clamped, snapped)", () => {
+    const changes = projectMultiResize(
+      [leaf("s1", "box", 100, 100, { width: 100, height: 60, thickness: 8, filled: false, color: "B", rounding: 0 })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      0.5,
+      0.5,
+      ident,
+    );
+    expect(changes).toEqual([
+      { id: "s1", x: 100, y: 100, props: { width: 50, height: 30 } },
+    ]);
+  });
+
+  it("does not scale thickness", () => {
+    const [change] = projectMultiResize(
+      [leaf("s1", "box", 100, 100, { width: 100, height: 60, thickness: 8, filled: false, color: "B", rounding: 0 })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      3,
+      3,
+      ident,
+    );
+    expect(change?.props).not.toHaveProperty("thickness");
+  });
+
+  it("reprojects a line endpoint into new angle and length", () => {
+    // Horizontal line stretched x2 horizontally stays horizontal, doubles.
+    const [h] = projectMultiResize(
+      [leaf("l1", "line", 100, 100, { angle: 0, length: 100, thickness: 2, color: "B" })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      2,
+      1,
+      ident,
+    );
+    expect(h?.props).toEqual({ angle: 0, length: 200, thickness: 2 });
+    // A 45 degree line under x-only scaling flattens toward the x axis.
+    const [d] = projectMultiResize(
+      [leaf("l2", "line", 100, 100, { angle: 45, length: 100, thickness: 2, color: "B" })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      2,
+      1,
+      ident,
+    );
+    expect(d?.props?.angle).toBeCloseTo(27, 0);
+    expect(d?.props?.length).toBe(158);
+  });
+
+  // Same invariant as the endpoint/panel commits: t > length would land in
+  // the ^GB t-promotion regime and print a t x t block.
+  it("caps line thickness to the shrunken length", () => {
+    const [c] = projectMultiResize(
+      [leaf("l1", "line", 100, 100, { angle: 0, length: 100, thickness: 40, color: "B" })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      0.25,
+      1,
+      ident,
+    );
+    expect(c?.props).toEqual({ angle: 0, length: 25, thickness: 25 });
+  });
+
+  it("ellipse honors lockAspect via its registry commit", () => {
+    const [c] = projectMultiResize(
+      [leaf("e1", "ellipse", 120, 120, { width: 80, height: 80, thickness: 3, filled: false, color: "B", lockAspect: true })],
+      bbox,
+      { x: bbox.x, y: bbox.y },
+      2,
+      1.5,
+      ident,
+    );
+    // lockAspect collapses to the smaller factor on both axes.
+    expect(c?.props).toEqual({ width: 120, height: 120 });
+  });
+
+  // Left-anchor drag: the origin moves, the right edge stays pinned.
+  it("keeps the opposite edge fixed when the origin moves", () => {
+    const changes = projectMultiResize(
+      [leaf("t1", "text", 300, 100, { content: "x" })],
+      bbox,
+      { x: 0, y: 100 },
+      1.5,
+      1,
+      ident,
+    );
+    // Anchor at the right bbox edge (x=300): 0 + 200 * 1.5 = 300, unchanged.
+    expect(changes).toEqual([{ id: "t1", x: 300, y: 100 }]);
+  });
+
+});

--- a/src/lib/multiResize.ts
+++ b/src/lib/multiResize.ts
@@ -1,0 +1,65 @@
+import type { LeafObject } from "../registry";
+import { getEntry, SHAPE_PRIMITIVE_TYPES } from "../registry";
+import type { BoundingBoxDots } from "./objectBounds";
+import { makeFree } from "./lineConstrain";
+
+export interface MultiResizeChange {
+  id: string;
+  x: number;
+  y: number;
+  props?: Record<string, number>;
+}
+
+/** Linear reprojection to a resized union: x' = origin.x + (x - bbox.x) * fx.
+ *  Shapes also scale (box/ellipse via commitTransform, line via endpoint),
+ *  stroke thickness never. `origin` is the POST-gesture bbox origin: left/top
+ *  drags move it while the opposite edge stays pinned. */
+export function projectMultiResize(
+  leafs: readonly LeafObject[],
+  bbox: BoundingBoxDots,
+  origin: { x: number; y: number },
+  fx: number,
+  fy: number,
+  snap: (v: number) => number,
+): MultiResizeChange[] {
+  const projectX = (x: number) => origin.x + (x - bbox.x) * fx;
+  const projectY = (y: number) => origin.y + (y - bbox.y) * fy;
+  const changes: MultiResizeChange[] = [];
+  for (const leaf of leafs) {
+    const x = Math.round(projectX(leaf.x));
+    const y = Math.round(projectY(leaf.y));
+    if (!SHAPE_PRIMITIVE_TYPES.has(leaf.type)) {
+      changes.push({ id: leaf.id, x, y });
+      continue;
+    }
+    if (leaf.type === "line") {
+      const p = leaf.props as { angle: number; length: number; thickness: number };
+      const rad = (p.angle * Math.PI) / 180;
+      // Reproject the endpoint, then read the new angle/length back off it.
+      const free = makeFree(Math.cos(rad) * p.length * fx, Math.sin(rad) * p.length * fy);
+      const length = Math.max(1, snap(free.length));
+      changes.push({
+        id: leaf.id,
+        x,
+        y,
+        props: {
+          angle: free.angle,
+          length,
+          // Same cap as the endpoint/panel commits; t > length lands in the
+          // ^GB t-promotion regime and prints a t x t block.
+          thickness: Math.min(p.thickness, length),
+        },
+      });
+      continue;
+    }
+    const commitFn = getEntry(leaf.type)?.commitTransform;
+    const props = commitFn
+      ? (commitFn(leaf, { sx: fx, sy: fy, snap, nodeHeight: 0, anchor: null }) as Record<
+          string,
+          number
+        >)
+      : undefined;
+    changes.push({ id: leaf.id, x, y, props });
+  }
+  return changes;
+}

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -40,9 +40,10 @@ import { symbol } from './symbol';
 
 // Graphic shape primitives (no `props.rotation`): box/ellipse/line. They
 // quarter-turn via geometry (w/h swap, or a line's angle), unlike image which
-// shares `group: 'shape'` but cannot turn. Shared by single-object rotation and
-// tidy classification. `satisfies` catches a typo/rename; the Set stays string-
-// keyed so `.has(obj.type)` (a string) type-checks.
+// shares `group: 'shape'` but cannot turn. Shared by single-object rotation,
+// tidy classification and multi-resize scaling (content types move only).
+// `satisfies` catches a typo/rename; the Set stays string-keyed so
+// `.has(obj.type)` (a string) type-checks.
 export const SHAPE_PRIMITIVE_TYPES: ReadonlySet<string> = new Set(
   ['box', 'ellipse', 'line'] as const satisfies readonly LeafType[],
 );


### PR DESCRIPTION
The selection scales as a group via an invisible transformer proxy at the model union bbox: shapes scale geometry (thickness stays), everything else reprojects its position only, in one undo entry.