### PR TITLE
refactor(gs1): emitters consume the fd plan

### DIFF
--- a/packages/core/src/lib/gs1.ts
+++ b/packages/core/src/lib/gs1.ts
@@ -407,13 +407,6 @@ export function segmentsToZplFd(segments: readonly Gs1Segment[]): string {
     .join("");
 }
 
-/** ^FD form of model content, raw or parenthesized (see segmentsToZplFd).
- *  Unparseable content passes through unchanged: its FNC1 positions are
- *  unknown, and re-escaping would corrupt existing invocations. */
-export function gs1ContentToZplFd(content: string): string {
-  const segs = parseGs1ToSegments(content);
-  return segs ? segmentsToZplFd(segs) : content;
-}
 
 /** Undo the ^FD invocations on import: strip FNC1 markers (the parens already
  *  delimit segments) and unescape literal `>`. Order matters: `>08` is an

--- a/packages/core/src/lib/gs1Plan.test.ts
+++ b/packages/core/src/lib/gs1Plan.test.ts
@@ -32,7 +32,7 @@ describe("planGs1Fd", () => {
     expect(dm.losses).toEqual([]);
   });
 
-  it("matches the real emitters byte for byte (drift tripwire via toZPL)", () => {
+  it("matches the full toZPL output byte for byte (covers the ^FH wrapping layer)", () => {
     // plan.fd is the payload handed to fdField, which may still wrap it in
     // ^FH hex (raw GS on the databar wire); undo that layer for comparison.
     const fdOf = (zpl: string): string => {

--- a/packages/core/src/lib/gs1Plan.ts
+++ b/packages/core/src/lib/gs1Plan.ts
@@ -5,8 +5,6 @@ import {
   segmentsToZplFd,
 } from "./gs1";
 import { gs1ContentToDataMatrixFd } from "./dataMatrixFd";
-import { hasTemplateMarkers } from "./fnTemplate";
-import { getEntry, isGs1Active } from "../registry";
 
 /** GS1 carriers with distinct ^FD grammars: ^BC mode D (parenthesized + >8),
  *  ^BX quality 200 (`_1` escapes), ^BR (raw content; separator grammar is
@@ -40,10 +38,9 @@ function parsefncRuns(content: string, joiner: string): string {
   return `^FNC1${runs.join(joiner)}`;
 }
 
-/** Single GS1 derivation (planCode128Fd's sibling): mirrors the emit
- *  transforms (byte-equality pinned by test); canvas and preflight consume
- *  it. Known limit: unparsed `>` invocations print as invocations (spec
- *  p.104) but render literally on canvas. */
+/** Single GS1 ^FD derivation (planCode128Fd's sibling): emit, canvas and
+ *  preflight consume it. Known limit: unparsed `>` invocations print as
+ *  invocations (spec p.104) but render literally. */
 export function planGs1Fd(content: string, carrier: Gs1Carrier): Gs1FdPlan {
   if (content === "") {
     return {
@@ -73,17 +70,6 @@ export function planGs1Fd(content: string, carrier: Gs1Carrier): Gs1FdPlan {
     case "databar":
       return parsed(content);
   }
-}
-
-/** Static GS1 content that ships verbatim: owns the gs1ContentUnparsed
- *  warning, and the canvas suppresses renderFailed on the same predicate.
- *  Template content is owned by markerValueFindings. */
-export function gs1StaticUnparsed(type: string, props: object, content: string): boolean {
-  const carrier = gs1CarrierFor(type);
-  return carrier !== null
-    && isGs1Active(getEntry(type), props)
-    && !hasTemplateMarkers(content)
-    && planGs1Fd(content, carrier).losses.length > 0;
 }
 
 /** GS1 carriers by leaf type; other types have no GS1 ^FD grammar. */

--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -1,4 +1,4 @@
-import { getEntry, isGs1Active, type LeafObject } from "../registry";
+import { getEntry, gs1StaticUnparsed, isGs1Active, usesPlainCode128Escape, type LeafObject } from "../registry";
 import { objectBoundsDots, offLabelPlacement, type ObjectBoundsCtx } from "./objectBounds";
 import { emittedAnchorDots } from "./emittedAnchor";
 import { suspiciousCharDetail } from "./suspiciousChars";
@@ -7,7 +7,6 @@ import { DATAMATRIX_FD_ESCAPE } from "./dataMatrixFd";
 import { extractTemplateRefs, hasTemplateMarkers, pickEmbedChar } from "./fnTemplate";
 import { hasClockMarkers, pickClockChars } from "./fcTemplate";
 import { planCode128Fd, planHasLoss } from "./code128Plan";
-import { gs1StaticUnparsed } from "./gs1Plan";
 import { resolveControlMarkers } from "../types/controlKey";
 import { classifyField, isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
@@ -387,7 +386,7 @@ export function computePreflight(
       // gap: an unencodable byte without any C0 (e.g. DEL plus Ä) drops
       // silently; C0_RE keys the drop loss, DEL alone is routing, not loss.
       const p = leaf.props as { serial?: unknown };
-      if (leafEntry?.ctrlNeedsOwnEscape && !gs1 && !p.serial) {
+      if (usesPlainCode128Escape(leafEntry, leaf.props) && !p.serial) {
         const templateFd = hasTemplateMarkers(resolveControlMarkers(content));
         const plan = planCode128Fd(content, templateFd ? "template" : "whole");
         for (const loss of plan.losses) {

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -1,5 +1,5 @@
 import { mmToDots } from './coordinates';
-import { getEntry, isGs1Active, BARCODE_1D_TYPES } from '../registry';
+import { getEntry, usesPlainCode128Escape, BARCODE_1D_TYPES } from '../registry';
 import { fdField, stripZplCommandChars, GRAPHIC_ANCHOR_TYPES, printerAnchoredX } from '../registry/zplHelpers';
 import {
   extractTemplateRefs,
@@ -89,8 +89,7 @@ export function planTemplateHeader(
     // '0'/'<'/'=' after this scan, and '<'/'=' are ^FC candidate chars.
     const leafEntry = getEntry(leaf.type);
     const scan =
-      leafEntry?.ctrlNeedsOwnEscape
-      && !isGs1Active(leafEntry, (leaf as { props?: object }).props)
+      usesPlainCode128Escape(leafEntry, (leaf as { props?: object }).props)
         ? planCode128Fd(c, 'template').fd
         : c;
     // Chips-only payloads arm no ^FE (they emit as invocations/bytes), so
@@ -507,8 +506,9 @@ export function generateBatchZpl(
     // raw instead: the escape would corrupt the co-consumers.
     const boundEntry = bound && !isGroup(bound) ? getEntry(bound.type) : undefined;
     const boundPlainShared =
-      bound && !isGroup(bound) && !!boundEntry?.ctrlNeedsOwnEscape
-      && !isGs1Active(boundEntry, bound.props) && plainSharedFns.has(v.fnNumber);
+      bound && !isGroup(bound)
+      && usesPlainCode128Escape(boundEntry, bound.props)
+      && plainSharedFns.has(v.fnNumber);
     const transform = boundPlainShared
       ? (s: string) => planCode128Fd(s, 'sharedRaw').fd
       : (bound && !isGroup(bound) ? boundEntry?.fdTransform?.(bound) : undefined) ??

--- a/packages/core/src/registry/barcode1d.ts
+++ b/packages/core/src/registry/barcode1d.ts
@@ -9,7 +9,8 @@ import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { classifyField, isLoneMarker } from '../lib/variableField';
 import { planCode128Fd } from '../lib/code128Plan';
 import { resolveControlMarkers } from '../types/controlKey';
-import { gs1ContentToZplFd, parseGs1ToSegments, segmentsToZplFd } from '../lib/gs1';
+import { parseGs1ToSegments, segmentsToZplFd } from '../lib/gs1';
+import { planGs1Fd } from '../lib/gs1Plan';
 import { GS1_CONTENT_SPEC } from './gs1FieldSpec';
 import type { ContentSpec } from '../types/contentSpec';
 import { type ZplRotation } from './rotation';
@@ -82,6 +83,8 @@ export interface Barcode1DCoreConfig {
   fdPlainEscape?: (payload: string) => string;
 }
 
+const gs1ModeDFd = (s: string): string => planGs1Fd(s, 'code128').fd;
+
 export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore<Barcode1DProps> {
   const defaultProps: Barcode1DProps = {
     content: '',
@@ -112,7 +115,7 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
           const base = isTemplate
             ? undefined
             : config.gs1Capable && obj.props.gs1
-              ? gs1ContentToZplFd
+              ? gs1ModeDFd
               : config.fdContent;
           // Non-template payloads are whole ^FD values; the plan owns the
           // invocation-vs-^FH decision (fdPlainEscape implies the code128
@@ -230,9 +233,10 @@ export function createBarcode1DCore(config: Barcode1DCoreConfig): ObjectTypeCore
         // fdPlainEscape (an injected `>0` would leave a stray 0 in the ^SF
         // mask) and a template seed skips the base transform too.
         ? serialFieldData(
+            // No gs1 arm: the serial path is gated on !p.gs1 above.
             (hasTemplateMarkers(p.content) && !isLoneMarker(p.content)
               ? undefined
-              : config.gs1Capable && p.gs1 ? gs1ContentToZplFd : config.fdContent
+              : config.fdContent
             )?.(p.content) ?? p.content,
             obj.props.serial)
         : fdFieldFor(content, ctx, fdTransformOnce, undefined,

--- a/packages/core/src/registry/datamatrix.ts
+++ b/packages/core/src/registry/datamatrix.ts
@@ -1,6 +1,7 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
 import { fieldPosZ, fdFieldFor } from './zplHelpers';
-import { DATAMATRIX_FD_ESCAPE, gs1ContentToDataMatrixFd } from '../lib/dataMatrixFd';
+import { DATAMATRIX_FD_ESCAPE } from '../lib/dataMatrixFd';
+import { planGs1Fd } from '../lib/gs1Plan';
 import { moduleTooSmallPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 import { GS1_CONTENT_SPEC } from './gs1FieldSpec';
@@ -18,6 +19,8 @@ export const DM_SQUARE_SIZES = [
 export const DM_RECT_SIZES = [
   [8, 18], [8, 32], [12, 26], [12, 36], [16, 36], [16, 48],
 ] as const;
+
+const dmGs1Fd = (s: string): string => planGs1Fd(s, 'datamatrix').fd;
 
 export interface DataMatrixProps {
   content: string;
@@ -70,7 +73,7 @@ export const datamatrix: ObjectTypeCore<DataMatrixProps> = {
   // GS1 mode FNC1-escapes the payload; shared with the CSV batch override.
   // Non-GS1 content is arbitrary bytes, emitted verbatim (the printer owns any
   // ^BX escape sequences it contains).
-  fdTransform: (obj) => (obj.props.gs1 ? gs1ContentToDataMatrixFd : undefined),
+  fdTransform: (obj) => (obj.props.gs1 ? dmGs1Fd : undefined),
 
   toZPL: (obj, ctx) => {
     const p = obj.props;
@@ -91,7 +94,7 @@ export const datamatrix: ObjectTypeCore<DataMatrixProps> = {
     return [
       fieldPosZ(obj),
       `^BX${params.join(',')}`,
-      fdFieldFor(p.content, ctx, p.gs1 ? gs1ContentToDataMatrixFd : undefined, undefined, CONTROL_CHARS && !p.gs1),
+      fdFieldFor(p.content, ctx, p.gs1 ? dmGs1Fd : undefined, undefined, CONTROL_CHARS && !p.gs1),
     ].join('');
   },
 };

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -1,4 +1,6 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
+import { hasTemplateMarkers } from '../lib/fnTemplate';
+import { gs1CarrierFor, planGs1Fd } from '../lib/gs1Plan';
 import type { LeafType, ObjectRegistryMap } from './leafObject';
 import { resolveContentSpec, type ContentSpec } from './contentSpec';
 import type { CtrlParity } from '../lib/markerResolve';
@@ -131,6 +133,26 @@ export function isGs1Active(
   if (!entry || !props) return false;
   if (entry.gs1Active) return entry.gs1Active(props);
   return entry.gs1Capable === true && (props as { gs1?: boolean }).gs1 === true;
+}
+
+/** The leaf's ^FD grammar is the plain Code 128 escape (ctrl-capable type
+ *  outside GS1 mode). */
+export function usesPlainCode128Escape(
+  entry: Parameters<typeof isGs1Active>[0],
+  props: object | undefined,
+): boolean {
+  return entry?.ctrlNeedsOwnEscape === true && !isGs1Active(entry, props);
+}
+
+/** Static GS1 content that ships verbatim: owns the gs1ContentUnparsed
+ *  warning, and the canvas suppresses renderFailed on the same predicate.
+ *  Template content is owned by markerValueFindings. */
+export function gs1StaticUnparsed(type: string, props: object, content: string): boolean {
+  const carrier = gs1CarrierFor(type);
+  return carrier !== null
+    && isGs1Active(getEntry(type), props)
+    && !hasTemplateMarkers(content)
+    && planGs1Fd(content, carrier).losses.length > 0;
 }
 
 /** Emitter parity for control-key chips: they resolve to bytes only on a

--- a/src/components/Canvas/barcodePreflight.ts
+++ b/src/components/Canvas/barcodePreflight.ts
@@ -1,7 +1,6 @@
-import { ctrlParityFor, type LeafObject } from "@zplab/core/registry";
+import { ctrlParityFor, gs1StaticUnparsed, type LeafObject } from "@zplab/core/registry";
 import { maxicodeScmOwnedByPreflight, type MaxicodeProps } from "@zplab/core/registry/maxicode";
 import { isBarcode } from "@zplab/core/lib/objectBounds";
-import { gs1StaticUnparsed } from "@zplab/core/lib/gs1Plan";
 import { PREFLIGHT_SEVERITY, type PreflightFinding } from "@zplab/core/lib/preflight";
 import type { Variable } from "@zplab/core/types/Variable";
 import {

--- a/src/lib/gs1.test.ts
+++ b/src/lib/gs1.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { planGs1Fd } from "@zplab/core/lib/gs1Plan";
 import {
   gtin14WithCheck,
   mod10CheckDigit,
@@ -16,7 +17,6 @@ import {
   GS1_AI_SPECS,
   gs1AddBlockReason,
   segmentsToZplFd,
-  gs1ContentToZplFd,
   zplFdToGs1Input,
 } from "@zplab/core/lib/gs1";
 
@@ -333,11 +333,13 @@ describe("constants", () => {
   });
 });
 
-describe("segmentsToZplFd / gs1ContentToZplFd (mode D ^FD form)", () => {
+const gs1ModeDFdOf = (content: string) => planGs1Fd(content, "code128").fd;
+
+describe("segmentsToZplFd / planGs1Fd fd (mode D ^FD form)", () => {
   const content = "0104012345678901" + "1020260707" + GS1_GS + "17261231" + "30144";
 
   it("adds the >8 FNC1 invocation only after non-final variable AIs", () => {
-    expect(gs1ContentToZplFd(content)).toBe(
+    expect(gs1ModeDFdOf(content)).toBe(
       "(01)04012345678901(10)20260707>8(17)261231(30)144",
     );
   });
@@ -345,19 +347,19 @@ describe("segmentsToZplFd / gs1ContentToZplFd (mode D ^FD form)", () => {
   it("passes unparseable content through verbatim (no re-escape corruption)", () => {
     // A foreign mode-D field kept verbatim on import must round-trip byte-stable;
     // re-escaping > here would turn >8 into >08 and corrupt the FNC1.
-    expect(gs1ContentToZplFd(">;>80100003486")).toBe(">;>80100003486");
+    expect(gs1ModeDFdOf(">;>80100003486")).toBe(">;>80100003486");
   });
 
   it("inserts >8 for the element-string form too, not just raw content", () => {
     // The parenthesized form must not bypass segment parsing into the fallback.
-    expect(gs1ContentToZplFd("(01)04012345678901(10)20260707(17)261231(30)144")).toBe(
+    expect(gs1ModeDFdOf("(01)04012345678901(10)20260707(17)261231(30)144")).toBe(
       "(01)04012345678901(10)20260707>8(17)261231(30)144",
     );
   });
 
   it("adds no separator for a single or final variable AI", () => {
-    expect(gs1ContentToZplFd("1020260707")).toBe("(10)20260707");
-    expect(gs1ContentToZplFd("010401234567890110ABC")).toBe("(01)04012345678901(10)ABC");
+    expect(gs1ModeDFdOf("1020260707")).toBe("(10)20260707");
+    expect(gs1ModeDFdOf("010401234567890110ABC")).toBe("(01)04012345678901(10)ABC");
   });
 
   it("escapes a literal > in values as >0", () => {


### PR DESCRIPTION
planGs1Fd becomes the single ^FD source for code128/DM GS1 mode; gs1StaticUnparsed moves beside isGs1Active, the twin plain-escape gates share usesPlainCode128Escape.