### PR TITLE
refactor(gs1): single emit-plan derivation for canvas, wire and prefl…

### DIFF
--- a/packages/core/src/lib/barcodeDims.ts
+++ b/packages/core/src/lib/barcodeDims.ts
@@ -15,8 +15,8 @@ import {
   GS1_DATABAR_DEFAULT_SEGMENTS,
   GS1_DATABAR_EXPANDED_SYMBOLOGIES,
   gtin14WithCheck,
-  gs1ContentToElementString,
 } from "./gs1";
+import { planGs1Fd } from "./gs1Plan";
 import { code128ControlBwipRaw, code128FdToSymbols, code128PlainFd, code128SymbolsToBwipRaw } from "./code128Subset";
 import { isRectangular, dmVersionString, type DataMatrixProps } from "../registry/datamatrix";
 import { MAXICODE_WIDTH_MM, MAXICODE_HEIGHT_MM } from "../registry/maxicode";
@@ -57,17 +57,6 @@ import { placeholderContentFor, samplePropsFor } from "../registry/placeholderCo
 export interface BwipEngine {
   raw(opts: object): unknown;
   render(opts: object, drawing: object): unknown;
-}
-
-function isAi01ElevenDigitFragment(content: string): boolean {
-  return /^01\d{11}$/.test(content);
-}
-
-function gs1BwipText(content: string): string {
-  if (isAi01ElevenDigitFragment(content)) return `(99)${content}`;
-  // Catalog parser handles variable AIs (GS-separated); falls back to the
-  // legacy fixed-AI wrapper for content it can't cleanly segment.
-  return gs1ContentToElementString(content);
 }
 
 /** ^B0 `d` param (AztecProps.ecLevel) -> bwip bcid + size options: 5-95 is EC%,
@@ -134,15 +123,23 @@ const BWIP_2D_INTERNAL_SCALE = 2;
 // compacts down stays approximate (use the printer preview for exact size).
 const CODABLOCK_FIRMWARE_MODULE_OFFSET = 6;
 
-/** GS1 mode: bwip auto-inserts FNC1 from the (AI)… element string. */
-export function dmBwipInput(p: DataMatrixProps): { bcid: string; text: string } {
+/** GS1 mode: bwip auto-inserts FNC1 from the (AI)… element string; content
+ *  the catalog cannot segment encodes as raw FNC1 markers instead of failing
+ *  on a guessed element string (the `_1` escapes print it fine, see Gs1FdLoss). */
+export function dmBwipInput(p: DataMatrixProps): { bcid: string; text: string; parsefnc?: boolean } {
   const rect = isRectangular(p);
-  return {
-    bcid: p.gs1
-      ? (rect ? "gs1datamatrixrectangular" : "gs1datamatrix")
-      : (rect ? "datamatrixrectangular" : "datamatrix"),
-    text: (p.gs1 ? gs1ContentToElementString(p.content) : p.content) || " ",
-  };
+  if (p.gs1) {
+    const plan = planGs1Fd(p.content, "datamatrix");
+    if (plan.bwipParsefncText !== null) {
+      return {
+        bcid: rect ? "datamatrixrectangular" : "datamatrix",
+        text: plan.bwipParsefncText,
+        parsefnc: true,
+      };
+    }
+    return { bcid: rect ? "gs1datamatrixrectangular" : "gs1datamatrix", text: plan.bwipText || " " };
+  }
+  return { bcid: rect ? "datamatrixrectangular" : "datamatrix", text: p.content || " " };
 }
 
 // Mirrors Zebra's columns=0 auto-heuristic. Empirically validated against
@@ -308,10 +305,13 @@ export function buildBwipOptions(
     case "code128": {
       const p = obj.props;
       const scale = bwipScale1D(p.moduleWidth, renderScale, renderDpmm);
-      // GS1-128: feed the (AI)data element string; not gs1BwipText, whose (99)
-      // shortcut is a DataBar convention that would desync bars from HRI/^FD.
+      // GS1-128 renders from the emit plan; unparsed content is the raw
+      // mode-D read (leading FNC1 plus literals, see the plan's parsefnc doc).
       if (p.gs1) {
-        opts = { bcid: "gs1-128", text: gs1ContentToElementString(p.content) || "(01)00000000000000", scale, height: 10 };
+        const plan = planGs1Fd(p.content, "code128");
+        opts = plan.bwipParsefncText !== null
+          ? { bcid: "code128", text: plan.bwipParsefncText, parsefnc: true, scale, height: 10 }
+          : { bcid: "gs1-128", text: plan.bwipText || "(01)00000000000000", scale, height: 10 };
         break;
       }
       const text = p.content || "0";
@@ -401,9 +401,10 @@ export function buildBwipOptions(
       const sym = p.symbology;
       const isExpanded = GS1_DATABAR_EXPANDED_SYMBOLOGIES.has(sym);
       // bwip needs (AI)data parens; model stores raw digits.
-      // Sym 1..5 require AI 01 + valid 14-digit GTIN with check.
+      // Sym 1..5 require AI 01 + valid 14-digit GTIN with check; Expanded
+      // renders from the emit plan (unparsed stays verbatim).
       const text = isExpanded
-        ? gs1BwipText(p.content)
+        ? planGs1Fd(p.content, "databar").bwipText
         : `(01)${gtin14WithCheck(p.content)}`;
       opts = {
         bcid: GS1_DATABAR_BCID[sym],

--- a/packages/core/src/lib/gs1.ts
+++ b/packages/core/src/lib/gs1.ts
@@ -103,14 +103,6 @@ const AI_BY_CODE: ReadonlyMap<string, Gs1AiSpec> = (() => {
 /** AI codes longest-first, so raw parsing matches 4/3-digit AIs before 2-digit. */
 const AI_CODES_BY_LEN: readonly string[] = [...AI_BY_CODE.keys()].sort((a, b) => b.length - a.length);
 
-/** Fixed-length AIs (single source: derived from the catalog), for the legacy
- *  raw-wrap fallback which only consumes 2-digit AIs. */
-const FIXED_AI_LEN: Record<string, number> = Object.fromEntries(
-  [...AI_BY_CODE.values()]
-    .filter((s) => s.ai.length === 2 && !isVariableKind(s.kind))
-    .map((s) => [s.ai, s.len]),
-);
-
 /** All resolved specs (ranges expanded, multiComponent omitted); the palette
  *  module builds its group index from this. */
 export const GS1_AI_SPECS: readonly Gs1AiSpec[] = [...AI_BY_CODE.values()];
@@ -549,18 +541,6 @@ export function parseGs1ToSegments(
 }
 
 /**
- * Element-string form for bwip-js from raw model content. Prefers a clean
- * segment parse; falls back to the legacy fixed-AI wrapper so existing content
- * still renders, and to verbatim pass-through for already-parenthesized input.
- */
-export function gs1ContentToElementString(content: string): string {
-  if (content.startsWith("(")) return content;
-  const segs = parseGs1ToSegments(content);
-  if (segs) return segmentsToElementString(segs);
-  return wrapGs1AIs(content);
-}
-
-/**
  * If `raw` is a pasted element string `(AI)…(AI)…` (whitespace tolerated), parse
  * it and return the raw model content with GS separators; otherwise null. Lets
  * the input accept pasted GS1 notation instead of silently stripping the parens.
@@ -570,29 +550,4 @@ export function elementStringToContent(raw: string): string | null {
   if (!trimmed.startsWith("(")) return null;
   const segs = parseGs1ToSegments(trimmed);
   return segs ? segmentsToContent(segs) : null;
-}
-/**
- * Legacy: wrap a raw fixed-AI sequence in parens for bwip-js. Kept for content
- * that predates the catalog parser. Unknown/variable AIs short-circuit and are
- * appended verbatim so bwip-js can surface a helpful parser error.
- */
-export function wrapGs1AIs(content: string): string {
-  if (content.includes("(")) return content;
-  let out = "";
-  let pos = 0;
-  while (pos < content.length) {
-    const ai = content.slice(pos, pos + 2);
-    const len = FIXED_AI_LEN[ai];
-    if (len === undefined) {
-      out += content.slice(pos);
-      break;
-    }
-    let data = content.slice(pos + 2, pos + 2 + len);
-    if (ai === "01" && data.length < 14 && /^\d+$/.test(data)) {
-      data = gtin14WithCheck(data);
-    }
-    out += `(${ai})${data}`;
-    pos += 2 + len;
-  }
-  return out;
 }

--- a/packages/core/src/lib/gs1Plan.test.ts
+++ b/packages/core/src/lib/gs1Plan.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { planGs1Fd } from "./gs1Plan";
+import { GS1_GS } from "./gs1";
+import { getEntry, type LeafObject } from "../registry";
+
+const GS = GS1_GS;
+
+describe("planGs1Fd", () => {
+  it("derives fd, element string and no losses for segmentable content", () => {
+    const content = "011234567890123110ABC";
+    const c128 = planGs1Fd(content, "code128");
+    expect(c128.fd).toBe("(01)12345678901231(10)ABC");
+    expect(c128.bwipText).toBe("(01)12345678901231(10)ABC");
+    expect(c128.losses).toEqual([]);
+    const dm = planGs1Fd(`10ABC${GS}21XYZ`, "datamatrix");
+    expect(dm.fd).toBe("_110ABC_121XYZ");
+    expect(dm.bwipText).toBe("(10)ABC(21)XYZ");
+    expect(planGs1Fd("0112345678901231", "databar").bwipText).toBe("(01)12345678901231");
+  });
+
+  it("goes verbatim on BOTH sides when the content does not segment", () => {
+    for (const carrier of ["code128", "databar"] as const) {
+      const plan = planGs1Fd("0112345", carrier);
+      expect(plan.fd).toBe("0112345");
+      expect(plan.bwipText).toBe("0112345");
+      expect(plan.losses).toEqual([{ kind: "unparsed" }]);
+    }
+    // DM still wraps the wire in its escape grammar (raw GS -> _1) and
+    // reports no loss: the `_1` codec keeps FNC1 positions exact.
+    const dm = planGs1Fd(`0112345678901231${GS}10ABC`, "datamatrix");
+    expect(dm.fd).toBe("_10112345678901231_110ABC");
+    expect(dm.losses).toEqual([]);
+  });
+
+  it("matches the real emitters byte for byte (drift tripwire via toZPL)", () => {
+    // plan.fd is the payload handed to fdField, which may still wrap it in
+    // ^FH hex (raw GS on the databar wire); undo that layer for comparison.
+    const fdOf = (zpl: string): string => {
+      const m = /\^FD([\s\S]*?)\^FS/.exec(zpl);
+      if (!m) throw new Error(`no ^FD in ${zpl}`);
+      const fd = m[1] ?? "";
+      return zpl.includes("^FH_")
+        ? fd.replace(/_([0-9A-F]{2})/g, (_, h: string) => String.fromCharCode(parseInt(h, 16)))
+        : fd;
+    };
+    const leaf = (type: string, props: object) =>
+      ({ id: "x", type, x: 0, y: 0, rotation: 0, props }) as unknown as LeafObject;
+    for (const content of [
+      "0112345678901231", `10ABC${GS}21XYZ`, "0112345", `01123${GS}`, "(01)12345678901231",
+      `0112345678901231${GS}10ABC`, "10>5B", "",
+    ]) {
+      const tag = JSON.stringify(content);
+      const bc = getEntry("code128")!.toZPL(leaf("code128", {
+        content, height: 100, moduleWidth: 2, printInterpretation: false,
+        printInterpretationAbove: false, checkDigit: false, rotation: "N", gs1: true,
+      }));
+      expect(planGs1Fd(content, "code128").fd, tag).toBe(fdOf(bc));
+      const bx = getEntry("datamatrix")!.toZPL(leaf("datamatrix", {
+        content, gs1: true, dimension: 20, quality: 200, rotation: "N",
+      }));
+      expect(planGs1Fd(content, "datamatrix").fd, tag).toBe(fdOf(bx));
+      const br = getEntry("gs1databar")!.toZPL(leaf("gs1databar", {
+        content, symbology: 6, magnification: 3, segments: 22, rotation: "N",
+      }));
+      expect(planGs1Fd(content, "databar").fd, tag).toBe(fdOf(br));
+    }
+  });
+
+  it("builds carrier-true parsefnc fallbacks (DM keeps FNC1 per GS, drops trailing)", () => {
+    const dm = planGs1Fd(`01123${GS}9^9${GS}`, "datamatrix");
+    expect(dm.bwipParsefncText).toBe("^FNC101123^FNC19^^9");
+    const bc = planGs1Fd(`01123${GS}9^9`, "code128");
+    expect(bc.bwipParsefncText).toBe("^FNC101123" + "9^^9");
+    expect(planGs1Fd("0112345678901231", "code128").bwipParsefncText).toBeNull();
+  });
+});

--- a/packages/core/src/lib/gs1Plan.ts
+++ b/packages/core/src/lib/gs1Plan.ts
@@ -1,0 +1,95 @@
+import {
+  GS1_GS,
+  parseGs1ToSegments,
+  segmentsToElementString,
+  segmentsToZplFd,
+} from "./gs1";
+import { gs1ContentToDataMatrixFd } from "./dataMatrixFd";
+import { hasTemplateMarkers } from "./fnTemplate";
+import { getEntry, isGs1Active } from "../registry";
+
+/** GS1 carriers with distinct ^FD grammars: ^BC mode D (parenthesized + >8),
+ *  ^BX quality 200 (`_1` escapes), ^BR (raw content; separator grammar is
+ *  hardware-unverified, so the wire form stays what the app always emitted). */
+export type Gs1Carrier = "code128" | "datamatrix" | "databar";
+
+/** `unparsed`: content does not segment against the AI catalog, so the wire
+ *  carries it verbatim and the canvas cannot promise the printed symbol.
+ *  Never reported for DM: its `_1` codec encodes FNC1 positions exactly. */
+export interface Gs1FdLoss {
+  kind: "unparsed";
+}
+
+export interface Gs1FdPlan {
+  /** The ^FD payload the emitter writes. */
+  fd: string;
+  /** bwip-js canvas input: element string when the content segments, else the
+   *  verbatim content. */
+  bwipText: string;
+  /** Raw-FNC1 canvas fallback for unparsed content (bwip `parsefnc` text,
+   *  carets doubled), mirroring the carrier's wire: DM keeps one FNC1 per GS
+   *  and drops a trailing separator like the `_1` codec; code128 mode D
+   *  strips GS per the measured C0 drop class. Null when the content parses. */
+  bwipParsefncText: string | null;
+  losses: Gs1FdLoss[];
+}
+
+function parsefncRuns(content: string, joiner: string): string {
+  const runs = content.split(GS1_GS).map((run) => run.replaceAll("^", "^^"));
+  while (runs.length > 1 && runs[runs.length - 1] === "") runs.pop();
+  return `^FNC1${runs.join(joiner)}`;
+}
+
+/** Single GS1 derivation (planCode128Fd's sibling): mirrors the emit
+ *  transforms (byte-equality pinned by test); canvas and preflight consume
+ *  it. Known limit: unparsed `>` invocations print as invocations (spec
+ *  p.104) but render literally on canvas. */
+export function planGs1Fd(content: string, carrier: Gs1Carrier): Gs1FdPlan {
+  if (content === "") {
+    return {
+      fd: carrier === "datamatrix" ? gs1ContentToDataMatrixFd("") : "",
+      bwipText: "",
+      bwipParsefncText: null,
+      losses: [],
+    };
+  }
+  const segs = parseGs1ToSegments(content);
+  if (!segs || segs.length === 0) {
+    const fd = carrier === "datamatrix" ? gs1ContentToDataMatrixFd(content) : content;
+    return {
+      fd,
+      bwipText: content,
+      bwipParsefncText: parsefncRuns(content, carrier === "datamatrix" ? "^FNC1" : ""),
+      losses: carrier === "datamatrix" ? [] : [{ kind: "unparsed" }],
+    };
+  }
+  const element = segmentsToElementString(segs);
+  const parsed = (fd: string): Gs1FdPlan => ({ fd, bwipText: element, bwipParsefncText: null, losses: [] });
+  switch (carrier) {
+    case "code128":
+      return parsed(segmentsToZplFd(segs));
+    case "datamatrix":
+      return parsed(gs1ContentToDataMatrixFd(content));
+    case "databar":
+      return parsed(content);
+  }
+}
+
+/** Static GS1 content that ships verbatim: owns the gs1ContentUnparsed
+ *  warning, and the canvas suppresses renderFailed on the same predicate.
+ *  Template content is owned by markerValueFindings. */
+export function gs1StaticUnparsed(type: string, props: object, content: string): boolean {
+  const carrier = gs1CarrierFor(type);
+  return carrier !== null
+    && isGs1Active(getEntry(type), props)
+    && !hasTemplateMarkers(content)
+    && planGs1Fd(content, carrier).losses.length > 0;
+}
+
+/** GS1 carriers by leaf type; other types have no GS1 ^FD grammar. */
+export function gs1CarrierFor(type: string): Gs1Carrier | null {
+  return type === "code128" ? "code128"
+    : type === "datamatrix" ? "datamatrix"
+    : type === "gs1databar" ? "databar"
+    : null;
+}

--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -7,6 +7,7 @@ import { DATAMATRIX_FD_ESCAPE } from "./dataMatrixFd";
 import { extractTemplateRefs, hasTemplateMarkers, pickEmbedChar } from "./fnTemplate";
 import { hasClockMarkers, pickClockChars } from "./fcTemplate";
 import { planCode128Fd, planHasLoss } from "./code128Plan";
+import { gs1StaticUnparsed } from "./gs1Plan";
 import { resolveControlMarkers } from "../types/controlKey";
 import { classifyField, isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
@@ -368,6 +369,14 @@ export function computePreflight(
       // is GS-delimited by spec; intentional, not smuggled, so drop GS first.
       const leafEntry = getEntry(leaf.type);
       const gs1 = isGs1Active(leafEntry, leaf.props);
+      if (gs1StaticUnparsed(leaf.type, leaf.props, content)) {
+        findings.push({
+          objectId: leaf.id,
+          kind: "gs1ContentUnparsed",
+          severity: PREFLIGHT_SEVERITY.gs1ContentUnparsed,
+          detail: "the printer receives the content verbatim",
+        });
+      }
       const gsStructural =
         gs1 ||
         (leaf.type === "maxicode" && [2, 3].includes((leaf.props as { mode?: number }).mode ?? 0));

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -37,7 +37,7 @@ import {
   type SymbolProps,
 } from "../../registry/symbol";
 import { applySerialToLeaf } from "../../registry/serialField";
-import { getEntry } from "../../registry";
+import { getEntry, isGs1Active } from "../../registry";
 import type { AztecProps } from "../../registry/aztec";
 import type { MaxicodeProps } from "../../registry/maxicode";
 import type { MicroPdf417Props } from "../../registry/micropdf417";
@@ -662,7 +662,14 @@ export function createFlushField(
     // The just-pushed leaf and whether its emitter honours ^SN/^SF: derived once,
     // consumed by both the ^FN-bind and the ^SN/^SF blocks below.
     const justPushed = objects[objects.length - 1];
-    const lastSerialisable = !!justPushed && !!getEntry(justPushed.type)?.serialisable;
+    // GS1 excluded: a serial counter inside GS1-structured data is
+    // meaningless, and the emit-side alnum filter would corrupt the payload
+    // (the UI blocks the combination; imports must not smuggle it in).
+    const lastGs1 = !!justPushed && !isGroup(justPushed)
+      && isGs1Active(getEntry(justPushed.type), justPushed.props);
+    const lastSerialisable = !!justPushed && !lastGs1
+      && !!getEntry(justPushed.type)?.serialisable;
+    if (s.field.snPending && lastGs1) s.result.partialCmds.add(`^${s.field.snMode}`);
 
     // Bind pending ^FN slot; existing Variable for same fnNumber is reused.
     if (s.comment.fnNumber !== null) {

--- a/packages/core/src/lib/zplParser/handlers/fields.ts
+++ b/packages/core/src/lib/zplParser/handlers/fields.ts
@@ -1,8 +1,9 @@
 import type { CustomFontMapping } from "../../../types/LabelConfig";
 import { FN_NUMBER_MAX, FN_NUMBER_MIN } from "../../../types/Variable";
 import { applySerialToLeaf } from "../../../registry/serialField";
-import { getEntry } from "../../../registry";
+import { getEntry, isGs1Active } from "../../../registry";
 import { classifyField } from "../../variableField";
+import { isGroup } from "../../../types/Group";
 import { ZPL_BUILTIN_FONT_LETTERS } from "../../customFonts";
 import {
   getDefaultTextH,
@@ -214,7 +215,9 @@ export function createFieldHandlers(
         // dropped at flush, so don't corrupt its ^FD / variable default. An empty
         // start (^SN,1,Y) keeps the ^FD, or seeds empty when there is none so an
         // empty-seed serial still survives (the pendingFD===null guard).
-        const serialisable = !!getEntry(s.field.fieldType)?.serialisable;
+        // GS1 fields drop the ^SN at flush, so the seed must not replace
+        // their ^FD either.
+        const serialisable = !!getEntry(s.field.fieldType)?.serialisable && !s.field.bcGs1;
         if (snStart && serialisable) s.field.pendingFD = snStart;
         else if (s.field.pendingFD === null) s.field.pendingFD = snStart;
         return;
@@ -222,6 +225,11 @@ export function createFieldHandlers(
       const lastObj = s.result.objects[s.result.objects.length - 1];
       // Only types whose emitter emits ^SN/^SF (text + 1D) take a serial; a
       // 2D/stacked field would import a state the emitter drops on export.
+      // GS1 fields drop it with a loss note, like the in-field placement.
+      if (lastObj && !isGroup(lastObj) && isGs1Active(getEntry(lastObj.type), lastObj.props)) {
+        s.result.partialCmds.add("^SN");
+        return;
+      }
       if (lastObj && getEntry(lastObj.type)?.serialisable) {
         const cur = (lastObj as { props: { content?: string } }).props.content ?? "";
         const cls = classifyField(cur, s.result.variables);

--- a/packages/core/src/registry/barcode1d.ts
+++ b/packages/core/src/registry/barcode1d.ts
@@ -219,10 +219,11 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
       // Control bytes on non-template payloads take the symbology's own
       // escape via the fdTransformFor ctrlEncode wrap; templates keep ^FH
       // (^FE tokens cannot survive inside the escape form).
-      const fieldData = obj.props.serial
-        // Serial seeds skip fdPlainEscape: ^SN data is filtered alphanumeric,
-        // and an injected `>0` would leave a stray 0 in the ^SF mask. A
-        // template seed skips the base transform too (pre-escape behaviour).
+      const fieldData = obj.props.serial && !p.gs1
+        // GS1 excluded (legacy models may carry both flags): the alnum seed
+        // filter would eat the >8 FNC1 and merge AI values. Serial seeds skip
+        // fdPlainEscape (an injected `>0` would leave a stray 0 in the ^SF
+        // mask) and a template seed skips the base transform too.
         ? serialFieldData(
             (hasTemplateMarkers(p.content) && !isLoneMarker(p.content)
               ? undefined

--- a/packages/core/src/registry/placeholderContent.ts
+++ b/packages/core/src/registry/placeholderContent.ts
@@ -1,13 +1,13 @@
-import { getEntry } from './index';
+import { getEntry, isGs1Active } from './index';
 import { GS1_SAMPLE_CONTENT } from '../lib/gs1';
 
 /** The sample a blank field renders on canvas and in the Labelary preview
- *  overlay: the type's placeholderContent, or the GS1 sample once the field
- *  is in GS1 mode (the type sample would not encode there). Never part of
- *  emit, export or print; a blank field's ^FD stays empty there. */
+ *  overlay, never part of emit or print: the type's placeholderContent, or
+ *  the GS1 sample in GS1 mode (the type sample would not encode there). */
 export function placeholderContentFor(type: string, props: object): string | undefined {
-  if ((props as { gs1?: boolean }).gs1) return GS1_SAMPLE_CONTENT;
-  return getEntry(type)?.placeholderContent;
+  const entry = getEntry(type);
+  if (isGs1Active(entry, props)) return GS1_SAMPLE_CONTENT;
+  return entry?.placeholderContent;
 }
 
 /** Props for sample rendering: the type's sampleProps overrides merged in, so

--- a/packages/core/src/types/preflight.ts
+++ b/packages/core/src/types/preflight.ts
@@ -18,6 +18,7 @@ export type PreflightKind =
   | 'markerValueUnsafe'
   | 'markerArmFailed'
   | 'gs1ValueInvalid'
+  | 'gs1ContentUnparsed'
   | 'emptyContent'
   | 'printerSupportLimited'
   | 'qrRotatedStatic'
@@ -60,6 +61,9 @@ export const PREFLIGHT_SEVERITY: Record<PreflightKind, PreflightSeverity> = {
   // (wrong fixed-AI width, charset, date) from a substitution; it still
   // prints, so warn rather than block.
   gs1ValueInvalid: 'warning',
+  // Static GS1 content that does not segment: it ships verbatim (FNC1
+  // positions unknown), so the scan risk is real but printing works.
+  gs1ContentUnparsed: 'warning',
   // A blank field is legal ZPL and a normal drafting state; it prints a gap,
   // so warn rather than block. Mirrors the canvas placeholder.
   emptyContent: 'warning',

--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -18,7 +18,7 @@ import {
   type EanUpcType,
 } from "./bwipHelpers";
 import { resolveHriAbove, gs1HriFontDots } from "@zplab/core/lib/barcodeHri";
-import { gs1ContentToElementString } from "@zplab/core/lib/gs1";
+import { gs1CarrierFor, planGs1Fd } from "@zplab/core/lib/gs1Plan";
 import { placeholderContentFor, samplePropsFor } from "@zplab/core/registry/placeholderContent";
 import { getObjectStringContent } from "@zplab/core/lib/variableBinding";
 import { hasTemplateMarkers } from "@zplab/core/lib/fnTemplate";
@@ -178,7 +178,11 @@ export function BarcodeObject({
   const invalid = usingSample && (unresolvableCtrl || !hasTemplateMarkers(contentRaw));
   const displayObj = showSample ? withSample : obj;
   const effectiveContent = showSample ? sample : contentRaw;
-  const rawContent = gs1Hri ? gs1ContentToElementString(effectiveContent) : effectiveContent;
+  // HRI shows the plan's element string; unparsed content stays verbatim,
+  // matching the bars.
+  const rawContent = gs1Hri
+    ? planGs1Fd(effectiveContent, gs1CarrierFor(obj.type) ?? "code128").bwipText
+    : effectiveContent;
   const printInterpEnabled =
     !ObjectRegistry[obj.type]?.interpretationLocked &&
     !!(obj.props as { printInterpretation?: boolean }).printInterpretation;

--- a/src/components/Canvas/barcodePreflight.test.ts
+++ b/src/components/Canvas/barcodePreflight.test.ts
@@ -81,6 +81,28 @@ describe("barcodeEncodeFindings", () => {
     expect(barcodeEncodeFindings([maxi(2, "1234567890")], 1, 8, noEnv, () => "bwipp.maxicodeExpectedCountryCode")).toEqual([]);
   });
 
+  it("does not emit renderFailed for static unparsed GS1 content (gs1ContentUnparsed owns it)", () => {
+    const c128gs1 = (content: string): LeafObject =>
+      ({ id: "g", type: "code128", x: 0, y: 0, rotation: 0,
+         props: { content, height: 100, moduleWidth: 2, printInterpretation: false,
+                  printInterpretationAbove: false, checkDigit: false, rotation: "N", gs1: true },
+       } as LabelObject as LeafObject);
+    expect(barcodeEncodeFindings([c128gs1("NOTGS1AT@ALL")], 1, 8, noEnv, () => "bwipp.GS1error")).toEqual([]);
+    // Marker content keeps the encode check (no static warning exists there).
+    const env: EncodeEnv = {
+      variables: [{ id: "v", name: "gtin", fnNumber: 1, defaultValue: "NOTGS1" }],
+      active: null,
+    };
+    expect(barcodeEncodeFindings([c128gs1("01«gtin»")], 1, 8, env, () => "bwipp.GS1error"))
+      .toHaveLength(1);
+    // DM is excluded from the suppression (its warning never fires).
+    const gs = String.fromCharCode(0x1d);
+    const dm = { id: "d", type: "datamatrix", x: 0, y: 0, rotation: 0,
+      props: { content: `0112345678901231${gs}10ABC`, gs1: true, dimension: 20, quality: 200, rotation: "N" },
+    } as LabelObject as LeafObject;
+    expect(barcodeEncodeFindings([dm], 1, 8, noEnv, () => "bwipp.someError")).toHaveLength(1);
+  });
+
   it("keeps renderFailed for a BOUND MaxiCode whose value has no separator (the producer never sees it)", () => {
     // The core producer skips marker content, so the resolved-value failure
     // must surface here; skipping both sides would hide the broken symbol.

--- a/src/components/Canvas/barcodePreflight.ts
+++ b/src/components/Canvas/barcodePreflight.ts
@@ -1,6 +1,7 @@
 import { ctrlParityFor, type LeafObject } from "@zplab/core/registry";
 import { maxicodeScmOwnedByPreflight, type MaxicodeProps } from "@zplab/core/registry/maxicode";
 import { isBarcode } from "@zplab/core/lib/objectBounds";
+import { gs1StaticUnparsed } from "@zplab/core/lib/gs1Plan";
 import { PREFLIGHT_SEVERITY, type PreflightFinding } from "@zplab/core/lib/preflight";
 import type { Variable } from "@zplab/core/types/Variable";
 import {
@@ -88,6 +89,11 @@ export function barcodeEncodeFindings(
       resolved.type === "maxicode" &&
       maxicodeScmOwnedByPreflight(getObjectStringContent(leaf) ?? "", resolved.props as MaxicodeProps)
     ) {
+      continue;
+    }
+    // Static unparsed GS1 is owned by gs1ContentUnparsed (see
+    // gs1StaticUnparsed); a second renderFailed would contradict it.
+    if (gs1StaticUnparsed(leaf.type, leaf.props, getObjectStringContent(leaf) ?? "")) {
       continue;
     }
     const error = encodeError(leaf, resolved);

--- a/src/components/Canvas/bwipHelpers.test.ts
+++ b/src/components/Canvas/bwipHelpers.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import bwipjs from "bwip-js/browser";
+import { measureBarcodeFootprintDotsWith, type BwipEngine } from "@zplab/core/lib/barcodeDims";
 import { buildBwipOptions, dataMatrixMinFitIndex, getDisplaySize, getEanUpcHriFragments } from "./bwipHelpers";
 import type { LeafObject } from "@zplab/core/registry";
 import { dmSizePairs, type DataMatrixProps } from "@zplab/core/registry/datamatrix";
@@ -146,9 +148,6 @@ describe("getDisplaySize gs1databar sym 7 fallback", () => {
 });
 
 describe("buildBwipOptions gs1databar Expanded fallback", () => {
-  // AI 01 + 11 numeric digits is not a valid GTIN-14 element string. Zebra
-  // firmware emits General Compaction (~149 modules) rather than Method 1
-  // padding. We route bwip-js through `(99)` so the rendered width matches.
   const obj = (content: string): LabelObject => ({
     id: "1",
     type: "gs1databar",
@@ -164,14 +163,55 @@ describe("buildBwipOptions gs1databar Expanded fallback", () => {
     },
   });
 
-  it("re-routes AI 01 + 11-digit fragment through (99) wrap", () => {
+  it("keeps an unparseable fragment verbatim (no guessed element string)", () => {
+    // 11 digits after AI 01 segment nothing; the wire ships it raw, so the
+    // canvas must not invent a (99) wrap that renders a different symbol.
     const opts = buildBwipOptions(obj("0112345678901"), 1, 8);
-    expect(opts?.text).toBe("(99)0112345678901");
+    expect(opts?.text).toBe("0112345678901");
+  });
+
+  it("still measures a footprint for blank/unparseable Expanded (GS1 sample)", () => {
+    // The honest encode failure must fall back to the GS1 sample, not null:
+    // MCP footprint and the canvas sample path depend on it.
+    const engine = bwipjs as unknown as BwipEngine;
+    for (const content of ["", "0112345678901"]) {
+      expect(measureBarcodeFootprintDotsWith(engine, obj(content), 8), content).not.toBeNull();
+    }
   });
 
   it("keeps valid AI 01 GTIN-14 input on the standard wrap path", () => {
     const opts = buildBwipOptions(obj("0112345678901231"), 1, 8);
     expect(opts?.text).toBe("(01)12345678901231");
+  });
+});
+
+describe("buildBwipOptions GS1 canvas == wire (plan-derived)", () => {
+  const c128 = (content: string): LabelObject =>
+    ({ id: "1", type: "code128", x: 0, y: 0, rotation: 0,
+       props: { content, height: 100, moduleWidth: 2, printInterpretation: false,
+                printInterpretationAbove: false, checkDigit: false, rotation: "N", gs1: true },
+     }) as LabelObject;
+
+  it("renders unparseable GS1-128 content as the raw mode-D stream, not a guess", () => {
+    // `0112345` ships verbatim (leading FNC1 only); the old element-string
+    // guess rendered (01)00000000123457, a symbol the printer never prints.
+    const opts = buildBwipOptions(c128("0112345"), 1, 8);
+    expect(opts?.bcid).toBe("code128");
+    expect(opts?.parsefnc).toBe(true);
+    expect(opts?.text).toBe("^FNC10112345");
+  });
+
+  it("encodes a GS-after-fixed-AI DataMatrix payload instead of alarming", () => {
+    // Legal input the catalog cannot segment; the `_1` wire prints it, so the
+    // canvas must encode the equivalent raw FNC1 stream.
+    const gs = String.fromCharCode(0x1d);
+    const dm = { id: "d", type: "datamatrix", x: 0, y: 0, rotation: 0,
+      props: { content: `0112345678901231${gs}10ABC`, gs1: true, dimension: 20, quality: 200, rotation: "N" },
+    } as LabelObject;
+    const opts = buildBwipOptions(dm, 1, 8);
+    expect(opts?.bcid).toBe("datamatrix");
+    expect(opts?.parsefnc).toBe(true);
+    expect(opts?.text).toBe(`^FNC10112345678901231^FNC110ABC`);
   });
 });
 
@@ -226,12 +266,14 @@ describe("buildBwipOptions datamatrix GS1 mode", () => {
   });
 
   it("disables nothing when the content cannot be auto-encoded at all", () => {
-    // Oversized (or invalid) content fails at every size — that is a content
-    // problem the preflight reports; the size list must stay usable.
+    // Oversized content fails at every size, a content problem the
+    // preflight reports; the size list must stay usable.
     const oversized = dm("X".repeat(200), false, { aspectRatio: 2 }).props as DataMatrixProps;
     expect(dataMatrixMinFitIndex(oversized, dmSizePairs(oversized))).toBe(0);
+    // Unsegmentable GS1 content still encodes (raw FNC1 path, matching the
+    // `_1` wire), so the fit is real, not the fallback.
     const invalidGs1 = dm("01095011015300031", true).props as DataMatrixProps;
-    expect(dataMatrixMinFitIndex(invalidGs1, dmSizePairs(invalidGs1))).toBe(0);
+    expect(dataMatrixMinFitIndex(invalidGs1, dmSizePairs(invalidGs1))).toBeGreaterThan(0);
   });
 
   it("forces a firmware-valid c/r pair via version; unknown pairs auto-size", () => {

--- a/src/components/Properties/SerialModeSection.tsx
+++ b/src/components/Properties/SerialModeSection.tsx
@@ -31,8 +31,8 @@ export function SerialModeCheckbox({ obj, onChange }: Props) {
   const t = useT();
   const { resolveDefaults } = usePreviewBinding();
   const entry = getEntry(obj.type);
-  // gs1 hides the toggle only while serial is OFF; the parser can import both
-  // flags on one field (^BC GS1 + ^SN), so serial-on must keep its way out.
+  // gs1 hides the toggle only while serial is OFF; legacy designs may still
+  // carry both flags, so serial-on must keep its way out.
   if (!entry?.serialisable || (obj.props.gs1 && !obj.props.serial)) return null;
   const spec = specForObject(obj);
   return (

--- a/src/lib/gs1.test.ts
+++ b/src/lib/gs1.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   gtin14WithCheck,
-  wrapGs1AIs,
   mod10CheckDigit,
   validateGs1Segment,
   validateGs1SegmentResolved,
@@ -11,7 +10,6 @@ import {
   segmentsToElementString,
   segmentsToContent,
   parseGs1ToSegments,
-  gs1ContentToElementString,
   GS1_GS,
   GS1_DATABAR_EXPANDED_SYMBOLOGIES,
   GS1_DATABAR_DEFAULT_SEGMENTS,
@@ -43,28 +41,6 @@ describe("gtin14WithCheck", () => {
 
   it("ignores non-digit characters", () => {
     expect(gtin14WithCheck("(01)12345")).toHaveLength(14);
-  });
-});
-
-describe("wrapGs1AIs", () => {
-  it("wraps raw AI 01 + GTIN-14 in parens", () => {
-    expect(wrapGs1AIs("0112345678901231")).toBe("(01)12345678901231");
-  });
-
-  it("auto-completes the GTIN check digit when AI 01 data is short", () => {
-    // 9 digits after "01" → padded to 13 + check = 14
-    const out = wrapGs1AIs("01123456789");
-    expect(out.startsWith("(01)")).toBe(true);
-    expect(out.slice(4)).toHaveLength(14);
-  });
-
-  it("passes through already-parenthesised input unchanged", () => {
-    expect(wrapGs1AIs("(01)12345678901231")).toBe("(01)12345678901231");
-  });
-
-  it("appends unknown AI data verbatim so bwip-js surfaces the error", () => {
-    // AI 99 is not in the fixed-length table
-    expect(wrapGs1AIs("99abcdef")).toBe("99abcdef");
   });
 });
 
@@ -341,19 +317,6 @@ describe("segments serialize/parse", () => {
   it("returns null for non-GS1 content (fallback to free text)", () => {
     expect(parseGs1ToSegments("hello world")).toBeNull();
     expect(parseGs1ToSegments("0112")).toBeNull(); // fixed AI too short
-  });
-
-  it("derives the bwip element string from raw content", () => {
-    expect(gs1ContentToElementString(segmentsToContent(segs))).toBe(
-      "(01)09501101530003(10)ABC123(21)12345",
-    );
-  });
-
-  it("falls back to the legacy wrapper when content is not cleanly segmentable", () => {
-    // AI 01 with a short body: catalog parse fails, legacy wrapper completes it.
-    const out = gs1ContentToElementString("01123");
-    expect(out.startsWith("(01)")).toBe(true);
-    expect(out.slice(4)).toHaveLength(14);
   });
 });
 

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -422,6 +422,30 @@ describe("computePreflight (suspicious-chars producer)", () => {
     expect(findings.some((f) => f.kind === "suspiciousChars")).toBe(true);
   });
 
+  it("warns when static GS1 content does not segment (ships verbatim)", () => {
+    const c128gs1 = (content: string): LeafObject =>
+      ({ id: "g", type: "code128", x: 0, y: 0, rotation: 0,
+         props: { content, height: 100, moduleWidth: 2, printInterpretation: false,
+                  printInterpretationAbove: false, checkDigit: false, rotation: "N", gs1: true },
+       } as LabelObject as LeafObject);
+    const bad = computePreflight([c128gs1("0112345")], ctx, "mm")
+      .find((f) => f.kind === "gs1ContentUnparsed");
+    expect(bad?.detail).toContain("verbatim");
+    expect(computePreflight([c128gs1("0112345678901231")], ctx, "mm")
+      .some((f) => f.kind === "gs1ContentUnparsed")).toBe(false);
+    // Template content is owned by markerValueFindings.
+    expect(computePreflight([c128gs1("01«gtin»")], ctx, "mm")
+      .some((f) => f.kind === "gs1ContentUnparsed")).toBe(false);
+    // DM excluded: its _1 codec encodes FNC1 positions exactly, nothing ships
+    // verbatim there.
+    const gs = String.fromCharCode(0x1d);
+    const dmGs1 = { id: "d", type: "datamatrix", x: 10, y: 10, rotation: 0,
+      props: { content: `0112345678901231${gs}10ABC`, gs1: true, dimension: 20, quality: 200, rotation: "N" },
+    } as LabelObject as LeafObject;
+    expect(computePreflight([dmGs1], ctx, "mm")
+      .some((f) => f.kind === "gs1ContentUnparsed")).toBe(false);
+  });
+
   it("does not flag the GS separator on expanded GS1 DataBar (symbology IS the GS1 flag)", () => {
     const dbar = (symbology: number): LeafObject =>
       ({ id: "r", type: "gs1databar", x: 0, y: 0, rotation: 0,

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -1960,6 +1960,22 @@ describe('generateBatchZpl', () => {
     expect(recall).not.toContain('^FH_');
   });
 
+  it('emits a GS1 field as mode-D data even when a legacy model carries serial', () => {
+    // The alnum seed filter would eat the >8 FNC1 and merge AI values; a
+    // legacy gs1+serial object must print its GS1 payload, not a seed.
+    const gs = String.fromCharCode(0x1d);
+    const leaf = {
+      id: 'g', type: 'code128', x: 0, y: 0, rotation: 0,
+      props: { content: `10LOT42${gs}21SER7`, height: 100, moduleWidth: 2,
+               printInterpretation: false, printInterpretationAbove: false,
+               checkDigit: false, rotation: 'N', gs1: true,
+               serial: { increment: 1, zplMode: 'SN' } },
+    } as unknown as LabelObject;
+    const out = generateZPL(baseLabel, [leaf]);
+    expect(out).toContain('^FD(10)LOT42>8(21)SER7^FS');
+    expect(out).not.toContain('^SN');
+  });
+
   it('keeps a compacted Subset C stream verbatim (adoption would widen the symbol)', () => {
     const zpl = '^XA^FO0,0^BY2^BCN,100,Y,N,N^FD>;12345678>773^FS^XZ';
     const { objects } = parseSingle(zpl, 8);

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -2677,6 +2677,32 @@ describe('parseZPL — ^FN defaults decode through the leaf\'s ^FD encoder', () 
     }
   });
 
+  it('drops an imported ^SN on a GS1 field and reports the loss (both placements)', () => {
+    // In-field and post-^FS: the handler doc names both forms; the post-^FS
+    // one also overwrote the GS1 content with the seed.
+    const shapes = [
+      '^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FD(01)12345678901231^SN1,1,Y^FS^XZ',
+      '^XA^FO10,10^BY2^BCN,100,Y,N,N,D^FD(01)12345678901231^FS^SN2,1,Y^XZ',
+    ];
+    for (const zpl of shapes) {
+      const r = parseSingle(zpl, 8);
+      expect(serialOf(defined(r.objects[0])), zpl).toBeUndefined();
+      expect(props(defined(r.objects[0])).content, zpl).toContain('12345678901231');
+      expect(r.findings.some((f) => f.kind === 'partial' && f.command === '^SN'), zpl).toBe(true);
+    }
+  });
+
+  it('keeps the field when an in-field ^SN seeds a GS1 field without ^FD', () => {
+    // The seed lands as content here on purpose: skipping it would leave
+    // pendingFD null and flushField would drop the whole field, losing the
+    // partial note with it. Bounded: a real ^FD is never overwritten.
+    const zpl = '^XA^FO10,10^BY2^BCN,100,Y,N,N,D^SN1234,1,Y^FS^XZ';
+    const r = parseSingle(zpl, 8);
+    expect(serialOf(defined(r.objects[0]))).toBeUndefined();
+    expect(props(defined(r.objects[0])).content).toBe('1234');
+    expect(r.findings.some((f) => f.kind === 'partial' && f.command === '^SN')).toBe(true);
+  });
+
   it('scopes candidates per page (a later page must not inherit the decode)', () => {
     const two = '^XA^FO10,10^BQN,2,4^FN1^FDQA,foo^FS^XZ'
       + '^XA^FO10,10^A0N,30,0^FN1^FDQA,foo^FS^XZ';

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -456,6 +456,7 @@ const ar = {
     markerValueUnsafe: 'قيمة المتغير تكسر الترميز',
     markerArmFailed: 'تُطبع العلامات كنص حرفي',
     gs1ValueInvalid: 'قيمة المتغير تُفسد بيانات GS1',
+    gs1ContentUnparsed: 'محتوى GS1 لا يمكن تحليله',
     printerSupportLimited: 'دعم محدود',
     qrRotatedStatic: 'رمز QR الدوّار يطبع قيمة ثابتة',
     qrRotatedModel2: 'رمز QR الدوّار يطبع كطراز 2',

--- a/src/locales/bg.ts
+++ b/src/locales/bg.ts
@@ -456,6 +456,7 @@ const bg = {
     markerValueUnsafe: 'Стойност нарушава кодирането',
     markerArmFailed: 'Маркерите се отпечатват като обикновен текст',
     gs1ValueInvalid: 'Стойността на променливата нарушава GS1 данни',
+    gs1ContentUnparsed: 'GS1 съдържанието не може да бъде анализирано',
     printerSupportLimited: 'Ограничена поддръжка',
     qrRotatedStatic: 'Завъртян QR код отпечатва статична стойност',
     qrRotatedModel2: 'Завъртян QR код отпечатва като Модел 2',

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -456,6 +456,7 @@ const cs = {
     markerValueUnsafe: 'Hodnota proměnné porušuje kódování',
     markerArmFailed: 'Značky se vytisknou jako prostý text',
     gs1ValueInvalid: 'Hodnota proměnné porušuje GS1 data',
+    gs1ContentUnparsed: 'Obsah GS1 nelze zpracovat',
     printerSupportLimited: 'Omezená podpora',
     qrRotatedStatic: 'Otočený QR kód tiskne statickou hodnotu',
     qrRotatedModel2: 'Otočený QR kód tiskne jako Model 2',

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -456,6 +456,7 @@ const da = {
     markerValueUnsafe: 'Variabelværdi bryder kodning',
     markerArmFailed: 'Markører udskrives som bogstavelig tekst',
     gs1ValueInvalid: 'Variabelværdi bryder GS1-data',
+    gs1ContentUnparsed: 'GS1-indhold kan ikke fortolkes',
     printerSupportLimited: 'Begrænset support',
     qrRotatedStatic: 'Roteret QR-kode udskriver statisk værdi',
     qrRotatedModel2: 'Roteret QR-kode udskriver som Model 2',

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -456,6 +456,7 @@ const de = {
     markerValueUnsafe: 'Variablenwert bricht Kodierung',
     markerArmFailed: 'Marker werden als reiner Text gedruckt',
     gs1ValueInvalid: 'Variablenwert bricht GS1-Daten',
+    gs1ContentUnparsed: 'GS1-Inhalt lässt sich nicht parsen',
     printerSupportLimited: 'Eingeschränkt unterstützt',
     qrRotatedStatic: 'Gedrehter QR-Code druckt statischen Wert',
     qrRotatedModel2: 'Gedrehter QR-Code druckt als Modell 2',

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -456,6 +456,7 @@ const el = {
     markerValueUnsafe: 'Τιμή μεταβλητής παραβιάζει κωδικοποίηση',
     markerArmFailed: 'Οι δείκτες εκτυπώνονται ως απλό κείμενο',
     gs1ValueInvalid: 'Η τιμή μεταβλητής παραβιάζει δεδομένα GS1',
+    gs1ContentUnparsed: 'Το περιεχόμενο GS1 δεν αναλύεται',
     printerSupportLimited: 'Περιορισμένη υποστήριξη',
     qrRotatedStatic: 'Περιστραμμένος κωδικός QR εκτυπώνει στατική τιμή',
     qrRotatedModel2: 'Περιστραμμένος κωδικός QR εκτυπώνει ως Μοντέλο 2',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -456,6 +456,7 @@ const en = {
     markerValueUnsafe: 'Variable value breaks encoding',
     markerArmFailed: 'Markers print as literal text',
     gs1ValueInvalid: 'Variable value breaks GS1 data',
+    gs1ContentUnparsed: 'GS1 content does not parse',
     printerSupportLimited: 'Limited support',
     qrRotatedStatic: 'Rotated QR prints a static value',
     qrRotatedModel2: 'Rotated QR prints as Model 2',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -456,6 +456,7 @@ const es = {
     markerValueUnsafe: 'Valor rompe la codificación',
     markerArmFailed: 'Los marcadores se imprimen como texto literal',
     gs1ValueInvalid: 'El valor de variable rompe los datos GS1',
+    gs1ContentUnparsed: 'El contenido GS1 no se puede analizar',
     printerSupportLimited: 'Soporte limitado',
     qrRotatedStatic: 'Código QR rotado imprime un valor estático',
     qrRotatedModel2: 'Código QR rotado imprime como Modelo 2',

--- a/src/locales/et.ts
+++ b/src/locales/et.ts
@@ -456,6 +456,7 @@ const et = {
     markerValueUnsafe: 'Muutuja väärtus rikub kodeeringut',
     markerArmFailed: 'Markerid trükitakse tavalise tekstina',
     gs1ValueInvalid: 'Muutuja väärtus rikub GS1 andmeid',
+    gs1ContentUnparsed: 'GS1 sisu ei õnnestu parsida',
     printerSupportLimited: 'Piiratud tugi',
     qrRotatedStatic: 'Pööratud QR-kood trükib staatilise väärtuse',
     qrRotatedModel2: 'Pööratud QR-kood trükib mudelina 2',

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -456,6 +456,7 @@ const fa = {
     markerValueUnsafe: 'مقدار متغیر کدگذاری را می‌شکند',
     markerArmFailed: 'نشانگرها به‌صورت متن ساده چاپ می‌شوند',
     gs1ValueInvalid: 'مقدار متغیر داده‌های GS1 را می‌شکند',
+    gs1ContentUnparsed: 'محتوای GS1 قابل تجزیه نیست',
     printerSupportLimited: 'پشتیبانی محدود',
     qrRotatedStatic: 'کد QR چرخانده‌شده مقدار ثابت چاپ می‌کند',
     qrRotatedModel2: 'کد QR چرخانده‌شده به‌صورت مدل ۲ چاپ می‌کند',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -456,6 +456,7 @@ const fi = {
     markerValueUnsafe: 'Muuttujan arvo rikkoo koodauksen',
     markerArmFailed: 'Merkit tulostuvat kirjaimellisena tekstinä',
     gs1ValueInvalid: 'Muuttujan arvo rikkoo GS1-tiedot',
+    gs1ContentUnparsed: 'GS1-sisältöä ei voi jäsentää',
     printerSupportLimited: 'Rajoitettu tuki',
     qrRotatedStatic: 'Käännetty QR-koodi tulostaa staattisen arvon',
     qrRotatedModel2: 'Käännetty QR-koodi tulostaa mallina 2',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -456,6 +456,7 @@ const fr = {
     markerValueUnsafe: "Valeur brise l'encodage",
     markerArmFailed: "Les marqueurs s'impriment en texte littéral",
     gs1ValueInvalid: 'La valeur de la variable enfreint les données GS1',
+    gs1ContentUnparsed: 'Le contenu GS1 ne peut pas être analysé',
     printerSupportLimited: 'Support limité',
     qrRotatedStatic: 'QR Code pivoté imprime une valeur statique',
     qrRotatedModel2: 'QR Code pivoté imprime en modèle 2',

--- a/src/locales/he.ts
+++ b/src/locales/he.ts
@@ -456,6 +456,7 @@ const he = {
     markerValueUnsafe: 'ערך משתנה שובר קידוד',
     markerArmFailed: 'הסמנים מודפסים כטקסט מילולי',
     gs1ValueInvalid: 'ערך המשתנה שובר נתוני GS1',
+    gs1ContentUnparsed: 'תוכן ה-GS1 לא ניתן לניתוח',
     printerSupportLimited: 'תמיכה מוגבלת',
     qrRotatedStatic: 'קוד QR מסובב מדפיס ערך סטטי',
     qrRotatedModel2: 'קוד QR מסובב מדפיס כדגם 2',

--- a/src/locales/hr.ts
+++ b/src/locales/hr.ts
@@ -456,6 +456,7 @@ const hr = {
     markerValueUnsafe: 'Vrijednost kvari kodiranje',
     markerArmFailed: 'Oznake se ispisuju kao obični tekst',
     gs1ValueInvalid: 'Vrijednost varijable kvari GS1 podatke',
+    gs1ContentUnparsed: 'GS1 sadržaj se ne može raščlaniti',
     printerSupportLimited: 'Ograničena podrška',
     qrRotatedStatic: 'Rotirani QR kod ispisuje statičnu vrijednost',
     qrRotatedModel2: 'Rotirani QR kod ispisuje kao Model 2',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -456,6 +456,7 @@ const hu = {
     markerValueUnsafe: 'Változóérték megtöri a kódolást',
     markerArmFailed: 'A jelölők egyszerű szövegként nyomtatódnak',
     gs1ValueInvalid: 'A változó értéke sérti a GS1 adatokat',
+    gs1ContentUnparsed: 'A GS1 tartalom nem elemezhető',
     printerSupportLimited: 'Korlátozott támogatás',
     qrRotatedStatic: 'Forgatott QR-kód statikus értéket nyomtat',
     qrRotatedModel2: 'Forgatott QR-kód 2. modellként nyomtat',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -456,6 +456,7 @@ const it = {
     markerValueUnsafe: 'Valore rompe la codifica',
     markerArmFailed: 'I marcatori vengono stampati come testo letterale',
     gs1ValueInvalid: 'Il valore della variabile viola i dati GS1',
+    gs1ContentUnparsed: 'Il contenuto GS1 non può essere analizzato',
     printerSupportLimited: 'Supporto limitato',
     qrRotatedStatic: 'Codice QR ruotato stampa un valore statico',
     qrRotatedModel2: 'Codice QR ruotato stampa come Modello 2',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -456,6 +456,7 @@ const ja = {
     markerValueUnsafe: '変数値がエンコードを破損',
     markerArmFailed: 'マーカーはそのままテキストとして印字されます',
     gs1ValueInvalid: '変数値がGS1データを破損',
+    gs1ContentUnparsed: 'GS1コンテンツを解析できません',
     printerSupportLimited: '一部非対応',
     qrRotatedStatic: '回転したQRコードは固定値を印刷',
     qrRotatedModel2: '回転したQRコードはモデル2として印刷',

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -456,6 +456,7 @@ const ko = {
     markerValueUnsafe: '변수 값이 인코딩을 깨뜨림',
     markerArmFailed: '마커가 일반 텍스트로 인쇄됩니다',
     gs1ValueInvalid: '변수 값이 GS1 데이터를 위반',
+    gs1ContentUnparsed: 'GS1 콘텐츠를 파싱할 수 없습니다',
     printerSupportLimited: '지원 제한',
     qrRotatedStatic: '회전된 QR 코드는 고정값을 인쇄',
     qrRotatedModel2: '회전된 QR 코드는 모델 2로 인쇄',

--- a/src/locales/lt.ts
+++ b/src/locales/lt.ts
@@ -456,6 +456,7 @@ const lt = {
     markerValueUnsafe: 'Kintamojo reikšmė laužo kodavimą',
     markerArmFailed: 'Žymos spausdinamos kaip paprastas tekstas',
     gs1ValueInvalid: 'Kintamojo reikšmė pažeidžia GS1 duomenis',
+    gs1ContentUnparsed: 'GS1 turinio nepavyksta apdoroti',
     printerSupportLimited: 'Ribotas palaikymas',
     qrRotatedStatic: 'Pasuktas QR kodas spausdina statinę reikšmę',
     qrRotatedModel2: 'Pasuktas QR kodas spausdina kaip 2 modelis',

--- a/src/locales/lv.ts
+++ b/src/locales/lv.ts
@@ -456,6 +456,7 @@ const lv = {
     markerValueUnsafe: 'Mainīgā vērtība pārkāpj kodējumu',
     markerArmFailed: 'Marķieri tiek drukāti kā vienkāršs teksts',
     gs1ValueInvalid: 'Mainīgā vērtība pārkāpj GS1 datus',
+    gs1ContentUnparsed: 'GS1 saturu nevar parsēt',
     printerSupportLimited: 'Ierobežots atbalsts',
     qrRotatedStatic: 'Pagriezts QR kods drukā statisku vērtību',
     qrRotatedModel2: 'Pagriezts QR kods drukā kā 2. modeli',

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -456,6 +456,7 @@ const nl = {
     markerValueUnsafe: 'Variabelwaarde breekt codering',
     markerArmFailed: 'Markers worden als letterlijke tekst afgedrukt',
     gs1ValueInvalid: 'Variabelewaarde schendt GS1-gegevens',
+    gs1ContentUnparsed: 'GS1-inhoud kan niet worden geparsed',
     printerSupportLimited: 'Beperkte ondersteuning',
     qrRotatedStatic: 'Gedraaide QR-code drukt statische waarde',
     qrRotatedModel2: 'Gedraaide QR-code drukt als model 2',

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -456,6 +456,7 @@ const no = {
     markerValueUnsafe: 'Variabelverdi bryter koding',
     markerArmFailed: 'Markører skrives ut som ren tekst',
     gs1ValueInvalid: 'Variabelverdi bryter GS1-data',
+    gs1ContentUnparsed: 'GS1-innhold kan ikke tolkes',
     printerSupportLimited: 'Begrenset støtte',
     qrRotatedStatic: 'Rotert QR-kode skriver ut statisk verdi',
     qrRotatedModel2: 'Rotert QR-kode skriver ut som Modell 2',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -456,6 +456,7 @@ const pl = {
     markerValueUnsafe: 'Wartość zmiennej łamie kodowanie',
     markerArmFailed: 'Znaczniki drukują się jako zwykły tekst',
     gs1ValueInvalid: 'Wartość zmiennej narusza dane GS1',
+    gs1ContentUnparsed: 'Nie można przeanalizować zawartości GS1',
     printerSupportLimited: 'Ograniczone wsparcie',
     qrRotatedStatic: 'Obrócony kod QR drukuje statyczną wartość',
     qrRotatedModel2: 'Obrócony kod QR drukuje jako Model 2',

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -456,6 +456,7 @@ const pt = {
     markerValueUnsafe: 'Valor quebra a codificação',
     markerArmFailed: 'Os marcadores são impressos como texto literal',
     gs1ValueInvalid: 'O valor da variável viola os dados GS1',
+    gs1ContentUnparsed: 'O conteúdo GS1 não pode ser analisado',
     printerSupportLimited: 'Suporte limitado',
     qrRotatedStatic: 'Código QR rotacionado imprime um valor estático',
     qrRotatedModel2: 'Código QR rotacionado imprime como Modelo 2',

--- a/src/locales/ro.ts
+++ b/src/locales/ro.ts
@@ -456,6 +456,7 @@ const ro = {
     markerValueUnsafe: 'Valoarea variabilei strică codificarea',
     markerArmFailed: 'Marcatorii se tipăresc ca text literal',
     gs1ValueInvalid: 'Valoarea variabilei încalcă datele GS1',
+    gs1ContentUnparsed: 'Conținutul GS1 nu poate fi analizat',
     printerSupportLimited: 'Suport limitat',
     qrRotatedStatic: 'Codul QR rotit imprimă o valoare statică',
     qrRotatedModel2: 'Codul QR rotit imprimă ca Modelul 2',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -456,6 +456,7 @@ const sk = {
     markerValueUnsafe: 'Hodnota premennej porušuje kódovanie',
     markerArmFailed: 'Značky sa vytlačia ako obyčajný text',
     gs1ValueInvalid: 'Hodnota premennej porušuje GS1 dáta',
+    gs1ContentUnparsed: 'Obsah GS1 sa nedá analyzovať',
     printerSupportLimited: 'Obmedzená podpora',
     qrRotatedStatic: 'Otočený QR kód tlačí statickú hodnotu',
     qrRotatedModel2: 'Otočený QR kód tlačí ako Model 2',

--- a/src/locales/sl.ts
+++ b/src/locales/sl.ts
@@ -456,6 +456,7 @@ const sl = {
     markerValueUnsafe: 'Vrednost spremenljivke krši kodiranje',
     markerArmFailed: 'Oznake se natisnejo kot navadno besedilo',
     gs1ValueInvalid: 'Vrednost spremenljivke krši GS1 podatke',
+    gs1ContentUnparsed: 'Vsebine GS1 ni mogoče razčleniti',
     printerSupportLimited: 'Omejena podpora',
     qrRotatedStatic: 'Zasukana QR koda natisne statično vrednost',
     qrRotatedModel2: 'Zasukana QR koda natisne kot Model 2',

--- a/src/locales/sr.ts
+++ b/src/locales/sr.ts
@@ -456,6 +456,7 @@ const sr = {
     markerValueUnsafe: 'Вредност квари кодирање',
     markerArmFailed: 'Маркери се штампају као обичан текст',
     gs1ValueInvalid: 'Вредност променљиве нарушава GS1 податке',
+    gs1ContentUnparsed: 'GS1 садржај се не може рашчланити',
     printerSupportLimited: 'Ограничена подршка',
     qrRotatedStatic: 'Ротирани QR код штампа статичну вредност',
     qrRotatedModel2: 'Ротирани QR код штампа као Модел 2',

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -456,6 +456,7 @@ const sv = {
     markerValueUnsafe: 'Variabelvärde bryter kodning',
     markerArmFailed: 'Markörer skrivs ut som vanlig text',
     gs1ValueInvalid: 'Variabelvärde bryter GS1-data',
+    gs1ContentUnparsed: 'GS1-innehåll kan inte tolkas',
     printerSupportLimited: 'Begränsat stöd',
     qrRotatedStatic: 'Roterad QR-kod skriver ut statiskt värde',
     qrRotatedModel2: 'Roterad QR-kod skriver ut som Modell 2',

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -456,6 +456,7 @@ const tr = {
     markerValueUnsafe: 'Değişken değeri kodlamayı bozuyor',
     markerArmFailed: 'İşaretleyiciler düz metin olarak yazdırılır',
     gs1ValueInvalid: 'Değişken değeri GS1 verilerini bozuyor',
+    gs1ContentUnparsed: 'GS1 içeriği ayrıştırılamıyor',
     printerSupportLimited: 'Sınırlı destek',
     qrRotatedStatic: 'Döndürülmüş QR Kodu statik değer basar',
     qrRotatedModel2: 'Döndürülmüş QR Kodu Model 2 olarak basar',

--- a/src/locales/zh-hans.ts
+++ b/src/locales/zh-hans.ts
@@ -456,6 +456,7 @@ const zhHans = {
     markerValueUnsafe: '变量值破坏编码',
     markerArmFailed: '标记将作为字面文本打印',
     gs1ValueInvalid: '变量值违反GS1数据',
+    gs1ContentUnparsed: 'GS1 内容无法解析',
     printerSupportLimited: '支持有限',
     qrRotatedStatic: '旋转的二维码打印静态值',
     qrRotatedModel2: '旋转的二维码以型号2打印',

--- a/src/locales/zh-hant.ts
+++ b/src/locales/zh-hant.ts
@@ -456,6 +456,7 @@ const zhHant = {
     markerValueUnsafe: '變數值破壞編碼',
     markerArmFailed: '標記將以純文字方式列印',
     gs1ValueInvalid: '變數值違反GS1資料',
+    gs1ContentUnparsed: 'GS1 內容無法解析',
     printerSupportLimited: '支援有限',
     qrRotatedStatic: '旋轉的二維碼列印靜態值',
     qrRotatedModel2: '旋轉的二維碼以型號2列印',


### PR DESCRIPTION
…ight

Canvas guessed element strings the printer never received (wrapGs1AIs, (99) shortcut); unsegmentable content now renders and warns as the verbatim wire. Imported ^SN on a GS1 field is dropped (the alnum filter corrupts FNC1).