### PR TITLE
feat: platform capability seams for non-secure contexts

### DIFF
--- a/packages/core/src/lib/fontCache.ts
+++ b/packages/core/src/lib/fontCache.ts
@@ -2,6 +2,7 @@
 
 import { hydrateLocalStoragePrefix, safeLocalStorageRemove, safeLocalStorageSet } from "./localStorageBucket";
 
+import { newId } from "./ids";
 export interface CachedFont {
   id: string;
   /** Uppercase printer filename. */
@@ -148,7 +149,7 @@ function registerBytes(bytes: Uint8Array, printerName: string): CachedFont {
   const dataUrl = `data:${fontMime(name)};base64,${btoa(binary)}`;
   const fontFamily = printerNameToFamily(name);
   const entry: CachedFont = {
-    id: crypto.randomUUID(),
+    id: newId(),
     name,
     dataUrl,
     fontFamily,

--- a/packages/core/src/lib/ids.ts
+++ b/packages/core/src/lib/ids.ts
@@ -1,0 +1,18 @@
+/** UUID v4. crypto.randomUUID is missing in non-secure contexts (plain-HTTP
+ *  self-hosting); the fallback builds a v4 from getRandomValues, which is
+ *  available everywhere. */
+export function newId(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10).join(""),
+  ].join("-");
+}

--- a/packages/core/src/lib/imageCache.ts
+++ b/packages/core/src/lib/imageCache.ts
@@ -7,6 +7,7 @@
 import { hydrateLocalStoragePrefix, safeLocalStorageRemove, safeLocalStorageSet } from "./localStorageBucket";
 import { loadImage } from "./loadImage";
 
+import { newId } from "./ids";
 export interface CachedImage {
   id: string;
   name: string;
@@ -66,7 +67,7 @@ export async function loadImageFile(file: File): Promise<CachedImage> {
       loadImage(dataUrl, `Failed to decode image: ${file.name}`)
         .then((img) => {
           const entry: CachedImage = {
-            id: crypto.randomUUID(),
+            id: newId(),
             name: file.name,
             dataUrl,
             width: img.naturalWidth,

--- a/packages/core/src/lib/reverseBacking.ts
+++ b/packages/core/src/lib/reverseBacking.ts
@@ -8,6 +8,7 @@ import type { LabelConfig } from "../types/LabelConfig";
 import type { LabelObject } from "../types/Group";
 import { isGroup } from "../types/Group";
 
+import { newId } from "./ids";
 type FontLabel = Pick<LabelConfig, "customFonts" | "defaultFontId">;
 
 /** Minimal text shape the geometry needs; works on typed and migrated data. */
@@ -121,7 +122,7 @@ export function makeReverseBackingBox(
   const geo = reverseBackingBoxGeometry(text, label);
   const { width, height, thickness } = geo.props;
   const base: Record<string, unknown> = {
-    id: crypto.randomUUID(),
+    id: newId(),
     x: geo.x,
     y: geo.y,
     rotation: 0,

--- a/packages/core/src/lib/storagePath.ts
+++ b/packages/core/src/lib/storagePath.ts
@@ -1,5 +1,7 @@
 // Zebra storage paths: bare `device:name` (~DY) vs `device:name.ext` (^XG).
 
+import { newId } from "./ids";
+
 /** R volatile RAM, E flash, B alt flash, A alias. */
 export const STORAGE_DEVICES = ["R", "E", "B", "A"] as const;
 export type StorageDevice = (typeof STORAGE_DEVICES)[number];
@@ -10,7 +12,7 @@ export const STORAGE_NAME_FILTER_RE = /[^A-Z0-9_]/g;
 
 /** Short UUID slice avoids collisions without forcing user-chosen name. */
 export function defaultStorageName(): string {
-  return `IMG_${crypto.randomUUID().slice(0, 4).toUpperCase()}`;
+  return `IMG_${newId().slice(0, 4).toUpperCase()}`;
 }
 
 export interface StoragePath {

--- a/packages/core/src/lib/zplParser/decoders/graphic.ts
+++ b/packages/core/src/lib/zplParser/decoders/graphic.ts
@@ -3,6 +3,7 @@ import { BITS_PER_BYTE } from "./constants";
 import { gfPayloadToBytes } from "./gfa";
 import type { DecodedGraphic } from "../types";
 
+import { newId } from "../../ids";
 /**
  * Decode a GF-shaped payload into an image-cache entry. Shared between
  * the `^GF` inline path and the `~DY` graphic-upload preamble; both
@@ -49,7 +50,7 @@ export function decodeGraphicToImage(
     }
   }
   ctx.putImageData(imgData, 0, 0);
-  const imageId = crypto.randomUUID();
+  const imageId = newId();
   putImage({
     id: imageId,
     name: nameHint,

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -43,6 +43,7 @@ import { upceData6FromFd } from "../../registry/hriFormatters";
 import { decodeFH, makeObj, variableNameFromComment } from "./helpers";
 import { getPosType, resetFieldBlockDefaults, type ParserState } from "./context";
 
+import { newId } from "../ids";
 /** Cross-family deps flushField borrows from graphics (^GB+^FR) and parseZPL (^FX). */
 export interface FlushFieldDeps {
   commitPendingReverseBg: () => void;
@@ -80,7 +81,7 @@ export function createFlushField(
     const hinted = variableNameFromComment(commentHint);
     const base = hinted && isValidVariableName(hinted) ? hinted : `field_${fnNumber}`;
     const v: Variable = {
-      id: crypto.randomUUID(),
+      id: newId(),
       name: uniqueVariableName(base, variables),
       fnNumber,
       defaultValue,

--- a/packages/core/src/lib/zplParser/handlers/graphics.ts
+++ b/packages/core/src/lib/zplParser/handlers/graphics.ts
@@ -11,6 +11,7 @@ import type { QrCodeProps } from "../../../registry/qrcode";
 import { dotsFor, ftTopLeft, int, makeObj, readColor, readRotation } from "../helpers";
 import type { Handler } from "../types";
 
+import { newId } from "../../ids";
 /** Characters of a `^GF`/`~DY` payload retained in browserLimit findings;
  *  rest is replaced with an ellipsis so a single multi-KB base64 blob
  *  doesn't drown out the import report. */
@@ -217,7 +218,7 @@ export function createGraphicsHandlers(
         gfBytesPerRow,
         gfParams[0] ?? "",
         gfParams[1] ?? "",
-        `imported_${crypto.randomUUID().slice(0, 8)}.png`,
+        `imported_${newId().slice(0, 8)}.png`,
       );
       if (!gfImage) {
         // Undecodable, but the header still describes the bitmap, so preserve

--- a/packages/core/src/lib/zplParser/helpers.ts
+++ b/packages/core/src/lib/zplParser/helpers.ts
@@ -2,6 +2,7 @@ import type { LabelObject } from "../../types/Group";
 import { isZplRotation, type ZplRotation } from "../../registry/rotation";
 import { opensImmediateCommand } from "../zplImmediate";
 
+import { newId } from "../ids";
 /** Validated ZplRotation or `fallback` (default 'N'). */
 export function readRotation(
   raw: string | undefined,
@@ -184,7 +185,7 @@ export function makeObj(
   comment?: string,
 ): LabelObject {
   return {
-    id: crypto.randomUUID(),
+    id: newId(),
     type,
     x,
     y,

--- a/src/components/Barcode/Gs1ContentModal.tsx
+++ b/src/components/Barcode/Gs1ContentModal.tsx
@@ -14,6 +14,7 @@ import { extractTemplateRefs, hasTemplateMarkers, markersToEmbeds } from "@zplab
 import { DEFAULT_CLOCK_CHARS, markersToTokens } from "@zplab/core/lib/fcTemplate";
 import { MarkerTextField } from "../Properties/MarkerTextField";
 import { findObjectById } from "@zplab/core/types/Group";
+import { newId } from "@zplab/core/lib/ids";
 import {
   aiSpec,
   gs1AddBlockReason,
@@ -46,7 +47,7 @@ interface DraftSegment extends Gs1Segment {
   key: string;
 }
 
-const draftSegment = (s: Gs1Segment): DraftSegment => ({ ...s, key: crypto.randomUUID() });
+const draftSegment = (s: Gs1Segment): DraftSegment => ({ ...s, key: newId() });
 
 /** Long-tail count for the palette hint: offerable catalog minus the curated
  *  set (all common AIs are satisfiable, guarded by test). */

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -34,6 +34,7 @@ import { registerBarcodeWidthProber, unregisterBarcodeWidthProber } from "../../
 import { applyBindingToObject } from "@zplab/core/lib/variableBinding";
 import { objectResolvesCtrl } from "@zplab/core/registry";
 import { measureBarcodeFootprintDots } from "./bwipHelpers";
+import { copyText } from "../../lib/clipboard";
 import { selectTidyTargets } from "../../lib/tidyClassify";
 import { safeAreaRectDots } from "../../lib/safeArea";
 import { measuredBoundsMap, subscribeMeasuredBounds, getMeasuredSnapshot } from "./measuredBoundsCache";
@@ -1241,10 +1242,10 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
       toggleLock: () => setSelectionLocked(!isSelectionLocked(objects, sel)),
       addHere: (type: string, propsOverride?: object) => addObject(type, click, propsOverride),
       copyZplSelected: () => {
-        void navigator.clipboard?.writeText(zplForSelection(label, objects, sel, variables));
+        void copyText(zplForSelection(label, objects, sel, variables));
       },
       copyZplLabel: () => {
-        void navigator.clipboard?.writeText(generateMultiPageZPL(label, pages, variables));
+        void copyText(generateMultiPageZPL(label, pages, variables));
       },
       copyImage: () => {
         // Call write synchronously with the pending blob so the user activation

--- a/src/components/Output/ZplImportModal.tsx
+++ b/src/components/Output/ZplImportModal.tsx
@@ -13,6 +13,7 @@ import { ImportSummaryBody } from './ImportSummary';
 import { ImportSetupChoice } from './ImportSetupChoice';
 import { useT } from '../../hooks/useT';
 import { DialogShell } from '../ui/DialogShell';
+import { copyText } from '../../lib/clipboard';
 
 interface Props {
   onClose: () => void;
@@ -153,7 +154,8 @@ export function ZplImportModal({ onClose }: Props) {
 
   const handleCopy = () => {
     if (!result) return;
-    navigator.clipboard.writeText(formatReportAsText(result)).then(() => {
+    void copyText(formatReportAsText(result)).then((r) => {
+      if (r !== 'copied') return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
@@ -227,7 +229,7 @@ export function ZplImportModal({ onClose }: Props) {
             <input
               ref={fileInputRef}
               type="file"
-              accept=".zpl,text/plain"
+              accept=".zpl,.prn,text/plain"
               className="hidden"
               onChange={handleFileSelect}
             />

--- a/src/components/PrinterSettings/DataSourcesTab.tsx
+++ b/src/components/PrinterSettings/DataSourcesTab.tsx
@@ -18,6 +18,7 @@ import { Select } from '../ui/Select';
 import { inputCls } from '../Properties/styles';
 import type { DbProfile, DbSslMode } from '../../lib/db';
 
+import { newId } from "@zplab/core/lib/ids";
 type Driver = DbProfile['driver'];
 
 /** Settings tab: pick-or-create a connection profile, browse its tables,
@@ -105,7 +106,7 @@ export function DataSourcesTab() {
 
   const handleAdd = () => {
     const created: DbProfile = {
-      id: crypto.randomUUID(),
+      id: newId(),
       name: nextProfileName(dbProfiles, tv.dbProfileLabel),
       driver: 'sqlite',
       path: '',

--- a/src/components/PrinterSettings/FontLinksField.tsx
+++ b/src/components/PrinterSettings/FontLinksField.tsx
@@ -4,6 +4,7 @@ import { useLabelStore } from "../../store/labelStore";
 import { FONT_LINKS_MAX_PER_BASE } from "@zplab/core/types/PrinterProfile";
 import { SafeStringInput, ZplCommandLabel, ZplField, ZplFieldHint } from "./zplFieldPrimitives";
 
+import { newId } from "@zplab/core/lib/ids";
 function overflowingBases(links: readonly { base: string }[]): string[] {
   const counts = new Map<string, number>();
   for (const l of links) {
@@ -25,10 +26,10 @@ export function FontLinksField() {
 
   // Stable per-row IDs preserve focus when rows are removed mid-list.
   // Re-synced when links arrive from outside the component (import, rehydrate).
-  const [rowIds, setRowIds] = useState<string[]>(() => links.map(() => crypto.randomUUID()));
+  const [rowIds, setRowIds] = useState<string[]>(() => links.map(() => newId()));
   if (rowIds.length !== links.length) {
     const next = rowIds.slice(0, links.length);
-    while (next.length < links.length) next.push(crypto.randomUUID());
+    while (next.length < links.length) next.push(newId());
     setRowIds(next);
   }
 
@@ -41,7 +42,7 @@ export function FontLinksField() {
     patch({ fontLinks: next.length > 0 ? next : undefined });
   };
   const addRow = () => {
-    setRowIds([...rowIds, crypto.randomUUID()]);
+    setRowIds([...rowIds, newId()]);
     patch({ fontLinks: [...links, { ext: "", base: "" }] });
   };
 

--- a/src/components/Variables/VariableMappingModal.tsx
+++ b/src/components/Variables/VariableMappingModal.tsx
@@ -27,6 +27,7 @@ import { VariableSourceBadge } from './VariableSourceBadge';
 import { Tooltip } from '../ui/Tooltip';
 
 
+import { newId } from "@zplab/core/lib/ids";
 interface Props {
   onClose: () => void;
   /** Opens the CSV file picker (the same one as the File menu's import). */
@@ -286,7 +287,7 @@ export function VariableMappingModal({ onClose, onImportCsv }: Props) {
       const fn = nextFreeFnNumber(prev.map((v) => v.fnNumber));
       if (fn === null) return prev;
       const newVar: Variable = {
-        id: crypto.randomUUID(),
+        id: newId(),
         name: nextDefaultVariableName(prev),
         fnNumber: fn,
         defaultValue: '',

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { copyText } from '../lib/clipboard';
 
 /** Copy-to-clipboard with a transient "copied" flag for button UI.
  *  `getPayload` is called at copy-time (not at hook-call-time) so
@@ -12,17 +13,15 @@ export function useCopyToClipboard(getPayload: () => string, resetMs = 1500) {
   const copy = () => {
     const payload = getPayload();
     if (!payload) return;
-    // navigator.clipboard is undefined in non-secure contexts
-    // (plain HTTP, file://) and in some embedded WebViews.
-    if (!navigator.clipboard) return;
-    navigator.clipboard.writeText(payload).then(() => {
+    void copyText(payload).then((r) => {
+      if (r !== 'copied') return;
       setCopied(true);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         setCopied(false);
       }, resetMs);
-    }).catch(() => { /* swallow: user-cancel or permission-denied */ });
+    });
   };
 
   useEffect(() => {

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,36 @@
+export type CopyResult = "copied" | "denied" | "unsupported";
+
+/** Deprecated execCommand path, kept only as the last resort where the async
+ *  clipboard API is unavailable (plain-HTTP self-hosting, some WebViews). */
+function copyViaExecCommand(text: string): CopyResult {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok: boolean;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  ta.remove();
+  return ok ? "copied" : "unsupported";
+}
+
+/** Single seam for copying text: async clipboard API when present, otherwise
+ *  the execCommand fallback, so copy works outside secure contexts too. */
+export async function copyText(text: string): Promise<CopyResult> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return "copied";
+    } catch {
+      // Permission denied (or user dismissal); execCommand won't do better.
+      return "denied";
+    }
+  }
+  return copyViaExecCommand(text);
+}

--- a/src/lib/ids.test.ts
+++ b/src/lib/ids.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { newId } from "@zplab/core/lib/ids";
+
+const V4_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("newId", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns v4-shaped, unique ids", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => newId()));
+    expect(ids.size).toBe(100);
+    for (const id of ids) expect(id).toMatch(V4_SHAPE);
+  });
+
+  it("falls back to getRandomValues when randomUUID is missing (non-secure context)", () => {
+    const real = globalThis.crypto;
+    vi.stubGlobal("crypto", {
+      getRandomValues: (arr: Uint8Array<ArrayBuffer>) => real.getRandomValues.call(real, arr),
+    });
+    const ids = new Set(Array.from({ length: 100 }, () => newId()));
+    expect(ids.size).toBe(100);
+    for (const id of ids) expect(id).toMatch(V4_SHAPE);
+  });
+});

--- a/src/store/labelStore.internals.ts
+++ b/src/store/labelStore.internals.ts
@@ -6,6 +6,7 @@ import { getObjectStringContent } from '@zplab/core/lib/variableBinding';
 import { getEntry } from '@zplab/core/registry';
 import { anchorRepin } from './anchorRepin';
 
+import { newId } from "@zplab/core/lib/ids";
 /** Meta fields that remain editable on a locked object so the user can
  *  release the lock or annotate without unlocking first. Everything else
  *  (position, props, rotation, positionType) is blocked. */
@@ -195,13 +196,13 @@ export function cloneChildrenFresh(children: LabelObject[]): LabelObject[] {
     if (isGroup(c)) {
       return {
         ...c,
-        id: crypto.randomUUID(),
+        id: newId(),
         children: cloneChildrenFresh(c.children),
       };
     }
     return dropProvenance({
       ...c,
-      id: crypto.randomUUID(),
+      id: newId(),
       props: { ...c.props },
     } as LabelObject);
   });
@@ -214,7 +215,7 @@ export function cloneShifted(src: LabelObject, dx: number, dy: number): LabelObj
   if (isGroup(src)) {
     return {
       ...src,
-      id: crypto.randomUUID(),
+      id: newId(),
       x: src.x + dx,
       y: src.y + dy,
       children: src.children.map((c) => cloneShifted(c, dx, dy)),
@@ -222,7 +223,7 @@ export function cloneShifted(src: LabelObject, dx: number, dy: number): LabelObj
   }
   return dropProvenance({
     ...src,
-    id: crypto.randomUUID(),
+    id: newId(),
     x: src.x + dx,
     y: src.y + dy,
     props: { ...src.props },

--- a/src/store/slices/objectSlice.ts
+++ b/src/store/slices/objectSlice.ts
@@ -28,6 +28,7 @@ import {
 import { selectPreviewLocksEditor, currentObjects } from '../labelStore.selectors';
 import type { LabelState } from '../labelStore';
 
+import { newId } from "@zplab/core/lib/ids";
 export interface ObjectSlice {
   pages: Page[];
   currentPageIndex: number;
@@ -108,7 +109,7 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
       ...spawnRotationOverride(type, propsOverride, get().canvasSettings.viewRotation),
     };
     const obj = {
-      id: crypto.randomUUID(),
+      id: newId(),
       type,
       x: position.x,
       y: position.y,
@@ -352,7 +353,7 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
         -1,
       );
       const group: GroupObject = {
-        id: crypto.randomUUID(),
+        id: newId(),
         type: 'group',
         x: 0,
         y: 0,
@@ -393,7 +394,7 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
     set((state) => {
       if (selectPreviewLocksEditor(state)) return {};
       const group: GroupObject = {
-        id: crypto.randomUUID(),
+        id: newId(),
         type: 'group',
         x: 0,
         y: 0,

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -13,6 +13,7 @@ import { makeCredentialHydrator, setCredential } from '../../lib/credentialStore
 import { generateMcpToken, stopMcpServer } from '../../lib/mcpServer';
 import { selectEffectivePreviewProvider } from '../labelStore.selectors';
 
+import { newId } from "@zplab/core/lib/ids";
 /** Credential-store account name for the Labelary API key. */
 const LABELARY_KEY_CRED = 'labelary-api-key';
 
@@ -411,7 +412,7 @@ export const createUiSlice: StateCreator<LabelState, [], [], UiSlice> = (set, ge
       if (state.paletteRows.some((r) => r.entryId === entryId)) {
         return { paletteRows: state.paletteRows.filter((r) => r.entryId !== entryId) };
       }
-      const id = `${entryId}-${crypto.randomUUID().slice(0, 8)}`;
+      const id = `${entryId}-${newId().slice(0, 8)}`;
       return { paletteRows: [...state.paletteRows, { id, entryId }] };
     }),
   removePaletteRow: (index) =>

--- a/src/store/slices/variablesSlice.ts
+++ b/src/store/slices/variablesSlice.ts
@@ -17,6 +17,7 @@ import { dropPageOverlays } from '@zplab/core/lib/pageOverlay';
 import { selectPreviewLocksEditor } from '../labelStore.selectors';
 import type { LabelState } from '../labelStore';
 
+import { newId } from "@zplab/core/lib/ids";
 export interface VariablesSlice {
   /** Document-level template variables. Fields reference them via `«name»`
    *  content markers; export emits `^FN{fnNumber}^FD{defaultValue}^FS`.
@@ -62,7 +63,7 @@ export const createVariablesSlice: StateCreator<LabelState, [], [], VariablesSli
     }
 
     const variable: Variable = {
-      id: crypto.randomUUID(),
+      id: newId(),
       name: trimmedName,
       fnNumber,
       // A default is a literal fallback; strip marker delimiters so it can't


### PR DESCRIPTION
newId() falls back to getRandomValues, copyText() to execCommand; .prn accepted on ZPL import.