### PR TITLE
feat(canvas): Alt resizes barcodes symmetrically around the center

### DIFF
--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -336,7 +336,6 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     return () => observer.disconnect();
   }, []);
 
-  useAltClickCycle({ containerRef, stageRef, selectObject });
 
   // Global binding so user can exit preview from anywhere.
   useEffect(() => {
@@ -895,6 +894,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     resizeEnabled,
     enabledAnchors,
     centeredScaling,
+    centeredResizeArmed,
     onTransformStart,
     onTransform,
     boundBoxFunc,
@@ -921,6 +921,10 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     viewRotation,
     previewLocks,
   });
+
+  // After useKonvaTransformer: reuses its centeredResizeArmed so the Alt-handle
+  // bypass matches the reflow arming's resolved leaf selection exactly.
+  useAltClickCycle({ containerRef, stageRef, selectObject, resizeArmed: centeredResizeArmed });
 
   // Step-rotation only (text/barcodes); box/ellipse/line/image use Transformer.
   const singleSelected = selectedIds.length === 1

--- a/src/components/Canvas/hooks/useAltClickCycle.ts
+++ b/src/components/Canvas/hooks/useAltClickCycle.ts
@@ -12,6 +12,9 @@ interface Options {
   containerRef: React.RefObject<HTMLDivElement | null>;
   stageRef: React.RefObject<Konva.Stage | null>;
   selectObject: (id: string | null) => void;
+  /** True when the single selection supports Alt-centered resize (1D barcode or
+   *  2D matrix code); only then does an Alt+handle grab bypass the cycle. */
+  resizeArmed: boolean;
 }
 
 /**
@@ -23,7 +26,18 @@ interface Options {
  * takes over selection without competing with the per-object onClick
  * handlers in KonvaObject.
  */
-export function useAltClickCycle({ containerRef, stageRef, selectObject }: Options): void {
+export function useAltClickCycle({
+  containerRef,
+  stageRef,
+  selectObject,
+  resizeArmed,
+}: Options): void {
+  // Kept in a ref so the capture-phase listener reads the latest value without
+  // re-subscribing on every selection change.
+  const resizeArmedRef = useRef(resizeArmed);
+  useEffect(() => {
+    resizeArmedRef.current = resizeArmed;
+  }, [resizeArmed]);
   const anchorRef = useRef<CycleAnchor | null>(null);
   useEffect(() => {
     const el = containerRef.current;
@@ -35,6 +49,10 @@ export function useAltClickCycle({ containerRef, stageRef, selectObject }: Optio
       if (!stage) return;
       const rect = el.getBoundingClientRect();
       const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      // A handle sits over object ink, so without this the cycle eats the
+      // Alt+handle grab; gated on resizeArmed so only centered-capable types
+      // bypass (supportsCenteredResize documents why others must not).
+      if (resizeArmedRef.current && stage.getIntersection(point)?.hasName("_anchor")) return;
       // Konva's own hit-graph respects view rotation, pan offset,
       // per-shape transforms and the listening flag; the cycle variant adds
       // a client-rect fallback so frame interiors stay reachable.

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -121,6 +121,13 @@ function applyResizeObjectSnap(
  *  it for multi-resize so member nodes never stretch live. */
 export const MULTI_RESIZE_PROXY_ID = "multi-resize-proxy";
 
+/** Types the transformer mirrors under Alt (1D barcodes, uniform-2D matrix
+ *  codes); mirrors the barcodeReflow arming, so the exposed centeredResizeArmed
+ *  matches it. Others pin one edge and jitter under Alt. Registry-derived. */
+function supportsCenteredResize(type: string): boolean {
+  return BARCODE_1D_TYPES.has(type) || !!getEntry(type)?.uniformScaleProp;
+}
+
 interface Options {
   transformerRef: React.RefObject<Konva.Transformer | null>;
   stageRef: React.RefObject<Konva.Stage | null>;
@@ -162,8 +169,11 @@ export interface TransformerState {
   /** Center-justified glyph blocks scale from the center so the box grows
    *  symmetrically and tracks the centered text live. */
   centeredScaling: boolean;
+  /** The single selection supports Alt-centered resize (1D barcode or 2D matrix
+   *  code); the Alt-handle bypass gates on it. */
+  centeredResizeArmed: boolean;
   onTransformStart: () => void;
-  onTransform: () => void;
+  onTransform: (e?: Konva.KonvaEventObject<Event>) => void;
   boundBoxFunc: (oldBox: BoundingBox, newBox: BoundingBox) => BoundingBox;
   onTransformEnd: () => void;
 }
@@ -255,12 +265,14 @@ export function useKonvaTransformer({
         uprightH0: number;
         snapshot: { x: number; y: number; moduleWidth: number; height?: number };
         changed: boolean;
+        lastCentered: boolean;
       })
     | (BarcodeHeightReflowStart & {
         mode: "height";
         uprightW0: number;
         snapshot: { x: number; y: number; height: number };
         changed: boolean;
+        lastCentered: boolean;
       })
     | (UniformReflowStart & {
         mode: "uniform";
@@ -272,6 +284,7 @@ export function useKonvaTransformer({
         uprightH0?: number;
         snapshot: { x: number; y: number; modules: number };
         changed: boolean;
+        lastCentered: boolean;
       })
     | null
   >(null);
@@ -306,7 +319,9 @@ export function useKonvaTransformer({
   // commit so toggling Alt mid-drag can't make start and end disagree.
   const blockResizeModeRef = useRef<"frame" | "glyph">("frame");
 
-  // Alt held at drag release flips the block resize mode for that one drag.
+  // Live Alt state: sampled once at drag start for the block resize mode,
+  // and read live per tick for centered barcode resize (mirrors Konva's own
+  // Alt-driven preview).
   const altKeyRef = useRef(false);
   useEffect(() => {
     const sync = (e: KeyboardEvent) => { altKeyRef.current = e.altKey; };
@@ -433,6 +448,9 @@ export function useKonvaTransformer({
       ? multiResizeBboxDots != null
       : selectedIds.length === 1 && !singleSelected?.locked;
   const singleType = singleSelected?.type ?? "";
+  // Exposed so the Alt-handle bypass (useAltClickCycle) gates on the SAME
+  // resolved leaf selection the reflow arming uses, not a re-derived one.
+  const centeredResizeArmed = supportsCenteredResize(singleType);
   const typeEntry = getEntry(singleType);
   const uniformScaleDef = typeEntry?.uniformScale;
   // uniformScaleProp implies uniformScale: integer-module 2D symbology scales
@@ -727,6 +745,7 @@ export function useKonvaTransformer({
             // baseline must restore that too.
             snapshot: { x: obj.x, y: obj.y, moduleWidth: p.moduleWidth, height: p.height },
             changed: false,
+            lastCentered: altKeyRef.current,
           };
           useLabelStore.temporal.getState().pause();
         } else if (heightAxisActive && typeof p.height === "number" && p.height > 0 && uprightH0 > 0) {
@@ -743,6 +762,7 @@ export function useKonvaTransformer({
             uprightW0: cache.uprightBarWDots ?? 0,
             snapshot: { x: obj.x, y: obj.y, height: p.height },
             changed: false,
+            lastCentered: altKeyRef.current,
           };
           useLabelStore.temporal.getState().pause();
         }
@@ -772,6 +792,7 @@ export function useKonvaTransformer({
           uprightH0: cache?.uprightBarHDots,
           snapshot: { x: obj.x, y: obj.y, modules },
           changed: false,
+          lastCentered: altKeyRef.current,
         };
         useLabelStore.temporal.getState().pause();
       }
@@ -782,7 +803,10 @@ export function useKonvaTransformer({
   // into blockWidth/blockLines, re-wrap via a synchronous store update, reset
   // the scale, re-pin the anchored edge, and re-baseline the handles. Keeps
   // glyphs constant and justify correct because the content actually re-renders.
-  const onTransform = () => {
+  const onTransform = (e?: Konva.KonvaEventObject<Event>) => {
+    // Track the drag's own Alt state, so a keydown missed before window focus
+    // (or an Alt+Tab blur) can't desync us from Konva's e.altKey centering.
+    if (e?.evt && "altKey" in e.evt) altKeyRef.current = (e.evt as MouseEvent).altKey;
     const mr = multiResizeRef.current;
     if (mr) {
       const fx = mr.proxy.scaleX();
@@ -878,16 +902,21 @@ export function useKonvaTransformer({
     const br = barcodeReflowRef.current;
     if (br) {
       const natural = naturalRect(node);
-      // The FT anchor and QR firmware shift both scale with magnification, so
-      // the same inversion as the 1D modes keeps them consistent with the
-      // render.
+      // Alt is read live (Konva's own preview mirrors on e.altKey live too), so
+      // holding or releasing it mid-drag flips centered resize like the preview.
+      const centered = altKeyRef.current;
+      // A mid-band Alt flip moves the pin by half the accumulated delta; write
+      // the store on the flip too, else release commits the crossing-time position.
+      const modeFlip = br.changed && centered !== br.lastCentered;
+      // The FT anchor and QR firmware shift both scale with magnification, so the
+      // same inversion as the 1D modes keeps them consistent with the render.
       if (br.mode === "uniform") {
-        const geo = uniformReflowGeometry(br, natural.width * sx, natural.height * sy);
+        const geo = uniformReflowGeometry(br, natural.width * sx, natural.height * sy, centered);
         if (!geo) return;
         const modCurrent = (cur.props as unknown as Record<string, number>)[br.propName];
         if (typeof modCurrent !== "number" || !(modCurrent > 0)) return;
         const crossed = geo.modules !== modCurrent;
-        if (crossed) {
+        if (crossed || modeFlip) {
           const ratio = geo.modules / br.modules0;
           const model = modelPositionFromRenderedTopLeft(
             cur,
@@ -905,6 +934,7 @@ export function useKonvaTransformer({
             });
           });
           br.changed = true;
+          br.lastCentered = centered;
         }
         // Pin every tick; subtract the child render offset (QR draws off the
         // group origin) so the rendered top-left lands on the target.
@@ -923,10 +953,10 @@ export function useKonvaTransformer({
         const mwCurrent = (cur.props as { moduleWidth?: number }).moduleWidth;
         if (typeof mwCurrent !== "number" || !(mwCurrent > 0)) return;
         const frameExtentPx = swapped ? natural.height * sy : natural.width * sx;
-        const geo = barcodeMwReflowGeometry(br, frameExtentPx);
+        const geo = barcodeMwReflowGeometry(br, frameExtentPx, centered);
         if (!geo) return;
         const crossed = geo.moduleWidth !== mwCurrent;
-        if (crossed) {
+        if (crossed || modeFlip) {
           const ratio = geo.moduleWidth / br.mw0;
           // Same inversion as the end commit for the ACTIVE axis; the anchored
           // axis keeps its pre-drag model value (mirrors the end commit's
@@ -947,6 +977,7 @@ export function useKonvaTransformer({
             });
           });
           br.changed = true;
+          br.lastCentered = centered;
         }
         // Pin every tick, not just on crossings: the reflow is the sole band
         // pin, so the raster holds in rotated views where boundBoxFunc bails.
@@ -969,7 +1000,7 @@ export function useKonvaTransformer({
       // The height re-render lands on the frame exactly, so the pin needs no
       // residual; the scale just resets to 1.
       const frameExtentPx = swapped ? natural.width * sx : natural.height * sy;
-      const geo = barcodeHeightReflowGeometry(br, frameExtentPx);
+      const geo = barcodeHeightReflowGeometry(br, frameExtentPx, centered);
       if (!geo) return;
       const newHeightDots = pxToDots(geo.barExtentPx, scale, dpmm);
       const hCurrent = (cur.props as { height?: number }).height;
@@ -985,9 +1016,9 @@ export function useKonvaTransformer({
         resizeMode: blockResizeModeRef.current,
       }) as { height?: number } | undefined;
       const hNext = committed?.height ?? newHeightDots;
-      const pin = barcodeHeightReflowGeometry(br, dotsToPx(hNext, scale, dpmm));
+      const pin = barcodeHeightReflowGeometry(br, dotsToPx(hNext, scale, dpmm), centered);
       if (!pin) return;
-      if (hNext !== hCurrent) {
+      if (hNext !== hCurrent || modeFlip) {
         const model = modelPositionFromRenderedTopLeft(
           cur,
           pxToDots(pin.targetXPx - objectsOffsetX, scale, dpmm),
@@ -1003,6 +1034,7 @@ export function useKonvaTransformer({
           });
         });
         br.changed = true;
+        br.lastCentered = centered;
       }
       // Pin every tick for the same reason as the mw axis: hold the node in
       // rotated views between dot bakes, else the anchored edge jitters.
@@ -1054,14 +1086,26 @@ export function useKonvaTransformer({
       return shrinkingBelowFloor(oldBox, newBox, MIN_RESIZE_BOX_PX) ? oldBox : newBox;
     }
     if (shrinkingBelowFloor(oldBox, newBox, MIN_RESIZE_BOX_PX)) return oldBox;
+    // Capture the TRUE drag-start box on tick 0, before any bail: a bail path
+    // (Alt) that later hands back to the snap path (Alt released mid-drag) must
+    // re-baseline from the real start, not a box already grown under the bail.
+    if (!transformStartBboxRef.current) {
+      transformStartBboxRef.current = {
+        id: selectedIds[0] ?? "",
+        x: oldBox.x,
+        y: oldBox.y,
+        width: oldBox.width,
+        height: oldBox.height,
+      };
+    }
     // The text-block reflow re-pins from its own captured edges, so the snap /
     // inactive-edge pin below would fight it; skip entirely.
     if (liveReflowRef.current) return newBox;
-    // Uniform 2D bails too, INCLUDING forceAspectBox: its moved-edge inference
-    // reads the box position in the transformer frame, so it re-anchors on the
-    // wrong axis under view rotation (the mid-drag sideways walk). The per-tick
-    // pin is the sole aspect and band snap.
-    if (barcodeReflowRef.current?.mode === "uniform") return newBox;
+    // boundBoxFunc yields to the per-tick reflow pin as sole authority: always
+    // for uniform-2D (moved-edge aspect is frame-wrong under view rotation),
+    // and for any barcode reflow under Alt (both edges move, snap fights mirror).
+    const br = barcodeReflowRef.current;
+    if (br && (br.mode === "uniform" || altKeyRef.current)) return newBox;
     // Locked-circle reflow needs forceAspectBox so Konva keeps sx==sy; node and
     // reflow only agree when the bbox keeps its aspect. Snap/pin below is free-axis only.
     if (shapeReflowRef.current && isUniformScale) {
@@ -1078,22 +1122,13 @@ export function useKonvaTransformer({
     // not rotated anyway.
     //
     // Latent coord-frame mismatch: at viewRotation=0 the transformer-frame
-    // bboxes (oldBox/newBox here, and the lazily-captured startBbox below)
-    // coincide with stage coords, which is the same frame othersSnapshotRef
-    // and labelRect use. Removing this early-return without first lifting
-    // the others / labelRect snapshot into the transformer frame would
-    // re-introduce the rotated-resize drift this whole block guards against.
+    // bboxes (oldBox/newBox here, and the startBbox captured above) coincide
+    // with stage coords, which is the same frame othersSnapshotRef and
+    // labelRect use. Removing this early-return without first lifting the
+    // others / labelRect snapshot into the transformer frame would re-introduce
+    // the rotated-resize drift this whole block guards against.
     if (viewRotation !== 0) return newBox;
     const dotPx = scale / dpmm;
-    if (!transformStartBboxRef.current) {
-      transformStartBboxRef.current = {
-        id: selectedIds[0] ?? "",
-        x: oldBox.x,
-        y: oldBox.y,
-        width: oldBox.width,
-        height: oldBox.height,
-      };
-    }
     const startBbox = transformStartBboxRef.current;
     let bbox = applyHeightSnap(
       oldBox,
@@ -1456,6 +1491,7 @@ export function useKonvaTransformer({
     resizeEnabled,
     enabledAnchors,
     centeredScaling,
+    centeredResizeArmed,
     onTransformStart,
     onTransform,
     boundBoxFunc,

--- a/src/components/Canvas/transformerGeometry.test.ts
+++ b/src/components/Canvas/transformerGeometry.test.ts
@@ -85,6 +85,22 @@ describe("barcodeMwReflowGeometry", () => {
     expect(geoTop).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 10, linearExtentPx: 120 });
   });
 
+  it("centered (Alt) mirrors the band around the start centre, any handle", () => {
+    // Start centre x = 200; band 300 px -> 50..350 regardless of handle side.
+    const geo = barcodeMwReflowGeometry(start(), 300, true);
+    expect(geo).toEqual({ moduleWidth: 3, targetXPx: 50, targetYPx: 50, linearExtentPx: 300 });
+    const leftGeo = barcodeMwReflowGeometry(start({ edges: edges({ left: true }) }), 300, true);
+    expect(leftGeo?.targetXPx).toBe(50);
+    // R/B: the mirrored axis is screen Y. Box 50..130 (centre 90), frame 120
+    // -> module 3, linear 120 -> top = 30.
+    const rb = barcodeMwReflowGeometry(
+      start({ rotation: "R", edges: edges({ bottom: true }) }),
+      120,
+      true,
+    );
+    expect(rb).toEqual({ moduleWidth: 3, targetXPx: 100, targetYPx: 30, linearExtentPx: 120 });
+  });
+
   it("rejects degenerate extents", () => {
     expect(barcodeMwReflowGeometry(start(), 0)).toBeNull();
     expect(barcodeMwReflowGeometry(start({ rightX: 100 }), 300)).toBeNull();
@@ -120,6 +136,12 @@ describe("barcodeHeightReflowGeometry", () => {
     const geo = barcodeHeightReflowGeometry(start({ edges: edges({ top: true }) }), 100);
     // Bbox extent = frame 100 + zone 20 = 120; bottom fixed at 150 -> top = 30.
     expect(geo).toEqual({ barExtentPx: 100, targetXPx: 100, targetYPx: 30 });
+  });
+
+  it("centered (Alt) mirrors the bbox (frame + zone) around the start centre", () => {
+    // Frame 100 -> bbox 120; centre y = 100 (box 50..150) -> top = 40.
+    const geo = barcodeHeightReflowGeometry(start(), 100, true);
+    expect(geo).toEqual({ barExtentPx: 100, targetXPx: 100, targetYPx: 40 });
   });
 
   it("R/B rotations run the height axis on screen X and pin left/right", () => {
@@ -466,6 +488,15 @@ describe("uniformReflowGeometry", () => {
     expect(geo?.targetYPx).toBe(150 - 150);
     expect((geo?.targetXPx ?? 0) + (geo?.linearW ?? 0)).toBe(150);
     expect((geo?.targetYPx ?? 0) + (geo?.linearH ?? 0)).toBe(150);
+  });
+
+  it("centered (Alt) mirrors both axes around the start centre, any corner", () => {
+    // Centre (100, 100), linear 150 -> 25..175 on both axes.
+    for (const e of [E(false, false), E(true, true)]) {
+      const geo = uniformReflowGeometry(start(e), 140, 140, true);
+      expect(geo?.targetXPx).toBe(25);
+      expect(geo?.targetYPx).toBe(25);
+    }
   });
 
   // Regression: at 90 degree view rotation the visual right handles are the

--- a/src/components/Canvas/transformerGeometry.ts
+++ b/src/components/Canvas/transformerGeometry.ts
@@ -40,6 +40,7 @@ export interface BarcodeMwReflowStart {
 export function barcodeMwReflowGeometry(
   start: BarcodeMwReflowStart,
   frameExtentPx: number,
+  centered = false,
 ): { moduleWidth: number; targetXPx: number; targetYPx: number; linearExtentPx: number } | null {
   if (!(start.mw0 > 0)) return null;
   const swapped = isAxisSwapped(start.rotation);
@@ -50,7 +51,7 @@ export function barcodeMwReflowGeometry(
   if (!swapped) {
     return {
       moduleWidth,
-      targetXPx: start.edges.left ? start.rightX - linearExtentPx : start.leftX,
+      targetXPx: pinnedMin(start.edges.left, start.leftX, start.rightX, linearExtentPx, centered),
       targetYPx: start.topY,
       linearExtentPx,
     };
@@ -58,9 +59,23 @@ export function barcodeMwReflowGeometry(
   return {
     moduleWidth,
     targetXPx: start.leftX,
-    targetYPx: start.edges.top ? start.bottomY - linearExtentPx : start.topY,
+    targetYPx: pinnedMin(start.edges.top, start.topY, start.bottomY, linearExtentPx, centered),
     linearExtentPx,
   };
+}
+
+/** Min-coordinate of the pinned new extent: centered (Alt) mirrors around the
+ *  start centre so both sides move; else the anchored (non-grabbed) edge holds
+ *  via the same math as `pinAnchoredEdge` (delegated so the two can't drift). */
+function pinnedMin(
+  minEdgeActive: boolean,
+  min: number,
+  max: number,
+  extent: number,
+  centered: boolean,
+): number {
+  if (centered) return (min + max - extent) / 2;
+  return pinAnchoredEdge(minEdgeActive, min, max - min, extent);
 }
 
 /** Start-of-drag frame for the 1D bar-height live reflow: the footprint bbox in
@@ -87,6 +102,7 @@ export interface BarcodeHeightReflowStart {
 export function barcodeHeightReflowGeometry(
   start: BarcodeHeightReflowStart,
   frameExtentPx: number,
+  centered = false,
 ): { barExtentPx: number; targetXPx: number; targetYPx: number } | null {
   if (!(frameExtentPx > 0)) return null;
   const barExtentPx = frameExtentPx;
@@ -95,14 +111,14 @@ export function barcodeHeightReflowGeometry(
   if (swapped) {
     return {
       barExtentPx,
-      targetXPx: start.edges.left ? start.rightX - bboxExtentPx : start.leftX,
+      targetXPx: pinnedMin(start.edges.left, start.leftX, start.rightX, bboxExtentPx, centered),
       targetYPx: start.topY,
     };
   }
   return {
     barExtentPx,
     targetXPx: start.leftX,
-    targetYPx: start.edges.top ? start.bottomY - bboxExtentPx : start.topY,
+    targetYPx: pinnedMin(start.edges.top, start.topY, start.bottomY, bboxExtentPx, centered),
   };
 }
 
@@ -191,6 +207,7 @@ export function uniformReflowGeometry(
   start: UniformReflowStart,
   frameWPx: number,
   frameHPx: number,
+  centered = false,
 ): { modules: number; targetXPx: number; targetYPx: number; linearW: number; linearH: number } | null {
   const startW = start.rightX - start.leftX;
   const startH = start.bottomY - start.topY;
@@ -203,8 +220,8 @@ export function uniformReflowGeometry(
   const linearH = startH * factor;
   return {
     modules,
-    targetXPx: start.edges.left ? start.rightX - linearW : start.leftX,
-    targetYPx: start.edges.top ? start.bottomY - linearH : start.topY,
+    targetXPx: pinnedMin(start.edges.left, start.leftX, start.rightX, linearW, centered),
+    targetYPx: pinnedMin(start.edges.top, start.topY, start.bottomY, linearH, centered),
     linearW,
     linearH,
   };


### PR DESCRIPTION
Live per-tick pin mirrors via the reflow geometry (mw, height, uniform); Alt is read live to match Konva's own centered preview.