### PR TITLE
fix(macos): grant MCP sidecar allow-jit entitlement

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- The MCP sidecar is a Node SEA binary; V8 needs to map executable memory
+       for its JIT. Under hardened runtime this crashes ("Failed to reserve
+       virtual memory for CodeRange") without these entitlements. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,8 @@
     "shortDescription": "ZPL label designer",
     "longDescription": "Visual designer for Zebra ZPL printer labels with live preview and ZPL import/export.",
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist"
     },
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
Node SEA binary crashes under hardened runtime without allow-jit ("Failed to reserve virtual memory for CodeRange"); the sidecar never reaches listening, so MCP fails to start on installed macOS builds.