### PR TITLE
fix(gs1): emit the FNC1 invocation between variable AIs

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -15,7 +15,7 @@ import { paletteGhostHandlers } from "./paletteGhostMonitor";
 import { Stage, Layer, Group, Image as KImage, Rect, Transformer } from "react-konva";
 import type Konva from "konva";
 import { useLabelStore, useCurrentObjects, currentObjects, getCurrentObjects, selectPreviewLocksEditor } from "../../store/labelStore";
-import { isGroup, getAllLeaves, expandSelection, selectionTargetId, findObjectById, canDeleteSelection, canGroupSelection, canUngroupSelection, isSelectionLocked, type LabelObject } from "../../types/Group";
+import { isGroup, getAllLeaves, exportableLeaves, expandSelection, selectionTargetId, findObjectById, canDeleteSelection, canGroupSelection, canUngroupSelection, isSelectionLocked, type LabelObject } from "../../types/Group";
 import { pxToDots, dotsToPx, mmToDots, SCREEN_PX_PER_MM } from "../../lib/coordinates";
 import { loadImage } from "../../lib/loadImage";
 import { SNAP_OPTIONS } from "../../lib/units";
@@ -75,7 +75,7 @@ import {
 import { CanvasContextMenu } from "./CanvasContextMenu";
 import { buildContextMenu, type MenuSection } from "./canvasActions";
 import { zplForSelection } from "../../lib/zplForSelection";
-import { generateMultiPageZPL, exportableLeaves } from "../../lib/zplGenerator";
+import { generateMultiPageZPL } from "../../lib/zplGenerator";
 import { nodeToPngBlob, downloadBlob, copyPngToClipboard } from "../../lib/canvasImage";
 import { printerPreviewLayout } from "../../lib/printerPreview";
 

--- a/src/lib/gs1.test.ts
+++ b/src/lib/gs1.test.ts
@@ -17,6 +17,9 @@ import {
   GS1_DATABAR_DEFAULT_SEGMENTS,
   GS1_AI_SPECS,
   gs1AddBlockReason,
+  segmentsToZplFd,
+  gs1ContentToZplFd,
+  zplFdToGs1Input,
 } from "./gs1";
 
 describe("gtin14WithCheck", () => {
@@ -364,5 +367,45 @@ describe("constants", () => {
   it("uses the spec-maximum 22 as the Expanded Stacked segments default", () => {
     expect(GS1_DATABAR_DEFAULT_SEGMENTS).toBe(22);
     expect(GS1_DATABAR_DEFAULT_SEGMENTS % 2).toBe(0);
+  });
+});
+
+describe("segmentsToZplFd / gs1ContentToZplFd (mode D ^FD form)", () => {
+  const content = "0104012345678901" + "1020260707" + GS1_GS + "17261231" + "30144";
+
+  it("adds the >8 FNC1 invocation only after non-final variable AIs", () => {
+    expect(gs1ContentToZplFd(content)).toBe(
+      "(01)04012345678901(10)20260707>8(17)261231(30)144",
+    );
+  });
+
+  it("passes unparseable content through verbatim (no re-escape corruption)", () => {
+    // A foreign mode-D field kept verbatim on import must round-trip byte-stable;
+    // re-escaping > here would turn >8 into >08 and corrupt the FNC1.
+    expect(gs1ContentToZplFd(">;>80100003486")).toBe(">;>80100003486");
+  });
+
+  it("inserts >8 for the element-string form too, not just raw content", () => {
+    // The parenthesized form must not bypass segment parsing into the fallback.
+    expect(gs1ContentToZplFd("(01)04012345678901(10)20260707(17)261231(30)144")).toBe(
+      "(01)04012345678901(10)20260707>8(17)261231(30)144",
+    );
+  });
+
+  it("adds no separator for a single or final variable AI", () => {
+    expect(gs1ContentToZplFd("1020260707")).toBe("(10)20260707");
+    expect(gs1ContentToZplFd("010401234567890110ABC")).toBe("(01)04012345678901(10)ABC");
+  });
+
+  it("escapes a literal > in values as >0", () => {
+    const segs = parseGs1ToSegments("10A>B" + GS1_GS + "30144");
+    expect(segs).not.toBeNull();
+    expect(segmentsToZplFd(segs!)).toBe("(10)A>0B>8(30)144");
+  });
+
+  it("zplFdToGs1Input undoes the invocations, including the >08 edge", () => {
+    expect(zplFdToGs1Input("(10)A>0B>8(30)144")).toBe("(10)A>B(30)144");
+    // >08 is an escaped > followed by a data 8, not an FNC1.
+    expect(zplFdToGs1Input("(10)A>08>8(30)144")).toBe("(10)A>8(30)144");
   });
 });

--- a/src/lib/gs1.ts
+++ b/src/lib/gs1.ts
@@ -375,30 +375,78 @@ function validateGs1SegmentImpl(ai: string, value: string): string | null {
   }
 }
 
+/** Escape a literal `>` in mode-D ^FD data; unescaped it reads as the >N
+ *  invocation prefix. */
+export function escapeGs1FdValue(value: string): string {
+  return value.replaceAll(">", ">0");
+}
+
+/** Inverse of escapeGs1FdValue: >0 only. Leaves >8 / GS / subset invocations
+ *  untouched so a foreign payload stays byte-stable. */
+export function unescapeGs1FdValue(value: string): string {
+  return value.replaceAll(">0", ">");
+}
+
+/** Segment value as emitted: GTIN completed to 14 digits, others verbatim. */
+function segmentValue(s: Gs1Segment): string {
+  return AI_BY_CODE.get(s.ai)?.kind === "gtin" ? gtin14WithCheck(s.value) : s.value;
+}
+
+/** A variable-length AI that is not the last segment needs a trailing FNC1
+ *  separator (GS in raw content, >8 in ZPL) so the next AI isn't absorbed. */
+function needsSeparator(s: Gs1Segment, index: number, count: number): boolean {
+  const spec = AI_BY_CODE.get(s.ai);
+  return !!spec && isVariableKind(spec.kind) && index < count - 1;
+}
+
 /** Element string `(01)…(10)…` for display and bwip-js input. GTIN values are
  *  completed to 14 digits so bwip-js accepts them. */
 export function segmentsToElementString(segments: readonly Gs1Segment[]): string {
+  return segments.map((s) => `(${s.ai})${segmentValue(s)}`).join("");
+}
+
+/** ZPL ^BC mode-D field data. Mode D auto-inserts only the LEADING FNC1
+ *  (Labelary-decoded), so a >8 after each non-final variable AI is required or
+ *  the next AI is read as value; a literal `>` escapes to >0. */
+export function segmentsToZplFd(segments: readonly Gs1Segment[]): string {
   return segments
-    .map((s) => {
-      const spec = AI_BY_CODE.get(s.ai);
-      const value = spec?.kind === "gtin" ? gtin14WithCheck(s.value) : s.value;
-      return `(${s.ai})${value}`;
-    })
+    .map((s, i) => `(${s.ai})${escapeGs1FdValue(segmentValue(s))}` +
+      (needsSeparator(s, i, segments.length) ? ">8" : ""))
     .join("");
+}
+
+/** ^FD form of model content, raw or parenthesized (see segmentsToZplFd).
+ *  Unparseable content passes through unchanged: its FNC1 positions are
+ *  unknown, and re-escaping would corrupt existing invocations. */
+export function gs1ContentToZplFd(content: string): string {
+  const segs = parseGs1ToSegments(content);
+  return segs ? segmentsToZplFd(segs) : content;
+}
+
+/** Undo the ^FD invocations on import: strip FNC1 markers (the parens already
+ *  delimit segments) and unescape literal `>`. Order matters: `>08` is an
+ *  escaped `>` followed by a data `8`, not an FNC1. */
+export function zplFdToGs1Input(raw: string): string {
+  return raw.replaceAll(">8", "").replaceAll(GS1_GS, "").replaceAll(">0", ">");
+}
+
+/** Canonical model content from a mode-D ^FD payload, or null (caller keeps
+ *  it verbatim). Parens delimit segments, so >8 is stripped there; in the raw
+ *  form >8 IS the separator and maps to GS. */
+export function zplFdToModelContent(raw: string): string | null {
+  if (raw.startsWith("(")) return elementStringToContent(zplFdToGs1Input(raw));
+  const content = unescapeGs1FdValue(raw.replaceAll(">8", GS1_GS));
+  const segs = parseGs1ToSegments(content);
+  return segs && segs.length > 0 ? segmentsToContent(segs) : null;
 }
 
 /** Raw model `content`: AI+value concatenated, with a GS separator after a
  *  variable-length AI that is not the last segment. GTIN completed to 14. */
 export function segmentsToContent(segments: readonly Gs1Segment[]): string {
-  let out = "";
-  segments.forEach((s, i) => {
-    const spec = AI_BY_CODE.get(s.ai);
-    const value = spec?.kind === "gtin" ? gtin14WithCheck(s.value) : s.value;
-    out += s.ai + value;
-    const variable = spec ? isVariableKind(spec.kind) : false;
-    if (variable && i < segments.length - 1) out += GS1_GS;
-  });
-  return out;
+  return segments
+    .map((s, i) => s.ai + segmentValue(s) +
+      (needsSeparator(s, i, segments.length) ? GS1_GS : ""))
+    .join("");
 }
 
 /** AI code present at `pos`, longest match first, or null. */

--- a/src/lib/gs1ModeDFns.ts
+++ b/src/lib/gs1ModeDFns.ts
@@ -1,0 +1,53 @@
+import { exportableLeaves, type LabelObject } from "../types/Group";
+import { extractTemplateRefs } from "./fnTemplate";
+import { getObjectStringContent } from "./variableBinding";
+import type { Variable } from "../types/Variable";
+
+/** ^BR and GS1 DataMatrix encode FNC1 differently and must not match. */
+export function isModeDLeaf(leaf: LabelObject): boolean {
+  return leaf.type === "code128" && (leaf.props as { gs1?: boolean }).gs1 === true;
+}
+
+function sweepFnConsumers(
+  objects: readonly LabelObject[],
+  variables: readonly Variable[],
+): { modeD: Set<number>; other: Set<number> } {
+  const fnByName = new Map(variables.map((v) => [v.name, v.fnNumber]));
+  const modeD = new Set<number>();
+  const other = new Set<number>();
+  // A non-exported consumer never prints, so it must not influence the sets.
+  for (const leaf of exportableLeaves(objects)) {
+    const c = getObjectStringContent(leaf);
+    if (c === undefined) continue;
+    const target = isModeDLeaf(leaf) ? modeD : other;
+    for (const name of extractTemplateRefs(c)) {
+      const fn = fnByName.get(name);
+      if (fn !== undefined) target.add(fn);
+    }
+  }
+  return { modeD, other };
+}
+
+/** ^FN numbers consumed exclusively by GS1 mode-D Code 128 fields. Firmware
+ *  substitutes one ^FN value into every consumer, so the mode-D encoding
+ *  (>0 escape, >8 FNC1) is only correct when no other field shares the slot.
+ *  Generator (escape on emit) and parser (normalize on import) both derive
+ *  this set from the document itself, keeping the round trip symmetric. */
+export function gs1ModeDExclusiveFns(
+  objects: readonly LabelObject[],
+  variables: readonly Variable[],
+): Set<number> {
+  const { modeD, other } = sweepFnConsumers(objects, variables);
+  for (const fn of other) modeD.delete(fn);
+  return modeD;
+}
+
+/** Slots a mode-D field shares with a literal consumer: no substituted value
+ *  is correct for both, so emit stays raw and preflight warns on a > value. */
+export function gs1ModeDSharedFns(
+  objects: readonly LabelObject[],
+  variables: readonly Variable[],
+): Set<number> {
+  const { modeD, other } = sweepFnConsumers(objects, variables);
+  return new Set([...modeD].filter((fn) => other.has(fn)));
+}

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -501,3 +501,37 @@ describe("markerValueFindings (typed-content marker values)", () => {
     ]);
   });
 });
+
+describe("markerValueFindings (mode-D shared ^FN slot)", () => {
+  const code128 = (id: string, content: string, gs1: boolean): LeafObject =>
+    ({ id, type: "code128", x: 0, y: 0, rotation: 0,
+       props: { content, height: 100, moduleWidth: 2, printInterpretation: false,
+                printInterpretationAbove: false, checkDigit: false, rotation: "N", gs1 } } as LabelObject as LeafObject);
+  const text = (id: string, content: string): LeafObject =>
+    ({ id, type: "text", x: 0, y: 0, rotation: 0,
+       props: { content, fontHeight: 30, fontWidth: 0, rotation: "N" } } as LabelObject as LeafObject);
+  const vars = [{ id: "v", name: "batch", fnNumber: 1, defaultValue: "A>B" }];
+  const deps = { variables: vars, csvDataset: null, csvMapping: null };
+  const gs1Content = "0104012345678901" + "10«batch»";
+
+  it("warns when a > value feeds a slot shared with a non-GS1 field", () => {
+    const out = markerValueFindings(
+      [code128("c", gs1Content, true), text("t", "lot «batch» end")], deps);
+    expect(out).toEqual([
+      { objectId: "c", kind: "markerValueUnsafe", severity: "warning",
+        detail: '">" in batch prints as an invocation code (slot shared with a non-GS1 field)' },
+    ]);
+  });
+
+  it("stays quiet for an exclusive slot (the emit escape handles it)", () => {
+    expect(markerValueFindings([code128("c", gs1Content, true)], deps)).toEqual([]);
+  });
+
+  it("stays quiet for a shared slot without > in any printing value", () => {
+    const clean = [{ id: "v", name: "batch", fnNumber: 1, defaultValue: "LOT7" }];
+    const out = markerValueFindings(
+      [code128("c", gs1Content, true), text("t", "lot «batch» end")],
+      { variables: clean, csvDataset: null, csvMapping: null });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -8,6 +8,7 @@ import { extractTemplateRefs, hasTemplateMarkers } from "./fnTemplate";
 import { isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
+import { gs1ModeDSharedFns, isModeDLeaf } from "./gs1ModeDFns";
 import { isBlankText } from "./zebraTextLayout";
 import { resolveTextMode } from "../registry/text";
 import type { CsvMapping, Variable } from "../types/Variable";
@@ -182,6 +183,32 @@ export function markerValueFindings(
     }
     markerValueCache.set(leaf, { ...deps, findings });
     out.push(...findings);
+  }
+  // Shared slot (see gs1ModeDSharedFns): a > in any printing value scans as
+  // an invocation code. Cross-leaf state, so outside the per-leaf cache.
+  const shared = gs1ModeDSharedFns(leaves, deps.variables);
+  if (shared.size > 0) {
+    const byName = new Map(deps.variables.map((v) => [v.name, v]));
+    for (const leaf of leaves) {
+      if (!isModeDLeaf(leaf)) continue;
+      const content = getObjectStringContent(leaf);
+      if (content === undefined || !hasTemplateMarkers(content)) continue;
+      const dirty: string[] = [];
+      for (const name of new Set(extractTemplateRefs(content))) {
+        const v = byName.get(name);
+        if (!v || !shared.has(v.fnNumber)) continue;
+        if (variableSubstitutions(v, deps.csvDataset, deps.csvMapping).some((val) => val.includes(">"))) {
+          dirty.push(v.name);
+        }
+      }
+      if (dirty.length > 0) {
+        out.push(finding(
+          leaf,
+          "markerValueUnsafe",
+          `">" in ${dirty.join(", ")} prints as an invocation code (slot shared with a non-GS1 field)`,
+        ));
+      }
+    }
   }
   return out;
 }

--- a/src/lib/zplGenerator.ts
+++ b/src/lib/zplGenerator.ts
@@ -13,11 +13,13 @@ import {
 } from './fcTemplate';
 import { boundColumnIndex, getObjectStringContent } from './variableBinding';
 import { classifyField } from './variableField';
+import { escapeGs1FdValue } from './gs1';
+import { gs1ModeDExclusiveFns } from './gs1ModeDFns';
 import { formatLabelMetaComment } from './zplLabelMeta';
 import type { ClockOffset, CustomFontMapping, LabelConfig } from '../types/LabelConfig';
 import type { ZplEmitContext } from '../types/ZplEmit';
 import type { Variable } from '../types/Variable';
-import { isGroup, walkObjects, type LabelObject, type LeafObject, type Page } from '../types/Group';
+import { exportableLeaves, isGroup, walkObjects, type LabelObject, type LeafObject, type Page } from '../types/Group';
 import { isOverlayConsistent } from './zplOverlay/overlay';
 import { objectBoundsDots, type ObjectBoundsCtx } from './objectBounds';
 import { formatFontDownloadFromPath } from './customFonts';
@@ -62,6 +64,7 @@ export function planTemplateHeader(
 ): { headerLines: string[]; emitCtx: ZplEmitContext } {
   // O(N+V) vs O(N*V) per-marker re-scan.
   const varsByName = new Map(variables.map((v) => [v.name, v]));
+  const modeDFns = gs1ModeDExclusiveFns(shifted, variables);
 
   const templatePayloads: string[] = [];
   const clockPayloads: string[] = [];
@@ -108,7 +111,9 @@ export function planTemplateHeader(
     if (pickedEmbedChar !== '#') headerLines.push(`^FE${pickedEmbedChar}`);
     for (const [fn, v] of [...templateVarsByFn].sort(([a], [b]) => a - b)) {
       if (singleBindFns.has(fn)) continue;
-      headerLines.push(`^FN${fn}${fdField(v.defaultValue)}`);
+      // Mode-D-exclusive slot: > needs its >0 invocation (parser reverses).
+      const def = modeDFns.has(fn) ? escapeGs1FdValue(v.defaultValue) : v.defaultValue;
+      headerLines.push(`^FN${fn}${fdField(def)}`);
     }
     emitCtx.embedChar = pickedEmbedChar;
   }
@@ -201,21 +206,6 @@ export function generateMultiPageZPL(
   return out;
 }
 
-/** Leaves that would actually export, honouring the `includeInExport=false`
- *  cascade through groups (mirrors `emitLeaf`). Also the leaf set preflight
- *  warns over, so its off-label checks track what prints, not editor visibility. */
-export function exportableLeaves(objects: LabelObject[]): LeafObject[] {
-  const out: LeafObject[] = [];
-  const walk = (list: LabelObject[]): void => {
-    for (const o of list) {
-      if (o.includeInExport === false) continue;
-      if (isGroup(o)) walk(o.children);
-      else out.push(o);
-    }
-  };
-  walk(objects);
-  return out;
-}
 
 /** Emit one page from its overlay: verbatim segments for untouched objects,
  *  in-place regeneration for dirty ones, appended fields for new ones, raw
@@ -361,6 +351,7 @@ export function generateBatchZpl(
   // Excluded leaves aren't in the stored template, so don't source a transform
   // from one (it could shadow an exported field sharing the same variable).
   const leaves = [...walkObjects(objects)].filter((o) => o.includeInExport !== false);
+  const modeDFns = gs1ModeDExclusiveFns(objects, variables);
   const overrides: { fn: number; colIdx: number; transform: (s: string) => string }[] = [];
   for (const v of variables) {
     const colIdx = boundColumnIndex(v, csvDataset, csvMapping);
@@ -375,9 +366,11 @@ export function generateBatchZpl(
       const cls = classifyField(c, variables);
       return cls.kind === "single" && cls.variable.id === v.id;
     });
+    // A template-embedded mode-D slot has no bound transform but still
+    // needs the > escape.
     const transform =
       (bound && !isGroup(bound) ? getEntry(bound.type)?.fdTransform?.(bound) : undefined) ??
-      identity;
+      (modeDFns.has(v.fnNumber) ? escapeGs1FdValue : identity);
     overrides.push({ fn: v.fnNumber, colIdx, transform });
   }
 

--- a/src/lib/zplParser.ts
+++ b/src/lib/zplParser.ts
@@ -1,4 +1,8 @@
 import { DEFAULT_CLOCK_CHARS, isDefaultClockChars } from "./fcTemplate";
+import { unescapeGs1FdValue, zplFdToModelContent } from "./gs1";
+import { gs1ModeDExclusiveFns } from "./gs1ModeDFns";
+import { extractTemplateRefs } from "./fnTemplate";
+import { isLoneMarker } from "./variableField";
 import { markerOf } from "../types/Variable";
 import { getObjectStringContent } from "./variableBinding";
 import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
@@ -271,6 +275,29 @@ export function parseZPL(
     const marker = markerOf(v.name);
     const used = objects.some((o) => getObjectStringContent(o)?.includes(marker));
     if (!used) variables.splice(i, 1);
+  }
+
+  // Normalize mode-D-exclusive ^FN defaults to model form (inverse of the
+  // emit escape; mixed slots stay raw, see gs1ModeDExclusiveFns). A lone-marker
+  // slot holds the whole payload and gets the full decode; an embedded slot is
+  // one AI's value, where canonicalization could mutate bytes (GTIN check
+  // digit), so only the >0 escape reverses.
+  const modeDFns = gs1ModeDExclusiveFns(objects, variables);
+  if (modeDFns.size > 0) {
+    const fnByVarName = new Map(variables.map((v) => [v.name, v.fnNumber]));
+    const loneMarkerFns = new Set<number>();
+    for (const o of objects) {
+      const c = getObjectStringContent(o);
+      if (c === undefined || !isLoneMarker(c)) continue;
+      const fn = fnByVarName.get(extractTemplateRefs(c)[0] ?? "");
+      if (fn !== undefined) loneMarkerFns.add(fn);
+    }
+    for (const v of variables) {
+      if (!modeDFns.has(v.fnNumber)) continue;
+      v.defaultValue = loneMarkerFns.has(v.fnNumber)
+        ? (zplFdToModelContent(v.defaultValue) ?? unescapeGs1FdValue(v.defaultValue))
+        : unescapeGs1FdValue(v.defaultValue);
+    }
   }
 
   // Build the overlay only when every parsed object linked to a source span;

--- a/src/lib/zplParser/flushField.ts
+++ b/src/lib/zplParser/flushField.ts
@@ -10,7 +10,7 @@ import { embedsToMarkers } from "../fnTemplate";
 import { tokensToMarkers } from "../fcTemplate";
 import { decodeFbContent } from "../fbContent";
 import { decodeTbContent } from "../tbContent";
-import { elementStringToContent } from "../gs1";
+import { zplFdToModelContent } from "../gs1";
 import { dataMatrixFdToGs1Content } from "../dataMatrixFd";
 import { zplAnchorToModel } from "../labelGeometry/textPositionTransforms";
 import { blockInterLineExtentDots } from "../zebraTextLayout";
@@ -238,7 +238,7 @@ export function createFlushField(
             s.field.x,
             s.field.y,
             {
-              content: gs1 ? (elementStringToContent(content) ?? content) : content,
+              content: gs1 ? (zplFdToModelContent(content) ?? content) : content,
               height: s.field.bcHeight,
               moduleWidth: s.defaults.byModuleWidth,
               printInterpretation: s.field.bcInterp,

--- a/src/registry/barcode1d.ts
+++ b/src/registry/barcode1d.ts
@@ -7,7 +7,7 @@ import { commitBarcodeWidthHeightTransform } from './transformHelpers';
 import { hasTemplateMarkers } from '../lib/fnTemplate';
 import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { isLoneMarker } from '../lib/variableField';
-import { gs1ContentToElementString, parseGs1ToSegments, segmentsToElementString } from '../lib/gs1';
+import { gs1ContentToZplFd, parseGs1ToSegments, segmentsToZplFd } from '../lib/gs1';
 import { type ZplRotation } from './rotation';
 
 export interface Barcode1DProps {
@@ -68,10 +68,10 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
     checkDigit: false,
     rotation: 'N',
   };
-  // Obj-aware ^FD transform (fdContent, or the GS1 element-string form in GS1
+  // Obj-aware ^FD transform (fdContent, or the GS1 mode-D ^FD form in GS1
   // mode), applied to literal/single-bind payloads. A template gets none: the
   // post-embed transform would mangle its #n# references; GS1 templates are
-  // instead pre-mapped to element-string form at segment level in toZPL.
+  // instead pre-mapped to the ^FD form at segment level in toZPL.
   // Shared by toZPL and the batch override.
   const fdTransformFor =
     config.fdContent || config.gs1Capable
@@ -81,7 +81,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
           if (hasTemplateMarkers(obj.props.content) && !isLoneMarker(obj.props.content)) {
             return undefined;
           }
-          if (config.gs1Capable && obj.props.gs1) return gs1ContentToElementString;
+          if (config.gs1Capable && obj.props.gs1) return gs1ContentToZplFd;
           return config.fdContent;
         }
       : undefined;
@@ -116,7 +116,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
     // e.g. UPC-E compaction; shared with the CSV batch override so a per-row
     // value is compacted the same way as the single-format default. Undefined
     // on a template field (see fdTransformFor; GS1 templates are handled by
-    // toZPL's segment-level element-string pre-map instead).
+    // toZPL's segment-level ^FD pre-map instead).
     fdTransform: fdTransformFor,
 
     toZPL: (obj, ctx) => {
@@ -138,19 +138,23 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
       // symbology's fdContent transform (e.g. UPC-E's number-system prefix) so a
       // serialized barcode emits the same payload shape as a non-serial one.
       const fdTransform = fdTransformFor?.(obj);
-      // GS1 TEMPLATE payload: convert to the element-string form at SEGMENT
-      // level (markers intact) BEFORE ^FE embed expansion. The post-embed
-      // transform would mangle the #n# references, and skipping it entirely
-      // would emit the raw GS-separated form literal payloads never use.
-      // Unparseable template content falls back to raw emit unchanged.
+      // GS1 TEMPLATE payload: pre-map to the mode-D ^FD form at SEGMENT level
+      // BEFORE ^FE embed expansion (the post-embed transform would mangle the
+      // #n# references). Unparseable content falls back to raw emit; marker
+      // VALUES are escaped at their ^FN declaration (gs1ModeDExclusiveFns).
       let content = p.content;
+      let fdTransformOnce = fdTransform;
       if (config.gs1Capable && p.gs1 && hasTemplateMarkers(content) && !isLoneMarker(content)) {
         const segs = ctx?.variables ? parseGs1ToSegments(content, ctx.variables) : null;
-        if (segs && segs.length > 0) content = segmentsToElementString(segs);
+        // Already the ^FD form; a second transform would double the >0 escapes.
+        if (segs && segs.length > 0) {
+          content = segmentsToZplFd(segs);
+          fdTransformOnce = undefined;
+        }
       }
       const fieldData = obj.props.serial
         ? serialFieldData(fdTransform ? fdTransform(p.content) : p.content, obj.props.serial)
-        : fdFieldFor(content, ctx, fdTransform);
+        : fdFieldFor(content, ctx, fdTransformOnce);
       return [
         byCmd,
         fieldPos(obj),

--- a/src/registry/code128.gs1.test.ts
+++ b/src/registry/code128.gs1.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { code128 } from './code128';
 import { parseZPL } from '../lib/zplParser';
-import { generateZPL } from '../lib/zplGenerator';
-import { GS1_SAMPLE_CONTENT, elementStringToContent } from '../lib/gs1';
+import { generateZPL, generateBatchZpl } from '../lib/zplGenerator';
+import type { Variable } from '../types/Variable';
+import { GS1_SAMPLE_CONTENT, GS1_GS, elementStringToContent } from '../lib/gs1';
 import { PALETTE_PRESET_IDS } from './palettePresets';
 import type { LabelConfig } from '../types/LabelConfig';
 import type { LabelObject } from '../types/Group';
@@ -61,7 +62,7 @@ describe('GS1-128 (code128 gs1 mode)', () => {
     const canonical = elementStringToContent('(01)09501101530003(10)LOT123(21)SER456');
     expect(canonical).not.toBeNull();
     const zpl = generateZPL(LABEL, [mk({ ...baseProps, gs1: true, content: canonical! })]);
-    expect(zpl).toContain('^FD(01)09501101530003(10)LOT123(21)SER456^FS');
+    expect(zpl).toContain('^FD(01)09501101530003(10)LOT123>8(21)SER456^FS');
     const { objects } = parseZPL(zpl, LABEL.dpmm);
     expect(propsOf(objects[0]).gs1).toBe(true);
     expect(propsOf(objects[0]).content).toBe(canonical);
@@ -92,5 +93,120 @@ describe('GS1-128 (code128 gs1 mode)', () => {
 
   it('registers the GS1-128 palette preset', () => {
     expect(PALETTE_PRESET_IDS).toContain('code128-gs1');
+  });
+});
+
+describe('GS1-128 FNC1 separators (mode D)', () => {
+  // Mode D only auto-inserts the leading FNC1 (Labelary-decoded), so the emit
+  // must place >8 after each non-final variable AI or scanners merge the AIs.
+  it('emits >8 after a non-final variable AI', () => {
+    const content = '0104012345678901' + '1020260707' + GS1_GS + '17261231' + '30144';
+    const zpl = code128.toZPL(mk({ ...baseProps, gs1: true, content }) as never);
+    expect(zpl).toContain('^FD(01)04012345678901(10)20260707>8(17)261231(30)144^FS');
+  });
+
+  it('round-trips a literal > in static content without compounding the escape', () => {
+    // (10)A>B emits (10)A>0B; parse must unescape so a second export is stable.
+    const zpl1 = generateZPL(LABEL, [mk({ ...baseProps, gs1: true, content: '10A>B' })]);
+    expect(zpl1).toContain('^FD(10)A>0B^FS');
+    const { objects } = parseZPL(zpl1, LABEL.dpmm);
+    expect(propsOf(objects[0]).content).toBe('10A>B');
+    expect(generateZPL(LABEL, objects as never)).toContain('^FD(10)A>0B^FS');
+  });
+
+  it('round-trips the >8 form back to canonical GS content', () => {
+    const zpl = '^XA^FO10,10^BCN,100,N,N,N,D^FD(01)04012345678901(10)20260707>8(17)261231(30)144^FS^XZ';
+    const { objects } = parseZPL(zpl, 8);
+    const p = propsOf(objects[0]);
+    expect(p.gs1).toBe(true);
+    expect(p.content).toBe('0104012345678901' + '1020260707' + GS1_GS + '17261231' + '30144');
+  });
+});
+
+describe('GS1-128 mode-D ^FN value symmetry', () => {
+  const vars: Variable[] = [{ id: 'v', name: 'batch', fnNumber: 1, defaultValue: 'A>B' }];
+  const tplContent = '01' + '04012345678901' + '10' + '«' + 'batch' + '»';
+  const gs1Tpl = () => mk({ ...baseProps, gs1: true, content: tplContent });
+  const textConsumer = () => ({
+    id: 't', type: 'text', x: 10, y: 60, rotation: 0,
+    props: { content: '«' + 'batch' + '» suffix', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+  }) as never;
+
+  it('escapes > in the ^FN default when the slot feeds only mode-D fields', () => {
+    expect(generateZPL(LABEL, [gs1Tpl()], vars)).toContain('^FN1^FDA>0B^FS');
+  });
+
+  it('normalizes a raw (non-paren) mode-D field payload to model form', () => {
+    const zpl = '^XA^FO10,10^BCN,100,N,N,N,D^FD010401234567890110LOT>821SER^FS^XZ';
+    const { objects } = parseZPL(zpl, LABEL.dpmm);
+    expect(propsOf(objects[0]).content).toBe('010401234567890110LOT' + GS1_GS + '21SER');
+  });
+
+  it('normalizes a raw mode-D single-bind ^FN default to model form', () => {
+    const zpl =
+      '^XA^FN1^FD010401234567890110LOT>821SER^FS' +
+      '^BY2^FO10,10^BCN,100,N,N,N,D^FE#^FD#1#^FS^XZ';
+    const parsed = parseZPL(zpl, LABEL.dpmm);
+    expect(parsed.variables.find((v) => v.fnNumber === 1)?.defaultValue)
+      .toBe('010401234567890110LOT' + GS1_GS + '21SER');
+  });
+
+  it('keeps an embedded numeric default byte-identical (no GS1 canonicalization)', () => {
+    // Value slot of (10); a 16-digit serial that HAPPENS to parse as (01)+14
+    // digits must not get a recomputed check digit.
+    const zpl =
+      '^XA^FN1^FD0112345678901231^FS' +
+      '^BY2^FO10,10^BCN,100,N,N,N,D^FE#^FD(01)04012345678901(10)#1#^FS^XZ';
+    const parsed = parseZPL(zpl, LABEL.dpmm);
+    expect(parsed.variables.find((v) => v.fnNumber === 1)?.defaultValue).toBe('0112345678901231');
+  });
+
+  it('preserves a foreign mode-D ^FN default byte-for-byte (no >8/GS stripping)', () => {
+    const zpl =
+      '^XA^FN1^FD>;>80100003486^FS' +
+      '^BY2^FO10,10^BCN,100,N,N,N,D^FE#^FD(01)04012345678901(10)#1#^FS^XZ';
+    const parsed = parseZPL(zpl, LABEL.dpmm);
+    expect(parsed.variables.find((v) => v.fnNumber === 1)?.defaultValue).toBe('>;>80100003486');
+  });
+
+  it('does not suppress the escape for a slot shared only with an EXCLUDED consumer', () => {
+    const gs1 = mk({ ...baseProps, gs1: true, content: '01' + '04012345678901' + '10' + '«' + 'batch' + '»' });
+    const excluded = {
+      id: 'g', type: 'group', x: 0, y: 0, rotation: 0, includeInExport: false,
+      children: [{ id: 't', type: 'text', x: 10, y: 60, rotation: 0,
+        props: { content: '«' + 'batch' + '» x', fontHeight: 30, fontWidth: 0, rotation: 'N' } }],
+      props: {},
+    } as never;
+    expect(generateZPL(LABEL, [gs1, excluded], vars)).toContain('^FN1^FDA>0B^FS');
+  });
+
+  it('round-trips the escaped default back to the raw > (no compounding)', () => {
+    const zpl = generateZPL(LABEL, [gs1Tpl()], vars);
+    const parsed = parseZPL(zpl, LABEL.dpmm);
+    expect(parsed.variables.find((v) => v.fnNumber === 1)?.defaultValue).toBe('A>B');
+    const zpl2 = generateZPL(LABEL, parsed.objects as never, parsed.variables);
+    expect(zpl2).toContain('^FN1^FDA>0B^FS');
+  });
+
+  it('keeps the default raw when a non-GS1 field shares the slot', () => {
+    expect(generateZPL(LABEL, [gs1Tpl(), textConsumer()], vars)).toContain('^FN1^FDA>B^FS');
+  });
+
+  it('escapes the per-row CSV value only for a mode-D-exclusive slot', () => {
+    const batch = (objs: Parameters<typeof generateBatchZpl>[1]) => generateBatchZpl(LABEL, objs, vars,
+      { headers: ['batch'], rows: [['X>Y']] }, { bindings: { v: 'batch' } });
+    expect(batch([gs1Tpl()])).toContain('^FN1^FDX>0Y^FS');
+    expect(batch([gs1Tpl(), textConsumer()])).toContain('^FN1^FDX>Y^FS');
+  });
+
+  it('normalizes a single-bind gs1 default to model form (stable re-export)', () => {
+    const content = '0104012345678901' + '10LOT>X' + GS1_GS + '21SER';
+    const single = mk({ ...baseProps, gs1: true, content: '«' + 'lot' + '»' });
+    const singleVars: Variable[] = [{ id: 'w', name: 'lot', fnNumber: 2, defaultValue: content }];
+    const zpl1 = generateZPL(LABEL, [single], singleVars);
+    const parsed = parseZPL(zpl1, LABEL.dpmm);
+    expect(parsed.variables.find((v) => v.fnNumber === 2)?.defaultValue).toBe(content);
+    const zpl2 = generateZPL(LABEL, parsed.objects as never, parsed.variables);
+    expect(zpl2).toBe(zpl1);
   });
 });

--- a/src/types/Group.ts
+++ b/src/types/Group.ts
@@ -27,13 +27,28 @@ export function isGroup(obj: LabelObject): obj is GroupObject {
 }
 
 /** DFS yielding parent before children, in render order. */
-export function* walkObjects(objects: LabelObject[]): Iterable<LabelObject> {
+export function* walkObjects(objects: readonly LabelObject[]): Iterable<LabelObject> {
   for (const obj of objects) {
     yield obj;
     if (isGroup(obj)) {
       yield* walkObjects(obj.children);
     }
   }
+}
+
+/** Leaves that actually export: an `includeInExport=false` node hides its
+ *  whole subtree. Also the preflight leaf set, so checks track what prints. */
+export function exportableLeaves(objects: readonly LabelObject[]): LeafObject[] {
+  const out: LeafObject[] = [];
+  const walk = (list: readonly LabelObject[]): void => {
+    for (const o of list) {
+      if (o.includeInExport === false) continue;
+      if (isGroup(o)) walk(o.children);
+      else out.push(o);
+    }
+  };
+  walk(objects);
+  return out;
 }
 
 /** Flat list of every leaf descendant of `objects`. Skips group nodes themselves. */


### PR DESCRIPTION
^BC mode D only auto-inserts the leading FNC1 (Labelary-decoded), so without >8 a scanner merges the AIs after a variable field; literal > escapes as >0 and the parser undoes both on import.