### PR TITLE
fix(gs1): use the registry's isGs1Active predicate everywhere

### DIFF
--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -1,4 +1,4 @@
-import { getEntry, type LeafObject } from "../registry";
+import { getEntry, isGs1Active, type LeafObject } from "../registry";
 import { objectBoundsDots, offLabelPlacement, type ObjectBoundsCtx } from "./objectBounds";
 import { emittedAnchorDots } from "./emittedAnchor";
 import { suspiciousCharDetail } from "./suspiciousChars";
@@ -70,8 +70,9 @@ export function markerValueFindings(
   for (const leaf of leaves) {
     const content = getObjectStringContent(leaf);
     if (content === undefined || !hasTemplateMarkers(content)) continue;
-    const gs1Data = (leaf.props as { gs1?: boolean }).gs1 === true || leaf.type === "gs1databar";
-    const typed = !gs1Data && !!getEntry(leaf.type)?.typedContent;
+    const leafEntry = getEntry(leaf.type);
+    const gs1Data = isGs1Active(leafEntry, leaf.props);
+    const typed = !gs1Data && !!leafEntry?.typedContent;
     const blockMode =
       !gs1Data && !typed && leaf.type === "text"
         ? resolveTextMode(leaf.props as Parameters<typeof resolveTextMode>[0])
@@ -365,8 +366,10 @@ export function computePreflight(
       // GS1 fields carry a structural GS separator (0x1D) between chained AIs,
       // and a MaxiCode carrier message (modes 2/3 only; 5 is plain EEC data)
       // is GS-delimited by spec; intentional, not smuggled, so drop GS first.
+      const leafEntry = getEntry(leaf.type);
+      const gs1 = isGs1Active(leafEntry, leaf.props);
       const gsStructural =
-        (leaf.props as { gs1?: boolean }).gs1 ||
+        gs1 ||
         (leaf.type === "maxicode" && [2, 3].includes((leaf.props as { mode?: number }).mode ?? 0));
       const scanned = gsStructural ? content.split(GS1_GS).join("") : content;
       let detail = suspiciousCharDetail(scanned);
@@ -374,8 +377,8 @@ export function computePreflight(
       // excluded: the ^SN seed is filtered to alphanumerics anyway. Known
       // gap: an unencodable byte without any C0 (e.g. DEL plus Ä) drops
       // silently; C0_RE keys the drop loss, DEL alone is routing, not loss.
-      const p = leaf.props as { gs1?: boolean; serial?: unknown };
-      if (getEntry(leaf.type)?.ctrlNeedsOwnEscape && !p.gs1 && !p.serial) {
+      const p = leaf.props as { serial?: unknown };
+      if (leafEntry?.ctrlNeedsOwnEscape && !gs1 && !p.serial) {
         const templateFd = hasTemplateMarkers(resolveControlMarkers(content));
         const plan = planCode128Fd(content, templateFd ? "template" : "whole");
         for (const loss of plan.losses) {

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -1,5 +1,5 @@
 import { mmToDots } from './coordinates';
-import { getEntry, BARCODE_1D_TYPES } from '../registry';
+import { getEntry, isGs1Active, BARCODE_1D_TYPES } from '../registry';
 import { fdField, stripZplCommandChars, GRAPHIC_ANCHOR_TYPES, printerAnchoredX } from '../registry/zplHelpers';
 import {
   extractTemplateRefs,
@@ -87,9 +87,10 @@ export function planTemplateHeader(
     }
     // Scan the payload as it will be EMITTED: the plain-^BC escape injects
     // '0'/'<'/'=' after this scan, and '<'/'=' are ^FC candidate chars.
+    const leafEntry = getEntry(leaf.type);
     const scan =
-      getEntry(leaf.type)?.ctrlNeedsOwnEscape
-      && !(leaf as { props?: { gs1?: boolean } }).props?.gs1
+      leafEntry?.ctrlNeedsOwnEscape
+      && !isGs1Active(leafEntry, (leaf as { props?: object }).props)
         ? planCode128Fd(c, 'template').fd
         : c;
     // Chips-only payloads arm no ^FE (they emit as invocations/bytes), so
@@ -504,12 +505,13 @@ export function generateBatchZpl(
     // A template-embedded mode-D or plain-^BC slot has no bound transform but
     // still needs its escape. A shared plain slot bound to the code128 emits
     // raw instead: the escape would corrupt the co-consumers.
+    const boundEntry = bound && !isGroup(bound) ? getEntry(bound.type) : undefined;
     const boundPlainShared =
-      bound && !isGroup(bound) && !!getEntry(bound.type)?.ctrlNeedsOwnEscape
-      && !(bound.props as { gs1?: boolean }).gs1 && plainSharedFns.has(v.fnNumber);
+      bound && !isGroup(bound) && !!boundEntry?.ctrlNeedsOwnEscape
+      && !isGs1Active(boundEntry, bound.props) && plainSharedFns.has(v.fnNumber);
     const transform = boundPlainShared
       ? (s: string) => planCode128Fd(s, 'sharedRaw').fd
-      : (bound && !isGroup(bound) ? getEntry(bound.type)?.fdTransform?.(bound) : undefined) ??
+      : (bound && !isGroup(bound) ? boundEntry?.fdTransform?.(bound) : undefined) ??
         (modeDFns.has(v.fnNumber)
           ? escapeGs1FdValue
           : plain128Fns.has(v.fnNumber)

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -123,15 +123,23 @@ export function getEntry(type: string): (typeof ObjectRegistry)[LeafType] | unde
   return (ObjectRegistry as Record<string, (typeof ObjectRegistry)[LeafType] | undefined>)[type];
 }
 
+/** Single evaluation point for {@link ObjectTypeCore.gs1Active}. */
+export function isGs1Active(
+  entry: (typeof ObjectRegistry)[LeafType] | undefined,
+  props: object | undefined,
+): boolean {
+  if (!entry || !props) return false;
+  if (entry.gs1Active) return entry.gs1Active(props);
+  return entry.gs1Capable === true && (props as { gs1?: boolean }).gs1 === true;
+}
+
 /** Emitter parity for control-key chips: they resolve to bytes only on a
  *  `controlChars` type outside GS1 mode. Callers pass this into the binding
  *  resolvers (variableBinding sits in the registry's init chain and must not
- *  look the flag up itself). */
+ *  resolve GS1 activity itself). */
 export function objectResolvesCtrl(obj: { type: string; props?: object }): boolean {
-  return (
-    getEntry(obj.type)?.controlChars === true &&
-    (obj.props as { gs1?: boolean } | undefined)?.gs1 !== true
-  );
+  const entry = getEntry(obj.type);
+  return entry?.controlChars === true && !isGs1Active(entry, obj.props);
 }
 
 /** {@link objectResolvesCtrl} refined by how the byte survives to the symbol,

--- a/packages/core/src/types/ObjectType.ts
+++ b/packages/core/src/types/ObjectType.ts
@@ -46,7 +46,7 @@ export interface ObjectTypeCore<P extends object = object> {
   /** Carrier offers the typed-content builder (URL/WiFi/vCard/...). Single
    *  source for cross-cutting consumers (marker-value preflight); the panels
    *  keep their own builder buttons. DataMatrix in GS1 mode carries GS1 data
-   *  instead, which consumers exclude via `props.gs1`. */
+   *  instead, which consumers exclude via the registry's isGs1Active. */
   typedContent?: boolean;
   /** Emitter honours `props.serial` (^SN/^SF). Only text and the free-data 1D
    *  family do; 2D/stacked emitters and fixed-check EAN/UPC do not, so the

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -422,6 +422,18 @@ describe("computePreflight (suspicious-chars producer)", () => {
     expect(findings.some((f) => f.kind === "suspiciousChars")).toBe(true);
   });
 
+  it("does not flag the GS separator on expanded GS1 DataBar (symbology IS the GS1 flag)", () => {
+    const dbar = (symbology: number): LeafObject =>
+      ({ id: "r", type: "gs1databar", x: 0, y: 0, rotation: 0,
+         props: { content: "10ABC" + GS + "21XYZ", symbology, magnification: 3, rotation: "N" },
+       } as unknown as LeafObject);
+    expect(computePreflight([dbar(6)], ctx, "mm")
+      .some((f) => f.kind === "suspiciousChars")).toBe(false);
+    // Non-expanded variants carry a plain GTIN; a GS there IS suspicious.
+    expect(computePreflight([dbar(1)], ctx, "mm")
+      .some((f) => f.kind === "suspiciousChars")).toBe(true);
+  });
+
   // The mode 2/3 carrier message is GS-delimited by spec; requiring the
   // separator and warning about it at the same time would be contradictory.
   const maxi = (mode: number, content: string): LeafObject =>
@@ -714,5 +726,29 @@ describe("markerValueFindings (mode-D shared ^FN slot)", () => {
     expect(markerValueFindings(
       [code128("c", "A«batch»B", false)],
       { variables: safe, dataset: null, columnMapping: null })).toEqual([]);
+  });
+});
+
+describe("markerValueFindings (GS1 activity is the entry's own predicate)", () => {
+  const br = (symbology: number, content: string): LeafObject =>
+    ({ id: "r", type: "gs1databar", x: 0, y: 0, rotation: 0,
+       props: { content, symbology, magnification: 3, rotation: "N" },
+     } as unknown as LeafObject);
+
+  it("does not GS1-validate a non-expanded DataBar (plain GTIN, no AI structure)", () => {
+    // A valid GTIN-13 parsed as an element string would flag "(12) dateMonth".
+    const vars = [{ id: "g", name: "gtin", fnNumber: 1, defaultValue: "1234567890128" }];
+    const dataset = { headers: ["gtin"], rows: [["1234567890128"]] };
+    const columnMapping = { bindings: { g: "gtin" }, headerSnapshot: ["gtin"] };
+    expect(markerValueFindings([br(1, "«gtin»")], { variables: vars, dataset, columnMapping })
+      .filter((f) => f.kind === "gs1ValueInvalid")).toEqual([]);
+    expect(markerValueFindings([br(1, "0«gtin»")], { variables: vars, dataset: null, columnMapping: null })
+      .filter((f) => f.kind === "gs1ValueInvalid")).toEqual([]);
+  });
+
+  it("still GS1-validates the expanded variants", () => {
+    const dirty = [{ id: "b", name: "batch", fnNumber: 1, defaultValue: "" }];
+    expect(markerValueFindings([br(6, "10«batch»")], { variables: dirty, dataset: null, columnMapping: null })
+      .some((f) => f.kind === "gs1ValueInvalid")).toBe(true);
   });
 });

--- a/src/lib/symbologySwitch.ts
+++ b/src/lib/symbologySwitch.ts
@@ -1,4 +1,4 @@
-import { getEntry, ObjectRegistry } from "@zplab/core/registry";
+import { getEntry, isGs1Active, ObjectRegistry } from "@zplab/core/registry";
 import { resolveContentSpec, hasValidLength, violatesCharset } from "@zplab/core/registry/contentSpec";
 import type { ContentSpec } from "@zplab/core/types/contentSpec";
 import type { LeafType } from "@zplab/core/registry/leafObject";
@@ -10,14 +10,6 @@ import { hasControlMarkers, resolveControlMarkers } from "@zplab/core/types/cont
 const BARCODE_GROUPS: ReadonlySet<ObjectGroup> = new Set(["code-1d", "code-2d", "legacy"]);
 
 type CoreEntry = NonNullable<ReturnType<typeof getEntry>>;
-
-/** Whether the object currently carries GS1 content, per the entry's own
- *  model (gs1Active hook, default `gs1Capable && props.gs1`). */
-function isGs1Active(entry: CoreEntry, props: Record<string, unknown> | undefined): boolean {
-  if (!props) return false;
-  if (entry.gs1Active) return entry.gs1Active(props);
-  return entry.gs1Capable === true && props.gs1 === true;
-}
 
 /** Props patch that puts a target into GS1 mode when GS1 content is carried in. */
 const gs1EnterProps = (entry: CoreEntry): object => entry.gs1EnterProps ?? { gs1: true };


### PR DESCRIPTION
Hand-spelled GS1 tests misclassified GS1 DataBar (symbology variant, not a props flag): false gs1ValueInvalid on plain-GTIN variants, false suspiciousChars on expanded structural GS.