### PR TITLE
feat(canvas): Alt resizes a line symmetrically around its midpoint

### DIFF
--- a/packages/core/src/lib/coordinates.ts
+++ b/packages/core/src/lib/coordinates.ts
@@ -1,8 +1,15 @@
 // CSS reference: 96 px/inch → px per mm at 100% zoom = physical label size
 export const SCREEN_PX_PER_MM = 96 / 25.4;
 
+/** Exact (unrounded) inverse of dotsToPx. Callers that rebuild geometry from
+ *  two screen points (e.g. centred line resize) must keep the fractional value
+ *  so a diagonal's true length/angle survives; rounding each point first can
+ *  inflate the length or drop the angle. */
+export const pxToDotsExact = (px: number, scale: number, dpmm: number): number =>
+  (px / scale) * dpmm;
+
 export const pxToDots = (px: number, scale: number, dpmm: number): number =>
-  Math.round((px / scale) * dpmm);
+  Math.round(pxToDotsExact(px, scale, dpmm));
 
 export const dotsToPx = (dots: number, scale: number, dpmm: number): number =>
   (dots / dpmm) * scale;

--- a/src/components/Canvas/LineObject.tsx
+++ b/src/components/Canvas/LineObject.tsx
@@ -2,8 +2,12 @@ import { useEffect, useRef, useState } from "react";
 import { Group, Line as KLine, Rect } from "react-konva";
 import type Konva from "konva";
 import type { LabelObject } from "@zplab/core/types/Group";
-import { dotsToPx, pxToDots } from "@zplab/core/lib/coordinates";
-import { constrainLine, type ConstrainMode } from "../../lib/lineConstrain";
+import { dotsToPx, pxToDots, pxToDotsExact } from "@zplab/core/lib/coordinates";
+import {
+  constrainLine,
+  centeredEndpointCommit,
+  type ConstrainMode,
+} from "../../lib/lineConstrain";
 import { useColorScheme } from "../../hooks/useColorScheme";
 import {
   computePointSnap,
@@ -12,6 +16,7 @@ import {
 } from "../../lib/snapGuides";
 import { diagonalPolygonPoints } from "../../lib/shapeGeometry";
 import { selectionHandlers, type KonvaObjectProps, MIN_HIT_STROKE_PX, lineHandlesNodeId, lineRootNodeId } from "./konvaObjectProps";
+import { LINE_HANDLE_NAME } from "./altClickCycle";
 
 
 const HANDLE_VISIBLE_SIZE = 7;
@@ -103,6 +108,9 @@ export function LineObject({
 
   const [livePt1, setLivePt1] = useState<{ x: number; y: number } | null>(null);
   const [livePt2, setLivePt2] = useState<{ x: number; y: number } | null>(null);
+  // Alt of the last drag-move: a keyup fires no drag event, so the commit reads
+  // this (not e.evt.altKey at mouse-up) to match the last centered preview.
+  const lastEndpointAlt = useRef(false);
 
   const [dragDelta, setDragDelta] = useState<{ x: number; y: number }>({
     x: 0,
@@ -329,6 +337,18 @@ export function LineObject({
   const thickHandleY =
     lineCenterY + (isHorizontal ? lineStrokeWidth : 0);
 
+  // Alt-centered endpoint drag: the dragged point is snapped normally (its real
+  // opposite endpoint as anchor, no drift), then both endpoints mirror around
+  // the fixed midpoint. endpointSumDot = start+end = 2*centre.
+  const endpointSumDot = {
+    x: obj.x + pxToDotsExact(x2 - offsetX, scale, dpmm),
+    y: obj.y + pxToDotsExact(y2 - offsetY, scale, dpmm),
+  };
+  const mirrorPx = (pt: { x: number; y: number }) => ({
+    x: x1 + x2 - pt.x,
+    y: y1 + y2 - pt.y,
+  });
+
   return (
     <Group id={lineRootNodeId(obj.id)}>
       {isAxisAligned ? (
@@ -406,8 +426,10 @@ export function LineObject({
             width={HANDLE_HIT_SIZE}
             height={HANDLE_HIT_SIZE}
             fill="transparent"
+            name={LINE_HANDLE_NAME}
             draggable={!obj.locked}
             onDragMove={(e) => {
+              const alt = e.evt.altKey;
               const endDotX = pxToDots(x2 - offsetX, scale, dpmm);
               const endDotY = pxToDots(y2 - offsetY, scale, dpmm);
               const r = endpointDrag(
@@ -424,8 +446,11 @@ export function LineObject({
                 y: r.movingPx.y - HANDLE_HIT_SIZE / 2,
               });
               setLivePt1(r.movingPx);
+              setLivePt2(alt ? mirrorPx(r.movingPx) : null);
+              lastEndpointAlt.current = alt;
             }}
             onDragEnd={(e) => {
+              const alt = lastEndpointAlt.current;
               const cursor = livePt1 ?? {
                 x: e.target.x() + HANDLE_HIT_SIZE / 2,
                 y: e.target.y() + HANDLE_HIT_SIZE / 2,
@@ -435,6 +460,7 @@ export function LineObject({
                 y: y1 + dy - HANDLE_HIT_SIZE / 2,
               });
               setLivePt1(null);
+              setLivePt2(null);
               const endDotX = pxToDots(x2 - offsetX, scale, dpmm);
               const endDotY = pxToDots(y2 - offsetY, scale, dpmm);
               const r = endpointDrag(
@@ -448,15 +474,27 @@ export function LineObject({
               );
               clearSnap();
               // Cap thickness to length; t > length triggers ^GB promotion (t x t).
-              onChange({
-                x: r.movingDotX,
-                y: r.movingDotY,
-                props: {
-                  length: r.length,
-                  angle: r.angle,
-                  thickness: Math.min(p.thickness, r.length),
-                },
-              });
+              if (alt) {
+                const c = centeredEndpointCommit(
+                  {
+                    x: pxToDotsExact(r.movingPx.x - offsetX, scale, dpmm),
+                    y: pxToDotsExact(r.movingPx.y - offsetY, scale, dpmm),
+                  },
+                  endpointSumDot,
+                  true,
+                );
+                onChange({
+                  x: c.x,
+                  y: c.y,
+                  props: { length: c.length, angle: c.angle, thickness: Math.min(p.thickness, c.length) },
+                });
+              } else {
+                onChange({
+                  x: r.movingDotX,
+                  y: r.movingDotY,
+                  props: { length: r.length, angle: r.angle, thickness: Math.min(p.thickness, r.length) },
+                });
+              }
             }}
           />
           <Rect
@@ -476,8 +514,10 @@ export function LineObject({
             width={HANDLE_HIT_SIZE}
             height={HANDLE_HIT_SIZE}
             fill="transparent"
+            name={LINE_HANDLE_NAME}
             draggable={!obj.locked}
             onDragMove={(e) => {
+              const alt = e.evt.altKey;
               const r = endpointDrag(
                 e.target.x() + HANDLE_HIT_SIZE / 2,
                 e.target.y() + HANDLE_HIT_SIZE / 2,
@@ -492,8 +532,11 @@ export function LineObject({
                 y: r.movingPx.y - HANDLE_HIT_SIZE / 2,
               });
               setLivePt2(r.movingPx);
+              setLivePt1(alt ? mirrorPx(r.movingPx) : null);
+              lastEndpointAlt.current = alt;
             }}
             onDragEnd={(e) => {
+              const alt = lastEndpointAlt.current;
               const cursor = livePt2 ?? {
                 x: e.target.x() + HANDLE_HIT_SIZE / 2,
                 y: e.target.y() + HANDLE_HIT_SIZE / 2,
@@ -503,6 +546,7 @@ export function LineObject({
                 y: y2 + dy - HANDLE_HIT_SIZE / 2,
               });
               setLivePt2(null);
+              setLivePt1(null);
               const r = endpointDrag(
                 cursor.x,
                 cursor.y,
@@ -513,13 +557,25 @@ export function LineObject({
                 e.target.getParent(),
               );
               clearSnap();
-              onChange({
-                props: {
-                  length: r.length,
-                  angle: r.angle,
-                  thickness: Math.min(p.thickness, r.length),
-                },
-              });
+              if (alt) {
+                const c = centeredEndpointCommit(
+                  {
+                    x: pxToDotsExact(r.movingPx.x - offsetX, scale, dpmm),
+                    y: pxToDotsExact(r.movingPx.y - offsetY, scale, dpmm),
+                  },
+                  endpointSumDot,
+                  false,
+                );
+                onChange({
+                  x: c.x,
+                  y: c.y,
+                  props: { length: c.length, angle: c.angle, thickness: Math.min(p.thickness, c.length) },
+                });
+              } else {
+                onChange({
+                  props: { length: r.length, angle: r.angle, thickness: Math.min(p.thickness, r.length) },
+                });
+              }
             }}
           />
           <Rect
@@ -532,7 +588,9 @@ export function LineObject({
             strokeWidth={1}
             listening={false}
           />
-          {/* Thickness handle, perpendicular drag; flip-on-overshoot deferred. */}
+          {/* Thickness handle, perpendicular drag; flip-on-overshoot deferred.
+              No line-handle name: Alt has no centering role here, so an Alt+click
+              should keep cycling rather than dead-click on the handle. */}
           <Rect
             x={thickHandleX - HANDLE_HIT_SIZE / 2}
             y={thickHandleY - HANDLE_HIT_SIZE / 2}

--- a/src/components/Canvas/altClickCycle.ts
+++ b/src/components/Canvas/altClickCycle.ts
@@ -8,6 +8,10 @@ export interface CycleAnchor {
 
 export const ALT_CYCLE_TOL_PX = 5;
 
+/** Konva name shared by a line's endpoint hit-rects; the Alt-cycle handler lets
+ *  their grabs through so Alt-centred resize works instead of cycling. */
+export const LINE_HANDLE_NAME = "line-handle";
+
 export function nextCycleIndex(
   hits: readonly string[],
   anchor: CycleAnchor | null,

--- a/src/components/Canvas/hooks/useAltClickCycle.ts
+++ b/src/components/Canvas/hooks/useAltClickCycle.ts
@@ -3,6 +3,7 @@ import type Konva from "konva";
 import { getCurrentObjects } from "../../../store/labelStore";
 import {
   ALT_CYCLE_TOL_PX,
+  LINE_HANDLE_NAME,
   nextCycleIndex,
   type CycleAnchor,
 } from "../altClickCycle";
@@ -13,8 +14,8 @@ interface Options {
   stageRef: React.RefObject<Konva.Stage | null>;
   selectObject: (id: string | null) => void;
   /** True when the single selection supports Alt-centered resize (1D barcode,
-   *  2D matrix code, or box/ellipse); only then does an Alt+handle grab bypass
-   *  the cycle. */
+   *  2D matrix code, or box/ellipse); gates the transformer-anchor bypass only.
+   *  Line endpoint handles bypass the cycle unconditionally (LINE_HANDLE_NAME). */
   resizeArmed: boolean;
 }
 
@@ -51,9 +52,14 @@ export function useAltClickCycle({
       const rect = el.getBoundingClientRect();
       const point = { x: e.clientX - rect.left, y: e.clientY - rect.top };
       // A handle sits over object ink, so without this the cycle eats the
-      // Alt+handle grab; gated on resizeArmed so only centered-capable types
-      // bypass (supportsCenteredResize documents why others must not).
-      if (resizeArmedRef.current && stage.getIntersection(point)?.hasName("_anchor")) return;
+      // Alt+handle grab. Line endpoint handles always edit (Alt-centred resize);
+      // transformer anchors only for centered-capable types (else they jitter,
+      // see supportsCenteredResize), hence the resizeArmed gate.
+      const hit = stage.getIntersection(point);
+      // draggable() excludes a locked line's handles: they render but can't drag,
+      // so cycling must pass through them instead of a dead spot.
+      if (hit?.hasName(LINE_HANDLE_NAME) && hit.draggable()) return;
+      if (resizeArmedRef.current && hit?.hasName("_anchor")) return;
       // Konva's own hit-graph respects view rotation, pan offset,
       // per-shape transforms and the listening flag; the cycle variant adds
       // a client-rect fallback so frame interiors stay reachable.

--- a/src/lib/lineConstrain.test.ts
+++ b/src/lib/lineConstrain.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { constrainLine } from "./lineConstrain";
+import { constrainLine, centeredEndpointCommit } from "./lineConstrain";
 
 describe("constrainLine — free", () => {
   it("returns Euclidean length and exact angle", () => {
@@ -10,6 +10,54 @@ describe("constrainLine — free", () => {
 
   it("clamps length to at least 1", () => {
     expect(constrainLine(0, 0, "free").length).toBe(1);
+  });
+});
+
+describe("centeredEndpointCommit", () => {
+  // A 0..5 horizontal line: start+end = {5,0}.
+  const sum = { x: 5, y: 0 };
+
+  it("keeps an odd length on a no-op drag (no doubled-half overshoot)", () => {
+    // End dropped on its own spot must stay length 5, not jump to 6.
+    expect(centeredEndpointCommit({ x: 5, y: 0 }, sum, false)).toEqual({
+      x: 0, y: 0, length: 5, angle: 0,
+    });
+    // Start likewise.
+    expect(centeredEndpointCommit({ x: 0, y: 0 }, sum, true)).toEqual({
+      x: 0, y: 0, length: 5, angle: 0,
+    });
+  });
+
+  it("grows symmetrically around the midpoint", () => {
+    // Drag end to 7 → start mirrors to -2, length 9, centre stays at 2.5.
+    expect(centeredEndpointCommit({ x: 7, y: 0 }, sum, false)).toEqual({
+      x: -2, y: 0, length: 9, angle: 0,
+    });
+  });
+
+  it("keeps the diagonal angle when shrinking toward the centre", () => {
+    // Short diagonal near the centre {2,2}: length rounds to 1 but the angle
+    // must survive (rounding both endpoints first would collapse to angle 0).
+    const diag = { x: 4, y: 4 };
+    expect(centeredEndpointCommit({ x: 2.4, y: 2.4 }, diag, true)).toMatchObject({
+      length: 1, angle: -135,
+    });
+  });
+
+  it("degenerates to a 1-dot line only at the exact centre", () => {
+    expect(centeredEndpointCommit({ x: 2, y: 2 }, { x: 4, y: 4 }, true)).toEqual({
+      x: 2, y: 2, length: 1, angle: 0,
+    });
+  });
+
+  it("preserves a diagonal's length on a no-op drag (exact dot inputs)", () => {
+    // A length-5 45° line's endpoint sits at 5*cos45 ≈ 3.54 dots. The real path
+    // feeds these exact (unrounded) coords via pxToDotsExact; rounding each to
+    // (4,4) first would inflate makeFree to length 6.
+    const d = 5 * Math.SQRT1_2;
+    expect(
+      centeredEndpointCommit({ x: d, y: d }, { x: d, y: d }, false),
+    ).toMatchObject({ length: 5, angle: 45 });
   });
 });
 

--- a/src/lib/lineConstrain.ts
+++ b/src/lib/lineConstrain.ts
@@ -37,6 +37,29 @@ export function makeFree(dxDots: number, dyDots: number): LineGeometry {
   return { length, angle, dx: Math.round(dxDots), dy: Math.round(dyDots) };
 }
 
+/** Alt-centred endpoint resize: the far endpoint mirrors around the fixed
+ *  midpoint. `movingDot` is the dragged endpoint (unrounded dots); `sumDot` =
+ *  start+end = 2*centre. The origin is rounded to a whole dot, but length and
+ *  angle come from the *unrounded* vector so a line shrinking toward the centre
+ *  keeps its direction (rounding both endpoints first would collapse a short
+ *  diagonal to makeFree(0,0) = a 1-dot horizontal line). */
+export function centeredEndpointCommit(
+  movingDot: { x: number; y: number },
+  sumDot: { x: number; y: number },
+  forStart: boolean,
+): { x: number; y: number; length: number; angle: number } {
+  const other = { x: sumDot.x - movingDot.x, y: sumDot.y - movingDot.y };
+  const origin = forStart ? movingDot : other;
+  const end = forStart ? other : movingDot;
+  const g = makeFree(end.x - origin.x, end.y - origin.y);
+  return {
+    x: Math.round(origin.x),
+    y: Math.round(origin.y),
+    length: g.length,
+    angle: g.angle,
+  };
+}
+
 /** Wrap to (-180, 180] so flipped axis angles stay in atan2's natural range. */
 function normalizeAngle(deg: number): number {
   let n = deg % 360;


### PR DESCRIPTION
Alt anchors endpointDrag at the fixed midpoint (half-line), doubling the length for the full mirrored line; both endpoints preview live. Endpoint handles are exempt from the Alt select-cycle so the gesture is reachable.