### PR TITLE
refactor(code128): single emit-plan derivation for fd, losses and gates

### DIFF
--- a/packages/core/src/lib/barcodeDims.ts
+++ b/packages/core/src/lib/barcodeDims.ts
@@ -316,7 +316,9 @@ export function buildBwipOptions(
       }
       const text = p.content || "0";
       // Control bytes render from the same symbol plan the emitter writes as
-      // subset invocations, so canvas width equals printed width by construction.
+      // subset invocations, so canvas width equals printed width by
+      // construction. This is planCode128Fd's whole mode in bwip symbol
+      // values; keep the two branches in lockstep with code128Plan.ts.
       const ctrlRaw = code128ControlBwipRaw(text);
       if (ctrlRaw) {
         opts = { bcid, text: ctrlRaw, raw: true, scale, height: 10 };

--- a/packages/core/src/lib/code128Plan.test.ts
+++ b/packages/core/src/lib/code128Plan.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { planCode128Fd, planHasLoss } from "./code128Plan";
+
+describe("planCode128Fd", () => {
+  it("whole: encodes control bytes as invocations, losslessly", () => {
+    expect(planCode128Fd("A\tB", "whole")).toEqual({ fd: ">9337334", losses: [] });
+    expect(planCode128Fd("A«ctrl:TAB»B", "whole").fd).toBe(">9337334");
+  });
+
+  it("whole: flags the ^FH drop when a byte fits no subset", () => {
+    const plan = planCode128Fd("Ä\tB", "whole");
+    expect(planHasLoss(plan, "controlBytesDropped")).toBe(true);
+    expect(plan.fd).toBe("Ä\tB");
+  });
+
+  it("whole: escapes >^~ and flags > before an invocation char", () => {
+    expect(planCode128Fd("A>B^C~D", "whole").fd).toBe("A>0B><C>=D");
+    const plan = planCode128Fd("A>5B", "whole");
+    expect(plan.fd).toBe("A>5B");
+    expect(plan.losses).toEqual([{ kind: "invocationRead", seqs: [">5"] }]);
+  });
+
+  it("template: escapes literal spans only and reports both loss kinds", () => {
+    const plan = planCode128Fd("A>«x^y»B«ctrl:TAB»>5", "template");
+    expect(plan.fd).toBe("A>0«x^y»B«ctrl:TAB»>5");
+    expect(planHasLoss(plan, "controlBytesDropped")).toBe(true);
+    expect(plan.losses).toContainEqual({ kind: "invocationRead", seqs: [">5"] });
+  });
+
+  it("templateValue: plain escape with chips PRESERVED as marker text in fd", () => {
+    expect(planCode128Fd("X>Y", "templateValue").fd).toBe("X>0Y");
+    // The header emit ships chip markers literally; only the losses look at
+    // the resolved bytes. The parser's plain-domain gate relies on this.
+    const plan = planCode128Fd("A«ctrl:TAB»B^C", "templateValue");
+    expect(plan.fd).toBe("A«ctrl:TAB»B><C");
+    expect(planHasLoss(plan, "controlBytesDropped")).toBe(true);
+  });
+
+  it("sharedRaw: chip-resolves only and reports the unescaped corruption", () => {
+    const plan = planCode128Fd("X>Y«ctrl:TAB»", "sharedRaw");
+    expect(plan.fd).toBe("X>Y\t");
+    expect(planHasLoss(plan, "rawUnescaped")).toBe(true);
+    expect(planHasLoss(plan, "controlBytesDropped")).toBe(true);
+    expect(planHasLoss(plan, "invocationRead")).toBe(false);
+    expect(planCode128Fd("LOT7", "sharedRaw")).toEqual({ fd: "LOT7", losses: [] });
+  });
+
+  it("annotates DEL as routing, never as an ^FH drop (DEL ships as a raw byte)", () => {
+    expect(planCode128Fd("A\x7FB", "whole")).toEqual({ fd: ">:A>1B", losses: [] });
+    expect(planHasLoss(planCode128Fd("\x7FX", "templateValue"), "controlBytesDropped")).toBe(false);
+  });
+
+  it("orders losses invocation-first (pinned detail order)", () => {
+    const plan = planCode128Fd("Ä>5\tB", "whole");
+    expect(plan.losses.map((l) => l.kind)).toEqual(["invocationRead", "controlBytesDropped"]);
+  });
+
+  it("is idempotent on its own output (adoption gate contract)", () => {
+    for (const text of ["A>B", "A\tB", "A^B~C", "ABC", "A>5B", "Ä\tB"]) {
+      const fd = planCode128Fd(text, "whole").fd;
+      expect(planCode128Fd(fd, "whole").fd, JSON.stringify(text)).toBe(fd);
+    }
+  });
+});

--- a/packages/core/src/lib/code128Plan.ts
+++ b/packages/core/src/lib/code128Plan.ts
@@ -1,0 +1,76 @@
+import {
+  code128ControlFd,
+  code128EscapeLiterals,
+  code128PlainFd,
+} from "./code128Subset";
+import { C0_RE, resolveControlMarkers } from "../types/controlKey";
+
+/** How a payload reaches a plain-^BC ^FD: `whole` = entire field (chips
+ *  resolve), `template` = literal spans around markers, `templateValue` =
+ *  ^FN declaration (chips stay marker TEXT in `fd`, losses approximate on
+ *  resolved bytes), `sharedRaw` = shared slot. Serial/GS1 bypass this grammar. */
+export type Code128FdMode = "whole" | "template" | "templateValue" | "sharedRaw";
+
+export type Code128FdLoss =
+  /** Control bytes cannot ride this mode's FD: they fall to ^FH, which the
+   *  firmware drops from the symbol (ZD230). */
+  | { kind: "controlBytesDropped" }
+  /** `>` before an invocation char stays verbatim (import round-trip channel),
+   *  so the firmware reads an invocation, not text. */
+  | { kind: "invocationRead"; seqs: string[] }
+  /** Raw emit: `>`/`^`/`~` reach the firmware unescaped and corrupt. */
+  | { kind: "rawUnescaped" };
+
+export interface Code128FdPlan {
+  /** The ^FD payload the emitter writes (before fdField's ^FH hex pass). */
+  fd: string;
+  losses: Code128FdLoss[];
+}
+
+const INVOCATION_SEQ = />[0-9:;<=]/g;
+
+function invocationSeqs(text: string): string[] {
+  return [...new Set(text.match(INVOCATION_SEQ) ?? [])];
+}
+
+/** Invocation loss first (pinned detail order); the drop loss is C0-only,
+ *  DEL ships as a raw byte on ^FH (routing class, not loss). */
+function pushLosses(losses: Code128FdLoss[], bytes: string): void {
+  const seqs = invocationSeqs(bytes);
+  if (seqs.length > 0) losses.push({ kind: "invocationRead", seqs });
+  if (C0_RE.test(bytes)) losses.push({ kind: "controlBytesDropped" });
+}
+
+/** Single derivation for plain-^BC field data: what the emitter writes and
+ *  what the printer loses. Emit, the parser's byte-identity gates and the
+ *  preflight loss channels all consume this, so they cannot drift. */
+export function planCode128Fd(payload: string, mode: Code128FdMode): Code128FdPlan {
+  const losses: Code128FdLoss[] = [];
+  switch (mode) {
+    case "whole": {
+      const bytes = resolveControlMarkers(payload);
+      const invocation = code128ControlFd(bytes);
+      if (invocation !== null) return { fd: invocation, losses };
+      pushLosses(losses, bytes);
+      return { fd: code128PlainFd(bytes), losses };
+    }
+    case "template": {
+      pushLosses(losses, resolveControlMarkers(payload));
+      return { fd: code128EscapeLiterals(payload), losses };
+    }
+    case "templateValue": {
+      pushLosses(losses, resolveControlMarkers(payload));
+      return { fd: code128PlainFd(payload), losses };
+    }
+    case "sharedRaw": {
+      const bytes = resolveControlMarkers(payload);
+      if (/[>^~]/.test(bytes)) losses.push({ kind: "rawUnescaped" });
+      if (C0_RE.test(bytes)) losses.push({ kind: "controlBytesDropped" });
+      return { fd: bytes, losses };
+    }
+  }
+}
+
+export function planHasLoss(plan: Code128FdPlan, kind: Code128FdLoss["kind"]): boolean {
+  return plan.losses.some((l) => l.kind === kind);
+}

--- a/packages/core/src/lib/markerResolve.ts
+++ b/packages/core/src/lib/markerResolve.ts
@@ -56,6 +56,8 @@ export function resolveMarkerChain(
   let next = content;
   // Template-form plain-^BC: escape literal spans pre-substitution, escape
   // substituted values like their ^FN declarations, drop bytes like ^FH does.
+  // Mirrors planCode128Fd's template/templateValue modes on the render side;
+  // changes there must land here too (code128Plan.ts is the emit oracle).
   let templateFd = false;
   let loneBind = false;
   if (getDates) {

--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -6,8 +6,8 @@ import { GS1_GS, parseGs1ToSegments, validateGs1Segment, validateGs1SegmentResol
 import { DATAMATRIX_FD_ESCAPE } from "./dataMatrixFd";
 import { extractTemplateRefs, hasTemplateMarkers, pickEmbedChar } from "./fnTemplate";
 import { hasClockMarkers, pickClockChars } from "./fcTemplate";
-import { code128ControlFd, code128EscapeLiterals, hasControlBytes } from "./code128Subset";
-import { C0_RE, resolveControlMarkers } from "../types/controlKey";
+import { planCode128Fd, planHasLoss } from "./code128Plan";
+import { resolveControlMarkers } from "../types/controlKey";
 import { classifyField, isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
@@ -241,44 +241,54 @@ export function markerValueFindings(
     (val) => val.includes(">"),
     (names) => `">" in ${names} prints as an invocation code (slot shared with a non-GS1 field)`,
   );
+  // Plain-^BC value channels: the LEAF shape picks the plan mode, the loss
+  // kind picks the message. Known over-warn on mixed slots' template leaf
+  // (the single-bind emit carries the invocation form there).
+  const c0Message = (names: string) =>
+    `control bytes in ${names} are dropped from the printed symbol (^FH path)`;
   slotValueWarnings(
     buckets.plainShared,
     plainLeaf,
-    // Not the escape delta: a `>` before an invocation char is unfixable by
-    // escaping yet still corrupts (swallow / subset switch), so flag every >^~.
-    (val) => /[>^~]/.test(val),
+    (val) => planHasLoss(planCode128Fd(val, "sharedRaw"), "rawUnescaped"),
     (names) => `">", "^" or "~" in ${names} corrupts the symbol (shared ^FN slot emits unescaped)`,
   );
   slotValueWarnings(
-    buckets.plainExclusive,
-    plainLeaf,
-    (val) => />[0-9:;<=]/.test(val),
-    (names) => `">" before an invocation character in ${names} prints as a barcode invocation, not text`,
-  );
-  const hasC0 = (val: string) => C0_RE.test(val);
-  const c0Message = (names: string) =>
-    `control bytes in ${names} are dropped from the printed symbol (^FH path)`;
-  // Exclusive slots: a lone bind encodes control bytes losslessly (invocation
-  // form), a template keeps ^FH where the firmware drops them.
-  slotValueWarnings(
-    buckets.plainExclusive,
-    (leaf) => plainLeaf(leaf) && !isLoneMarker(getObjectStringContent(leaf) ?? ""),
-    hasC0,
-    c0Message,
-  );
-  // Lone binds still lose when the value defeats the invocation plan (a byte
-  // no subset carries): the emit then falls back to ^FH.
-  slotValueWarnings(
-    buckets.plainExclusive,
-    (leaf) => plainLeaf(leaf) && isLoneMarker(getObjectStringContent(leaf) ?? ""),
-    (val) => hasC0(val) && code128ControlFd(resolveControlMarkers(val)) === null,
-    c0Message,
-  );
-  // Shared slots emit raw/^FH even for a lone bind, so no exemption there.
-  slotValueWarnings(
     buckets.plainShared,
     plainLeaf,
-    hasC0,
+    (val) => planHasLoss(planCode128Fd(val, "sharedRaw"), "controlBytesDropped"),
+    c0Message,
+  );
+  // Exclusive slots: a lone bind is a whole ^FD (invocation form covers
+  // control bytes AND protects `>`+invocation sequences by encoding them);
+  // a template value keeps ^FH and ships the sequences verbatim.
+  const invMessage = (names: string) =>
+    `">" before an invocation character in ${names} prints as a barcode invocation, not text`;
+  const templateLeaf = (leaf: LeafObject) =>
+    plainLeaf(leaf) && !isLoneMarker(getObjectStringContent(leaf) ?? "");
+  const loneLeaf = (leaf: LeafObject) =>
+    plainLeaf(leaf) && isLoneMarker(getObjectStringContent(leaf) ?? "");
+  slotValueWarnings(
+    buckets.plainExclusive,
+    templateLeaf,
+    (val) => planHasLoss(planCode128Fd(val, "templateValue"), "invocationRead"),
+    invMessage,
+  );
+  slotValueWarnings(
+    buckets.plainExclusive,
+    loneLeaf,
+    (val) => planHasLoss(planCode128Fd(val, "whole"), "invocationRead"),
+    invMessage,
+  );
+  slotValueWarnings(
+    buckets.plainExclusive,
+    templateLeaf,
+    (val) => planHasLoss(planCode128Fd(val, "templateValue"), "controlBytesDropped"),
+    c0Message,
+  );
+  slotValueWarnings(
+    buckets.plainExclusive,
+    loneLeaf,
+    (val) => planHasLoss(planCode128Fd(val, "whole"), "controlBytesDropped"),
     c0Message,
   );
   // Exhausted ^FC/^FE candidate sets arm nothing at export: markers ship as
@@ -292,7 +302,7 @@ export function markerValueFindings(
   for (const leaf of leaves) {
     const c = getObjectStringContent(leaf);
     if (c === undefined || !inScan(c)) continue;
-    const scan = plainLeaf(leaf) ? code128EscapeLiterals(c) : c;
+    const scan = plainLeaf(leaf) ? planCode128Fd(c, "template").fd : c;
     if (armsFe(c)) templatePayloads.push(scan);
     if (hasClockMarkers(c)) clockPayloads.push(scan);
   }
@@ -360,27 +370,21 @@ export function computePreflight(
         (leaf.type === "maxicode" && [2, 3].includes((leaf.props as { mode?: number }).mode ?? 0));
       const scanned = gsStructural ? content.split(GS1_GS).join("") : content;
       let detail = suspiciousCharDetail(scanned);
-      // Plain ^BC: `>` before an invocation char stays verbatim (escaping it
-      // would corrupt imported streams), so the firmware reads an invocation.
-      // Serial excluded: the ^SN seed is filtered to alphanumerics anyway.
+      // Plain ^BC: read the emit plan's losses for this content. Serial is
+      // excluded: the ^SN seed is filtered to alphanumerics anyway. Known
+      // gap: an unencodable byte without any C0 (e.g. DEL plus Ä) drops
+      // silently; C0_RE keys the drop loss, DEL alone is routing, not loss.
       const p = leaf.props as { gs1?: boolean; serial?: unknown };
       if (getEntry(leaf.type)?.ctrlNeedsOwnEscape && !p.gs1 && !p.serial) {
-        const invocations = content.match(/>[0-9:;<=]/g);
-        if (invocations) {
-          const inv = `${[...new Set(invocations)].map((s) => `"${s}"`).join(", ")} read as barcode invocation codes, not text`;
-          detail = detail ? `${detail}; ${inv}` : inv;
-        }
-        // Control bytes (chips or raw) beside other markers (^FH path) or
-        // beside a byte no subset carries (invocation plan bails) both drop
-        // from the symbol.
-        const resolved = resolveControlMarkers(content);
-        if (hasControlBytes(resolved)) {
-          const drop = hasTemplateMarkers(resolved)
-            ? "control bytes in a template field are dropped from the printed symbol"
-            : code128ControlFd(resolved) === null
-              ? "control bytes are dropped from the printed symbol (payload has a character Code 128 cannot encode)"
-              : null;
-          if (drop) detail = detail ? `${detail}; ${drop}` : drop;
+        const templateFd = hasTemplateMarkers(resolveControlMarkers(content));
+        const plan = planCode128Fd(content, templateFd ? "template" : "whole");
+        for (const loss of plan.losses) {
+          const msg = loss.kind === "invocationRead"
+            ? `${loss.seqs.map((s) => `"${s}"`).join(", ")} read as barcode invocation codes, not text`
+            : templateFd
+              ? "control bytes in a template field are dropped from the printed symbol"
+              : "control bytes are dropped from the printed symbol (payload has a character Code 128 cannot encode)";
+          detail = detail ? `${detail}; ${msg}` : msg;
         }
       }
       if (detail) {

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -11,7 +11,7 @@ import { boundColumnIndex, getObjectStringContent } from './variableBinding';
 import { classifyField } from './variableField';
 import { escapeGs1FdValue } from './gs1';
 import { fnConsumerBuckets } from './gs1ModeDFns';
-import { code128EscapeLiterals, code128PlainFd } from './code128Subset';
+import { planCode128Fd } from './code128Plan';
 import { resolveControlMarkers } from '../types/controlKey';
 import { formatLabelMetaComment } from './zplLabelMeta';
 import { jmDensityOf } from '../types/LabelConfig';
@@ -90,7 +90,7 @@ export function planTemplateHeader(
     const scan =
       getEntry(leaf.type)?.ctrlNeedsOwnEscape
       && !(leaf as { props?: { gs1?: boolean } }).props?.gs1
-        ? code128EscapeLiterals(c)
+        ? planCode128Fd(c, 'template').fd
         : c;
     // Chips-only payloads arm no ^FE (they emit as invocations/bytes), so
     // their literals must not constrain the embed-char pick.
@@ -121,7 +121,7 @@ export function planTemplateHeader(
       const def = modeDFns.has(fn)
         ? escapeGs1FdValue(v.defaultValue)
         : plain128Fns.has(fn)
-          ? code128PlainFd(v.defaultValue)
+          ? planCode128Fd(v.defaultValue, 'templateValue').fd
           : v.defaultValue;
       headerLines.push(`^FN${fn}${fdField(def)}`);
     }
@@ -508,11 +508,13 @@ export function generateBatchZpl(
       bound && !isGroup(bound) && !!getEntry(bound.type)?.ctrlNeedsOwnEscape
       && !(bound.props as { gs1?: boolean }).gs1 && plainSharedFns.has(v.fnNumber);
     const transform = boundPlainShared
-      ? resolveControlMarkers
+      ? (s: string) => planCode128Fd(s, 'sharedRaw').fd
       : (bound && !isGroup(bound) ? getEntry(bound.type)?.fdTransform?.(bound) : undefined) ??
         (modeDFns.has(v.fnNumber)
           ? escapeGs1FdValue
-          : plain128Fns.has(v.fnNumber) ? code128PlainFd : identity);
+          : plain128Fns.has(v.fnNumber)
+            ? (s: string) => planCode128Fd(s, 'templateValue').fd
+            : identity);
     overrides.push({ fn: v.fnNumber, colIdx, transform });
   }
 

--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_CLOCK_CHARS } from "./fcTemplate";
 import { unescapeGs1FdValue, zplFdToModelContent } from "./gs1";
 import { code128PlainExclusiveFns, gs1ModeDExclusiveFns } from "./gs1ModeDFns";
-import { code128ControlFd, code128FdToBytes, code128PlainFd, hasControlBytes } from "./code128Subset";
+import { code128FdToBytes, hasControlBytes } from "./code128Subset";
+import { planCode128Fd } from "./code128Plan";
 import { extractTemplateRefs, hasTemplateMarkers } from "./fnTemplate";
 import { controlBytesToMarkers, resolveControlMarkers } from "../types/controlKey";
 import { isLoneMarker } from "./variableField";
@@ -91,25 +92,26 @@ function normalizeCode128PlainDefaults(objects: readonly LabelObject[], variable
     const bytes = code128FdToBytes(v.defaultValue);
     let adopted = false;
     if (bytes !== null && hasControlBytes(bytes)) {
-      if (pureLone && code128ControlFd(bytes) === v.defaultValue) {
+      // Raw C0 in the decode = invocation-form default; chips-free domain.
+      if (pureLone && planCode128Fd(bytes, "whole").fd === v.defaultValue) {
         v.defaultValue = controlBytesToMarkers(bytes);
         adopted = true;
       }
     } else if (bytes !== null && bytes !== v.defaultValue
-        && code128PlainFd(bytes) === v.defaultValue) {
-      // Identity "adoption" (bytes === default) must fall through: a default
-      // carrying chip markers decodes to itself yet regen-encodes differently.
+        && planCode128Fd(bytes, "templateValue").fd === v.defaultValue) {
+      // Marker-PRESERVING domain: whole mode would resolve chips and never
+      // match a chipified default. Identity adoption (bytes === default)
+      // falls through to the lossy check.
       v.defaultValue = bytes;
       adopted = true;
     }
     if (adopted) continue;
-    // Not adopted: regen emits the escape form; flag when that rewrites the
-    // imported bytes (chips resolve either way, so compare against both).
-    const resolved = resolveControlMarkers(v.defaultValue);
-    const emitted = pureLone
-      ? (code128ControlFd(resolved) ?? code128PlainFd(resolved))
-      : code128PlainFd(v.defaultValue);
-    if (emitted !== v.defaultValue && emitted !== resolved) regenLossy = true;
+    // Not adopted: the plan says what regen emits; flag when that rewrites
+    // the imported bytes (chips resolve either way, compare against both).
+    const emitted = planCode128Fd(v.defaultValue, pureLone ? "whole" : "templateValue").fd;
+    if (emitted !== v.defaultValue && emitted !== resolveControlMarkers(v.defaultValue)) {
+      regenLossy = true;
+    }
   }
   return regenLossy;
 }

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -10,14 +10,8 @@ import type { LabelObject } from "../../types/Group";
 import { embedsToMarkers, hasTemplateMarkers } from "../fnTemplate";
 import { tokensToMarkers } from "../fcTemplate";
 import { controlBytesToMarkers } from "../../types/controlKey";
-import {
-  code128ControlFd,
-  code128DecodeLiterals,
-  code128EscapeLiterals,
-  code128FdToBytes,
-  code128PlainFd,
-  hasControlBytes,
-} from "../code128Subset";
+import { code128DecodeLiterals, code128FdToBytes } from "../code128Subset";
+import { planCode128Fd } from "../code128Plan";
 import { decodeFbContent } from "../fbContent";
 import { decodeTbContent } from "../tbContent";
 import { zplFdToModelContent } from "../gs1";
@@ -59,25 +53,19 @@ export interface FlushFieldDeps {
   takeComment: () => string | undefined;
 }
 
-/** Adopt a plain-^BC ^FD into model bytes only when the emit re-encodes it
- *  byte-identically (an uncatalogued C0 stays a raw byte; a compacted
+/** Adopt a plain-^BC ^FD into model bytes only when the emit plan re-encodes
+ *  it byte-identically (an uncatalogued C0 stays a raw byte; a compacted
  *  Subset-C or FNC stream stays verbatim and re-exports unchanged). Payloads
  *  a regen would rewrite flag `bcFdRegenLossy` instead. */
 function adoptCode128Fd(content: string, s: ParserState): string {
-  const bytes = hasTemplateMarkers(content) ? null : code128FdToBytes(content);
-  const unescaped = hasTemplateMarkers(content) ? code128DecodeLiterals(content) : null;
-  if (bytes !== null
-      && (hasControlBytes(bytes)
-        ? code128ControlFd(bytes) === content
-        : code128PlainFd(bytes) === content)) {
-    return bytes;
+  if (hasTemplateMarkers(content)) {
+    const unescaped = code128DecodeLiterals(content);
+    if (planCode128Fd(unescaped, "template").fd === content) return unescaped;
+  } else {
+    const bytes = code128FdToBytes(content);
+    if (bytes !== null && planCode128Fd(bytes, "whole").fd === content) return bytes;
   }
-  if (unescaped !== null && code128EscapeLiterals(unescaped) === content) {
-    // Marker-bearing payload: the emit escaped the literal spans before
-    // tokenization, so reverse that (same byte-identity gate).
-    return unescaped;
-  }
-  if (code128PlainFd(content) !== content || code128ControlFd(content) !== null) {
+  if (planCode128Fd(content, "whole").fd !== content) {
     // Regen rewrites this field (bare `>` re-escaped, ^FH-imported control
     // bytes become invocations; unencodable bytes keep the identical ^FH
     // path), so byte exactness only holds through the page's overlay.

--- a/packages/core/src/registry/barcode1d.ts
+++ b/packages/core/src/registry/barcode1d.ts
@@ -7,7 +7,7 @@ import { commitBarcodeWidthHeightTransform } from './transformHelpers';
 import { hasTemplateMarkers } from '../lib/fnTemplate';
 import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { classifyField, isLoneMarker } from '../lib/variableField';
-import { code128EscapeLiterals } from '../lib/code128Subset';
+import { planCode128Fd } from '../lib/code128Plan';
 import { resolveControlMarkers } from '../types/controlKey';
 import { gs1ContentToZplFd, parseGs1ToSegments, segmentsToZplFd } from '../lib/gs1';
 import { GS1_CONTENT_SPEC } from './gs1FieldSpec';
@@ -109,20 +109,16 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
             : config.gs1Capable && obj.props.gs1
               ? gs1ContentToZplFd
               : config.fdContent;
-          // Non-template payloads are whole ^FD values, so control bytes in a
-          // bound default/CSV cell encode in the symbology's own form; the
-          // ^FH hex fdField would otherwise drop them from the symbol.
-          const ctrlEncode =
-            !isTemplate && escape && config.ctrlFdEncode && config.controlChars === true
-              ? config.ctrlFdEncode
-              : undefined;
+          // Non-template payloads are whole ^FD values; the plan owns the
+          // invocation-vs-^FH decision (fdPlainEscape implies the code128
+          // grammar, pinned by the carrier tripwire in gs1ModeDFns.test).
+          const ctrlWhole =
+            !isTemplate && escape && config.ctrlFdEncode && config.controlChars === true;
           const plain = !base ? escape : !escape ? base : (s: string) => escape(base(s));
-          if (!ctrlEncode || !plain) return plain;
-          // Resolve once so the ^FH fallback gets bytes, not chip marker text.
-          return (s: string) => {
-            const r = resolveControlMarkers(s);
-            return ctrlEncode(r) ?? plain(r);
-          };
+          if (!ctrlWhole || !plain) return plain;
+          // base stays in the chain (runs pre chip-resolve; unreachable until
+          // a carrier defines both fdContent and ctrlFdEncode).
+          return (s: string) => planCode128Fd(base ? base(s) : s, 'whole').fd;
         }
       : undefined;
 
@@ -199,7 +195,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
           && isLoneMarker(content)) {
         const cls = classifyField(content, ctx.variables);
         if (cls.kind === 'single' && ctx.rawFdFns.has(cls.variable.fnNumber)) {
-          fdTransformOnce = resolveControlMarkers;
+          fdTransformOnce = (s: string) => planCode128Fd(s, 'sharedRaw').fd;
         }
       }
       // Template payload: escape literal spans BEFORE ^FE/^FC tokenization. A
@@ -209,7 +205,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
       // marker BODIES stay raw too (names may carry >/^/~).
       if (!p.gs1 && config.fdPlainEscape && !isLoneMarker(content)
           && hasTemplateMarkers(resolveControlMarkers(content))) {
-        content = code128EscapeLiterals(content);
+        content = planCode128Fd(content, 'template').fd;
         fdTransformOnce = undefined;
       }
       if (config.gs1Capable && p.gs1 && hasTemplateMarkers(content) && !isLoneMarker(content)) {

--- a/packages/core/src/registry/hriFormatters.ts
+++ b/packages/core/src/registry/hriFormatters.ts
@@ -82,8 +82,9 @@ export function stripHriControlBytes(text: string): string {
 }
 
 /** Plain ^BC HRI shows the DECODED data, never invocation codes (spec p.98,
- *  Fig 3/4). Runs on the emit-escaped form, so typed text the escape protects
- *  is a fixed point. GS1 mode bypasses this (mode-D grammar). */
+ *  Fig 3/4). Runs on the emit-escaped form (planCode128Fd's plain fallback;
+ *  keep in lockstep), so typed text the escape protects is a fixed point.
+ *  GS1 mode bypasses this (mode-D grammar). */
 export function formatCode128Hri(content: string): string {
   return code128FdToDisplayText(code128PlainFd(content));
 }

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -408,6 +408,13 @@ describe("computePreflight (suspicious-chars producer)", () => {
     const rawUnencodable = computePreflight([bc("h", "Ä\tB")], ctx, "mm")
       .find((x) => x.kind === "suspiciousChars");
     expect(rawUnencodable?.detail).toContain("cannot encode");
+    // Whole-field content the invocation form protects stays quiet: `>`
+    // sequences encode as symbol values, they are never read as invocations.
+    expect(computePreflight([bc("i", "A>8\tB")], ctx, "mm")
+      .some((x) => x.detail?.includes("invocation"))).toBe(false);
+    // DEL ships as a raw byte on the ^FH path, never a drop warning.
+    expect(computePreflight([bc("j", "A\x7FB«sku»")], ctx, "mm")
+      .some((x) => x.detail?.includes("dropped"))).toBe(false);
   });
 
   it("still flags a control char in a non-GS1 field", () => {
@@ -679,6 +686,18 @@ describe("markerValueFindings (mode-D shared ^FN slot)", () => {
     // embed pick nor warn (it exports as a Code 128 invocation).
     const chips = markerValueFindings([code128("c", "#@|%&?!«ctrl:TAB»", false)], deps);
     expect(chips.some((f) => f.kind === "markerArmFailed")).toBe(false);
+  });
+
+  it("stays quiet when the whole-field emit protects the value (plan modes)", () => {
+    // Lone bind with encodable C0 plus >5: whole mode encodes everything as
+    // invocation symbols, so neither loss channel may fire.
+    const dirty = [{ id: "v", name: "batch", fnNumber: 1, defaultValue: "A\t>5B" }];
+    const deps = { variables: dirty, dataset: null, columnMapping: null };
+    expect(markerValueFindings([code128("c", "«batch»", false)], deps)).toEqual([]);
+    // The same value on a TEMPLATE consumer loses both ways and must warn.
+    const out = markerValueFindings([code128("c", "X«batch»Y", false)], deps);
+    expect(out.some((f) => f.detail?.includes("invocation"))).toBe(true);
+    expect(out.some((f) => f.detail?.includes("control bytes"))).toBe(true);
   });
 
   it("flags > before an invocation char in an EXCLUSIVE plain slot", () => {

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -1828,6 +1828,28 @@ describe('generateBatchZpl', () => {
     expect(generateZPL(baseLabel, r.objects, r.variables)).toBe(out);
   });
 
+  it('emits a chip-bearing template ^FN default with chips as literal text', () => {
+    // Lockstep pin for the generator half of the templateValue pair: the
+    // header ships chip markers literally (only >^~ escape), the parser's
+    // normalize gate reverses in the same marker-preserving domain.
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'A«ctrl:TAB»B^C' }];
+    const out = generateZPL(baseLabel, code128Chip('X«sku»Y'), variables);
+    expect(out).toContain('^FN1^FDA«ctrl:TAB»B><C^FS');
+  });
+
+  it('reverses ^FN-default escapes in the chip-PRESERVING domain', () => {
+    // The adoption gate must compare marker text against marker text: a
+    // whole-field (chip-resolving) comparison never matches a chipified
+    // default and the escape form leaks into the model.
+    for (const dv of ['Ä^B«ctrl:TAB»', 'A>>«ctrl:TAB»']) {
+      const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: dv }];
+      const out = generateZPL(baseLabel, code128Chip('«sku»'), variables);
+      const r = parseSingle(out, 8);
+      expect(defined(r.variables[0]).defaultValue, dv).toBe(dv);
+      expect(generateZPL(baseLabel, r.objects, r.variables)).toBe(out);
+    }
+  });
+
   it('leaves a shared-slot ^FN default verbatim on import (exclusivity decides)', () => {
     // flushField must not decode the default: only the page-close pass knows
     // the slot is shared, where the raw emit makes `>0AB` the true bytes.


### PR DESCRIPTION
Intentional deltas: adoption now covers invocation-impossible payloads; over-warnings on losslessly encoded invocation payloads and DEL-only drop warnings are gone.