### PR TITLE
fix(parser): decode ^FN defaults through the leaf's ^FD encoder

### DIFF
--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -11,7 +11,7 @@ import { getObjectStringContent } from "./variableBinding";
 import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
 import { tokenize } from "./zplParser/helpers";
 import { lookaheadJmDensity, scanBareStream } from "./zplHeadScan";
-import { createParserState, deriveUnitScale, resetFormatScopedState } from "./zplParser/context";
+import { createParserState, deriveUnitScale, resetFormatScopedState, type FnDefaultCandidate } from "./zplParser/context";
 import { createFlushField } from "./zplParser/flushField";
 import { createBarcodeHandlers } from "./zplParser/handlers/barcodes";
 import { createDynamicFontAWildcard, createFieldHandlers } from "./zplParser/handlers/fields";
@@ -38,8 +38,23 @@ export type {
 import type { LabelObject } from "../types/Group";
 import type { Variable } from "../types/Variable";
 
-/** Lone-marker vs. template consumers per ^FN slot; shared by both default
- *  normalizers so their whole-payload criterion cannot drift. */
+/** Page-close override of the upsert-order default. Runs BEFORE the
+ *  mode-D/code128 normalizers, whose slots carry wire-form candidates. */
+function adoptFnDefaultCandidates(
+  variables: Variable[],
+  candidates: ReadonlyMap<number, FnDefaultCandidate>,
+  templateFns: ReadonlySet<number>,
+): void {
+  for (const v of variables) {
+    const rec = candidates.get(v.fnNumber);
+    if (rec?.decoded && !templateFns.has(v.fnNumber)) {
+      v.defaultValue = rec.value;
+    }
+  }
+}
+
+/** Lone-marker vs. template consumers per ^FN slot; shared by all page-close
+ *  default passes so their whole-payload criterion cannot drift. */
 function fnConsumerShapes(
   objects: readonly LabelObject[],
   variables: readonly Variable[],
@@ -65,10 +80,13 @@ function fnConsumerShapes(
  *  AI's value, where canonicalization could mutate bytes (GTIN check digit), so
  *  only the >0 escape reverses. Scoped per page: a later page reusing the same
  *  ^FN number with a plain field must not inherit this page's GS1 decode. */
-function normalizeModeDDefaults(objects: readonly LabelObject[], variables: Variable[]): void {
+function normalizeModeDDefaults(
+  objects: readonly LabelObject[],
+  variables: Variable[],
+  loneFns: ReadonlySet<number>,
+): void {
   const modeDFns = gs1ModeDExclusiveFns(objects, variables);
   if (modeDFns.size === 0) return;
-  const { loneFns } = fnConsumerShapes(objects, variables);
   for (const v of variables) {
     if (!modeDFns.has(v.fnNumber)) continue;
     v.defaultValue = loneFns.has(v.fnNumber)
@@ -81,10 +99,14 @@ function normalizeModeDDefaults(objects: readonly LabelObject[], variables: Vari
  *  payloads verbatim: only this pass knows slot exclusivity). Adopts only
  *  byte-identical re-encodes; returns true when a default's regen would
  *  rewrite the imported bytes (lossyEdit signal). */
-function normalizeCode128PlainDefaults(objects: readonly LabelObject[], variables: Variable[]): boolean {
+function normalizeCode128PlainDefaults(
+  objects: readonly LabelObject[],
+  variables: Variable[],
+  shapes: { loneFns: ReadonlySet<number>; templateFns: ReadonlySet<number> },
+): boolean {
   const plainFns = code128PlainExclusiveFns(objects, variables);
   if (plainFns.size === 0) return false;
-  const { loneFns, templateFns } = fnConsumerShapes(objects, variables);
+  const { loneFns, templateFns } = shapes;
   let regenLossy = false;
   for (const v of variables) {
     if (!plainFns.has(v.fnNumber)) continue;
@@ -330,8 +352,10 @@ export function parseZPL(
     const pagePartial = [...s.result.partialCmds];
     const pageObjects = objects.slice(pg.obj);
     const pageVariables = variables.slice(pg.vari);
-    normalizeModeDDefaults(pageObjects, pageVariables);
-    if (normalizeCode128PlainDefaults(pageObjects, pageVariables)) s.bcFdRegenLossy = true;
+    const shapes = fnConsumerShapes(pageObjects, pageVariables);
+    adoptFnDefaultCandidates(pageVariables, s.fnDefaultCandidates, shapes.templateFns);
+    normalizeModeDDefaults(pageObjects, pageVariables, shapes.loneFns);
+    if (normalizeCode128PlainDefaults(pageObjects, pageVariables, shapes)) s.bcFdRegenLossy = true;
     const pageIndex = pages.length;
     const findings = bucketFindings(
       pageIndex,

--- a/packages/core/src/lib/zplParser/context.ts
+++ b/packages/core/src/lib/zplParser/context.ts
@@ -233,6 +233,8 @@ export interface FieldState {
   snMode: SerialMode["zplMode"];
 }
 
+export type FnDefaultCandidate = { value: string; decoded: boolean } | null;
+
 export interface ParserState {
   result: ParserResult;
   label: LabelFrameState;
@@ -261,6 +263,10 @@ export interface ParserState {
    *  `>` in an unadopted stream): regen changes bytes, so the page is only
    *  byte-exact through its overlay. */
   bcFdRegenLossy: boolean;
+  /** Per ^FN slot: the bound consumers' default candidate. `null` = consumers
+   *  disagreed; `decoded` = at least one consumer actually decoded (a bare
+   *  wire-form echo must not override a header declaration). */
+  fnDefaultCandidates: Map<number, FnDefaultCandidate>;
 }
 
 /** trimEnd: `token` carries `rest` up to the next command, which in multi-line
@@ -282,6 +288,14 @@ export function getDefaultTextW(defaults: DefaultsState): number {
 /** ^FO vs ^FT discriminator for emit sites. */
 export function getPosType(field: FieldState): "FT" | "FO" {
   return field.positionIsFT ? "FT" : "FO";
+}
+
+/** Sticky GS1/^BX mode flags would act on any later field, so every flush
+ *  path drops them with the flushed field. */
+export function resetSymbologyModeFlags(field: FieldState): void {
+  field.bcGs1 = false;
+  field.dmEscape = undefined;
+  field.dmQuality = 200;
 }
 
 /** Reset the field-scoped ^FB/^TB block defaults. They bind to a single field
@@ -312,6 +326,7 @@ export function resetFormatScopedState(s: ParserState): void {
   s.field.justify = s.defaults.fwJustify;
   s.format.fhActive = false;
   s.bcFdRegenLossy = false;
+  s.fnDefaultCandidates = new Map();
   resetFieldBlockDefaults(s.defaults);
 }
 
@@ -380,6 +395,7 @@ export function createParserState(): ParserState {
     varScopeStart: 0,
     sawXa: false,
     bcFdRegenLossy: false,
+    fnDefaultCandidates: new Map(),
     field: freshFieldState(),
   };
 }

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -6,7 +6,9 @@ import {
   markerOf,
   type Variable,
 } from "../../types/Variable";
-import type { LabelObject } from "../../types/Group";
+import { isGroup, type LabelObject } from "../../types/Group";
+import { isModeDLeaf } from "../gs1ModeDFns";
+import { getObjectStringContent } from "../variableBinding";
 import { embedsToMarkers, hasTemplateMarkers } from "../fnTemplate";
 import { tokensToMarkers } from "../fcTemplate";
 import { controlBytesToMarkers } from "../../types/controlKey";
@@ -43,7 +45,13 @@ import type { CodablockProps } from "../../registry/codablock";
 import type { Tlc39Props } from "../../registry/tlc39";
 import { upceData6FromFd } from "../../registry/hriFormatters";
 import { decodeFH, makeObj, variableNameFromComment } from "./helpers";
-import { getPosType, resetFieldBlockDefaults, type ParserState } from "./context";
+import {
+  getPosType,
+  resetFieldBlockDefaults,
+  resetSymbologyModeFlags,
+  type FnDefaultCandidate,
+  type ParserState,
+} from "./context";
 
 import { newId } from "../ids";
 /** Cross-family deps flushField borrows from graphics (^GB+^FR) and parseZPL (^FX). */
@@ -72,6 +80,37 @@ function adoptCode128Fd(content: string, s: ParserState): string {
     s.bcFdRegenLossy = true;
   }
   return content;
+}
+
+/** Slot-scoped: a plain co-consumer prints the raw slot value, so only a
+ *  re-encodable decode may be offered. Mode-D/plain ^BC defer to their
+ *  page-close normalizers. */
+function fnDefaultCandidate(
+  leaf: LabelObject,
+  varDefault: string,
+  wire: string,
+): NonNullable<FnDefaultCandidate> {
+  if (!isGroup(leaf) && !isModeDLeaf(leaf) && !getEntry(leaf.type)?.ctrlNeedsOwnEscape) {
+    const leafContent = getObjectStringContent(leaf);
+    if (leafContent !== undefined && leafContent !== varDefault) {
+      const encode = getEntry(leaf.type)?.fdTransform?.(leaf);
+      if (encode && encode(leafContent) === wire) {
+        return { value: leafContent, decoded: true };
+      }
+    }
+  }
+  return { value: varDefault, decoded: false };
+}
+
+function recordFnDefaultCandidate(
+  map: Map<number, FnDefaultCandidate>,
+  fn: number,
+  cand: NonNullable<FnDefaultCandidate>,
+): void {
+  const rec = map.get(fn);
+  if (rec === undefined) map.set(fn, cand);
+  else if (rec === null || rec.value !== cand.value) map.set(fn, null);
+  else if (cand.decoded) rec.decoded = true;
 }
 
 /** Field-emit closure: turns cached s.field into a pushed LabelObject at ^FS. */
@@ -158,6 +197,7 @@ export function createFlushField(
       s.field.pendingFD = null;
       // Reset half-formed field (e.g. `^GS…^FS` without `^FD`) so kind doesn't leak.
       s.field.fieldType = null;
+      resetSymbologyModeFlags(s.field);
       return;
     }
     const rawDecoded = s.format.fhActive
@@ -627,8 +667,8 @@ export function createFlushField(
     // Bind pending ^FN slot; existing Variable for same fnNumber is reused.
     if (s.comment.fnNumber !== null) {
       if (justPushed) {
-        // ^TB encodes the bound default (`<<>`), so store the decoded plain
-        // value to stay symmetric with the generator; ^FB/plain keep content.
+        // ^TB decodes here: its wire form (`<<>`) is not stable under a
+        // second encode, so the generic candidate path cannot recover it.
         const varDefault = isTbField ? decoded : content;
         const variable = upsertVariable(s.comment.fnNumber, varDefault, s.comment.fnComment);
         // Serial wins over the binding, but only when actually applied
@@ -640,6 +680,15 @@ export function createFlushField(
         if (serialApplied) {
           s.serialStrippedFns.add(s.comment.fnNumber);
         } else {
+          // An empty ^FD carries no wire form; abstaining keeps the slot's
+          // agreement intact.
+          if (content !== "") {
+            recordFnDefaultCandidate(
+              s.fnDefaultCandidates,
+              s.comment.fnNumber,
+              fnDefaultCandidate(justPushed, varDefault, content),
+            );
+          }
           // Field links to its variable via a single «name» marker (single-bind
           // on emit), not a stored variableId.
           const leaf = justPushed as { props?: { content?: string } };
@@ -671,6 +720,7 @@ export function createFlushField(
     s.field.fieldType = null;
     s.field.pendingFD = null;
     s.field.frActive = false;
+    resetSymbologyModeFlags(s.field);
   };
 
   return flushField;

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { zlibSync } from 'fflate';
 import { parseZPL, BY_CONSUMING_BARCODE_TYPES } from '@zplab/core/lib/zplParser';
+import { generateZPL } from '@zplab/core/lib/zplGenerator';
 import { formatLabelMetaComment } from '@zplab/core/lib/zplLabelMeta';
 import { ObjectRegistry } from '@zplab/core/registry';
-import { props, serialOf, parseSingle, commandsOf } from '../test/helpers';
+import { defined, props, serialOf, parseSingle, commandsOf } from '../test/helpers';
 
 // Drift guard for the bare-^BY hazard set. Every 1D and postal barcode emits a
 // ^BY on regen, so it must be classified ^BY-consuming; a forgotten new one
@@ -2580,6 +2581,144 @@ describe('parseZPL — ^FO with justification parameter', () => {
     expect(objects[0]?.x).toBeCloseTo(100);
     expect(objects[0]?.y).toBeCloseTo(200 - 4.62);
     expect(props(objects[0]).content).toBe('Justified');
+  });
+});
+
+describe('parseZPL — ^FN defaults decode through the leaf\'s ^FD encoder', () => {
+  // Without the symmetric decode every import/export cycle stacked another
+  // encode layer (QA,QA,..., C:\\\\x).
+  const FN_BASE = { widthMm: 100, heightMm: 50, dpmm: 8 };
+  const cycle = (zpl: string) => {
+    const r1 = parseSingle(zpl, 8);
+    const out1 = generateZPL(FN_BASE, r1.objects, r1.variables);
+    const r2 = parseSingle(out1, 8);
+    const out2 = generateZPL(FN_BASE, r2.objects, r2.variables);
+    return { default1: r1.variables[0]?.defaultValue, out1, out2 };
+  };
+
+  it('strips the QR {ec}A, prefix from the default and stays fixed', () => {
+    const { default1, out1, out2 } = cycle('^XA^FO10,10^BQN,2,4^FN1^FDQA,https://x.io^FS^XZ');
+    expect(default1).toBe('https://x.io');
+    expect(out1).toContain('^FDQA,https://x.io^FS');
+    expect(out2).toBe(out1);
+  });
+
+  it('unescapes an ^FB default and stays fixed', () => {
+    const { default1, out1, out2 } = cycle('^XA^FO10,10^A0N,30,0^FB200,2,0,L,0^FN1^FDC:\\\\x^FS^XZ');
+    expect(default1).toBe('C:\\x');
+    expect(out2).toBe(out1);
+  });
+
+  it('decodes a GS1 DataMatrix default and stays fixed', () => {
+    const zpl = '^XA^FO10,10^BXN,5,200,,,,_^FN1^FD_101234567890123_110ABC^FS^XZ';
+    const { out1, out2 } = cycle(zpl);
+    expect(out2).toBe(out1);
+  });
+
+  it('strips the UPC-E number-system digit from the default and stays fixed', () => {
+    const { default1, out1, out2 } = cycle('^XA^FO10,10^B9N,100,Y,N,Y^FN1^FD0123456^FS^XZ');
+    expect(default1).toBe('123456');
+    expect(out2).toBe(out1);
+  });
+
+  it('keeps a foreign default verbatim when the encoder cannot reproduce it', () => {
+    const { default1 } = cycle('^XA^FO10,10^BQN,2,4^FN1^FDhello^FS^XZ');
+    expect(default1).toBe('hello');
+  });
+
+  it('keeps a slot shared with a plain co-consumer verbatim (slot-scoped value)', () => {
+    // The text field prints the raw slot value; adopting the UPC-E decode
+    // would rewrite what it prints.
+    const zpl = '^XA^FO10,10^B9N,100,Y,N,Y^FN1^FD0123456^FS^FO10,300^A0N,30,0^FN1^FD0123456^FS^XZ';
+    const { default1, out1 } = cycle(zpl);
+    expect(default1).toBe('0123456');
+    expect(out1).toContain('^A0N,30,0^FN1^FD0123456^FS');
+  });
+
+  it('adopts a shared slot when the co-consumer carries the model value', () => {
+    // Own-export shape: the QR wire has the prefix, the text wire is the raw
+    // default, so both candidates agree on the model value.
+    const zpl = '^XA^FO10,10^BQN,2,4^FN1^FDQA,foo^FS^FO10,300^A0N,30,0^FN1^FDfoo^FS^XZ';
+    const { default1, out1, out2 } = cycle(zpl);
+    expect(default1).toBe('foo');
+    expect(out2).toBe(out1);
+  });
+
+  it('adopts past a bare pre-declaration (page-close overrides upsert order)', () => {
+    const zpl = '^XA^FN1^FDQA,foo^FS^FO10,10^BQN,2,4^FN1^FDQA,foo^FS^XZ';
+    const { default1, out1, out2 } = cycle(zpl);
+    expect(default1).toBe('foo');
+    expect(out2).toBe(out1);
+  });
+
+  it('still adopts after an unrelated mode-D field (per-leaf gate, not field flag)', () => {
+    // The flag reset itself is pinned by the chip-tokenising test below.
+    const zpl = '^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FN2^FD(01)12345678901231^FS'
+      + '^FO10,300^BQN,2,4^FN1^FDQA,foo^FS^XZ';
+    const r = parseSingle(zpl, 8);
+    expect(r.variables.find((v) => v.fnNumber === 1)?.defaultValue).toBe('foo');
+    const { out1, out2 } = cycle(zpl);
+    expect(out2).toBe(out1);
+  });
+
+  it('tokenises control chips after an unrelated mode-D field', () => {
+    // The mode flags must fall with the flushed field on EVERY flush path,
+    // including the half-formed early return and the ^BX escape flag.
+    const chipTail = '^FH^FO10,300^BQN,2,4^FDQA,A_0DB^FS^XZ';
+    const shapes: [name: string, zpl: string, objIdx: number][] = [
+      ['fs', `^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FD(01)12345678901231^FS${chipTail}`, 1],
+      ['fo', `^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FD(01)12345678901231${chipTail}`, 1],
+      ['ft', `^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FD(01)12345678901231^FS^FH^FT10,300^BQN,2,4^FDQA,A_0DB^FS^XZ`, 1],
+      ['half-formed', `^XA^FO10,10^BY2^BCN,100,Y,N,N,D${chipTail}`, 0],
+      ['bx-escape', `^XA^FO10,10^BXN,5,200,,,,_^FD_101234567890123^FS${chipTail}`, 1],
+    ];
+    for (const [name, zpl, objIdx] of shapes) {
+      expect(props(defined(parseSingle(zpl, 8).objects[objIdx])).content, name).toBe('A«ctrl:CR»B');
+    }
+  });
+
+  it('scopes candidates per page (a later page must not inherit the decode)', () => {
+    const two = '^XA^FO10,10^BQN,2,4^FN1^FDQA,foo^FS^XZ'
+      + '^XA^FO10,10^A0N,30,0^FN1^FDQA,foo^FS^XZ';
+    const r = parseZPL(two, 8);
+    expect(defined(defined(r.pages[0]).variables[0]).defaultValue).toBe('foo');
+    expect(defined(defined(r.pages[1]).variables[0]).defaultValue).toBe('QA,foo');
+  });
+
+  it('keeps a header default when the bound field has an empty ^FD', () => {
+    // A wire-form echo (no decode) must never override the declaration.
+    const cases: [zpl: string, expected: string][] = [
+      ['^XA^FN1^FDreal^FS^FO10,10^A0N,30,0^FN1^FD^FS^XZ', 'real'],
+      ['^XA^FN1^FDQA,real^FS^FO10,10^BQN,2,4^FN1^FD^FS^XZ', 'QA,real'],
+      ['^XA^FN1^FDother^FS^FO10,10^A0N,30,0^FN1^FDfoo^FS^XZ', 'other'],
+    ];
+    for (const [zpl, expected] of cases) {
+      expect(defined(parseSingle(zpl, 8).variables[0]).defaultValue, zpl).toBe(expected);
+    }
+  });
+
+  it('lets an empty ^FD abstain so a decoding co-consumer still adopts', () => {
+    const zpl = '^XA^FO10,10^BQN,2,4^FN1^FDQA,real^FS^FO10,200^BQN,2,4^FN1^FD^FS^XZ';
+    const { default1, out1, out2 } = cycle(zpl);
+    expect(default1).toBe('real');
+    expect(out2).toBe(out1);
+    const withHeader = cycle('^XA^FN1^FDQA,real^FS^FO10,10^BQN,2,4^FN1^FDQA,real^FS^FO10,200^BQN,2,4^FN1^FD^FS^XZ');
+    expect(withHeader.default1).toBe('real');
+  });
+
+  it('ignores the candidate of a serial-stripped field (not a slot consumer)', () => {
+    const zpl = '^XA^FN1^FDseed^FS'
+      + '^FO10,10^A0N,30,0^FB200,2,0,L,0^FN1^SN1,1,Y^FDA\\&B^FS^XZ';
+    const r = parseSingle(zpl, 8);
+    expect(defined(r.variables[0]).defaultValue).toBe('seed');
+  });
+
+  it('declines adoption on a shared slot with disagreeing candidates (QR + text)', () => {
+    // No roundtrip assert: the emit-side re-encode of such a slot is a known
+    // pre-existing limitation.
+    const zpl = '^XA^FO10,10^BQN,2,4^FN1^FDQA,foo^FS^FO10,300^A0N,30,0^FN1^FDQA,foo^FS^XZ';
+    const r = parseSingle(zpl, 8);
+    expect(defined(r.variables[0]).defaultValue).toBe('QA,foo');
   });
 });
 


### PR DESCRIPTION
Emit encodes single-bind defaults (QR prefix, block escapes, UPC-E, GS1 DataMatrix); without the inverse every import/export cycle stacked another layer. Also drops the GS1/^BX mode flags at every field flush (they leaked into later fields' control-chip tokenising).