### PR TITLE
fix(ui): dialogs close via X and Escape only, not backdrop clicks

### DIFF
--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -14,7 +14,7 @@ interface ConfirmDialogProps {
  * Minimal confirm dialog matching the project's modal aesthetic.
  *
  * Mount it conditionally (`{open && <ConfirmDialog … />}`); the parent owns
- * visibility state. Backdrop click and Escape both fire `onCancel`.
+ * visibility state. Escape fires `onCancel`.
  */
 export function ConfirmDialog({
   message,

--- a/src/components/ui/DialogShell.test.tsx
+++ b/src/components/ui/DialogShell.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { DialogShell } from './DialogShell';
+
+afterEach(cleanup);
+
+function setup() {
+  const onClose = vi.fn();
+  const utils = render(
+    <DialogShell onClose={onClose} labelledBy="t" boxClassName="box">
+      <span id="t">Title</span>
+      <input aria-label="field" />
+    </DialogShell>,
+  );
+  const backdrop = utils.getByRole('dialog');
+  const input = utils.getByLabelText('field');
+  return { onClose, backdrop, input };
+}
+
+describe('DialogShell close mechanics', () => {
+  it('backdrop interactions never dismiss (stray click or selection drag)', () => {
+    // Historic bug: any backdrop click closed, which a selection drag released
+    // past the dialog edge also fired (click targets the common ancestor).
+    const { onClose, backdrop, input } = setup();
+    fireEvent.pointerDown(backdrop);
+    fireEvent.pointerUp(backdrop);
+    fireEvent.click(backdrop);
+    fireEvent.pointerDown(input);
+    fireEvent.pointerUp(backdrop);
+    fireEvent.click(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Escape closes', () => {
+    const { onClose, backdrop } = setup();
+    fireEvent.keyDown(backdrop, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ui/DialogShell.tsx
+++ b/src/components/ui/DialogShell.tsx
@@ -27,12 +27,9 @@ type Props = Labelling & {
 };
 
 /** Modal shell: backdrop + dialog box with focus trap, body scroll
- *  lock, ARIA dialog semantics, and Escape / click-outside close.
- *
- *  Backdrop close uses click + target===currentTarget: the click event
- *  only fires when press and release land on the same element, so
- *  dragging text out of an input or starting a selection on the
- *  backdrop and releasing inside the dialog will not close it. */
+ *  lock, and ARIA dialog semantics. Closes via X and Escape only, like a
+ *  native dialog: a backdrop click never dismisses, so a stray click or a
+ *  text selection dragged past the dialog edge cannot throw away state. */
 export function DialogShell(props: Props) {
   const {
     onClose,
@@ -56,7 +53,6 @@ export function DialogShell(props: Props) {
       // that purely programmatic focus.
       tabIndex={-1}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 focus:outline-none"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role={role}
       aria-modal="true"
       aria-labelledby={labelledBy}


### PR DESCRIPTION
click fires on the common ancestor of press and release, so a text selection dragged past the dialog edge dismissed the modal; dropping backdrop close entirely matches native dialog behaviour and removes the whole failure class.