### PR TITLE
fix(mcp): faithful headless export and geometry

### DIFF
--- a/packages/core/src/lib/barcodeDims.ts
+++ b/packages/core/src/lib/barcodeDims.ts
@@ -1120,11 +1120,11 @@ function tlc39DimsPx(
 /** Headless twin of the app's canvas measureBarcodeFootprintDots: identical
  *  blank/sample fallback and zone math, dims from the injected bwip engine.
  *  Measures at scale = dpmm (px = dots), intrinsic to a headless measure. */
-export function measureBarcodeFootprintDotsWith(
+function measureDisplayWith(
   bwip: BwipEngine,
   obj: LeafObject,
   dpmm: number,
-): { w: number; h: number } | null {
+): BarcodeDisplaySize | null {
   const blank = (getObjectStringContent(obj) ?? "").trim() === "";
   let target = obj;
   let dims = blank ? null : barcodeDimsPx(bwip, obj, dpmm, dpmm);
@@ -1136,8 +1136,45 @@ export function measureBarcodeFootprintDotsWith(
     if (!dims) return null;
   }
   const dim = getDisplaySize(target, dims, dpmm, dpmm);
-  if (dim.w <= 0 || dim.h <= 0) return null;
-  return { w: pxToDots(dim.w, dpmm, dpmm), h: pxToDots(dim.h, dpmm, dpmm) };
+  return dim.w > 0 && dim.h > 0 ? dim : null;
+}
+
+export function measureBarcodeFootprintDotsWith(
+  bwip: BwipEngine,
+  obj: LeafObject,
+  dpmm: number,
+): { w: number; h: number } | null {
+  const dim = measureDisplayWith(bwip, obj, dpmm);
+  return dim ? { w: pxToDots(dim.w, dpmm, dpmm), h: pxToDots(dim.h, dpmm, dpmm) } : null;
+}
+
+/** Headless twin of BarcodeObject's measured-bounds record: the full
+ *  bar-rect, so objectBounds anchors FT/rotated fields exactly. */
+export function measureBarcodeBoundsWith(
+  bwip: BwipEngine,
+  obj: LeafObject,
+  dpmm: number,
+): {
+  width: number;
+  height: number;
+  barHeightDots: number;
+  barLeftDots: number;
+  barTopDots: number;
+  uprightBarWDots: number;
+  uprightBarHDots: number;
+} | null {
+  const dim = measureDisplayWith(bwip, obj, dpmm);
+  if (!dim) return null;
+  const d = (px: number) => pxToDots(px, dpmm, dpmm);
+  return {
+    width: d(dim.w),
+    height: d(dim.h),
+    barHeightDots: d(dim.barH),
+    barLeftDots: d(dim.barLeftPx),
+    barTopDots: d(dim.barTopPx),
+    uprightBarWDots: d(dim.upright.barW),
+    uprightBarHDots: d(dim.upright.barH),
+  };
 }
 
 /** Marker resolution for measurement: variable defaults only, no dataset row

--- a/packages/core/src/lib/objectBounds.ts
+++ b/packages/core/src/lib/objectBounds.ts
@@ -13,6 +13,8 @@
 import type { LabelObject } from "../types/Group";
 import { getAllLeaves, isGroup } from "../types/Group";
 import type { LeafObject } from "../registry";
+import { gfaHeaderDims, type ImageProps } from "../registry/image";
+import { getImage } from "./imageCache";
 import { BARCODE_1D_TYPES, STACKED_2D_TYPES, getEntry } from "../registry";
 import type { LabelConfig } from "../types/LabelConfig";
 import { effectiveDpmm, type JmDensity } from "../types/LabelConfig";
@@ -176,6 +178,13 @@ export function isBarcode(obj: { type: string }): boolean {
   return BARCODE_TYPES.has(obj.type);
 }
 
+/** Store-less ^GFA header dims (the byte truth objectBoundsDots sizes by);
+ *  null whenever the image resolves through any other source. */
+function imageHeaderBounds(p: ImageProps): { width: number; height: number | null } | null {
+  if (p.storedAs || p.rawGf || getImage(p.imageId) || objectRotation(p) !== "N") return null;
+  return gfaHeaderDims(p._gfaCache);
+}
+
 /** True when objectBoundsDots estimates this leaf headlessly: barcode registry
  *  footprint, single-line-text font estimate, image-without-heightDots square
  *  guess. Everything else, and any leaf with a `measured` footprint (render
@@ -186,7 +195,9 @@ export function boundsAreApprox(
 ): boolean {
   if (measured?.has(obj.id)) return false;
   if (isBarcode(obj)) return true;
-  if (obj.type === "image") return obj.props.heightDots === undefined;
+  if (obj.type === "image") {
+    return obj.props.heightDots === undefined && imageHeaderBounds(obj.props) === null;
+  }
   if (obj.type !== "text") return false;
   const p = obj.props;
   return !(resolveTextMode(p) !== "normal" && !!p.blockWidth && p.blockWidth > 0);
@@ -210,6 +221,14 @@ export function objectBoundsDots(obj: LabelObject, ctx: ObjectBoundsCtx): Boundi
       // fallback rotates the upright prop dims itself for R/B.
       const m = ctx.measured?.get(obj.id);
       if (m) return { x: obj.x, y: obj.y, width: m.width, height: m.height };
+      const header = imageHeaderBounds(p);
+      if (header) {
+        return {
+          x: obj.x, y: obj.y,
+          width: header.width,
+          height: header.height ?? (p.heightDots ?? p.widthDots),
+        };
+      }
       // storedAs/rawGf stay upright (rot='N'), so their fallback footprint isn't
       // swapped. (Pure path: no cache check, but a no-cache image is empty and
       // inconsequential.)

--- a/packages/core/src/registry/image.ts
+++ b/packages/core/src/registry/image.ts
@@ -40,6 +40,12 @@ export function imageEmitDims(p: ImageProps): { width: number; height: number } 
   if (isImageRotatable(p) && isAxisSwapped(objectRotation(p))) {
     return { width: gfByteWidth(imageEmitHeight(p)), height: p.widthDots };
   }
+  if (!getImage(p.imageId) && objectRotation(p) === 'N') {
+    const header = gfaHeaderDims(p._gfaCache);
+    if (header) {
+      return { width: header.width, height: header.height ?? (p.heightDots ?? p.widthDots) };
+    }
+  }
   return { width: gfByteWidth(p.widthDots), height: imageEmitHeight(p) };
 }
 
@@ -99,6 +105,30 @@ function gfaSync(dataUrl: string, widthDots: number, threshold: number, rotation
   return raster ? gfaFromRaster(raster) : '';
 }
 
+/** Printed size from a ^GF header (spec p.215: width = bytes per row x 8,
+ *  lines = count / bytes per row); the header, not the props, is the byte
+ *  truth for store-less emit and bounds (uploads never persist heightDots).
+ *  Empty count slot (preserved foreign header): height null, callers fall
+ *  back to model dims. Null on unparsable or non-positive/fractional rows. */
+export function gfaHeaderDims(
+  cache: string | undefined,
+): { width: number; height: number | null } | null {
+  const m = cache ? /^\^GF[ABC],\d*,(\d*),(\d+),/.exec(cache) : null;
+  if (!m) return null;
+  const bytesPerRow = Number(m[2]);
+  if (bytesPerRow <= 0) return null;
+  const width = bytesPerRow * 8;
+  if (m[1] === "") return { width, height: null };
+  const height = Number(m[1]) / bytesPerRow;
+  return Number.isInteger(height) && height > 0 ? { width, height } : null;
+}
+
+/** Store-less byte source: unrotated (a re-raster needs the source image)
+ *  with a parsable header, which then also provides the emit dimensions. */
+function gfaCacheUsable(p: ImageProps): boolean {
+  return !!p._gfaCache && objectRotation(p) === 'N' && gfaHeaderDims(p._gfaCache) !== null;
+}
+
 export const image: ObjectTypeCore<ImageProps> = {
   label: 'Image',
   icon: 'img',
@@ -112,12 +142,23 @@ export const image: ObjectTypeCore<ImageProps> = {
   },
   defaultSize: { width: 200, height: 200 },
 
+  // A width/threshold change without a fresh cache in the same change
+  // invalidates the bytes, or emit/preflight would use the stale raster.
+  normalizeChanges: (_obj, changes) => {
+    const next = changes.props as Partial<ImageProps> | undefined;
+    if (!next || !('widthDots' in next || 'threshold' in next) || '_gfaCache' in next) {
+      return changes;
+    }
+    return { ...changes, props: { ...next, _gfaCache: undefined } };
+  },
+
   // No resolvable bytes (no opaque ^GF, no recall path, nothing cached) emits a
   // blank ^FD^FS, so flag the silent empty graphic. Pure (mirrors toZPL), so it
   // also covers exportable-but-hidden images the canvas never renders.
   preflight: (obj) => {
     const p = obj.props;
-    const resolvable = !!p.rawGf || !!p.storedAs || !!getImage(p.imageId);
+    const resolvable =
+      !!p.rawGf || !!p.storedAs || !!getImage(p.imageId) || gfaCacheUsable(p);
     return resolvable ? [] : [{ kind: 'imageMissing' }];
   },
 
@@ -174,7 +215,12 @@ export const image: ObjectTypeCore<ImageProps> = {
     if (p.storedAs) {
       return `${anchor}^XG${formatStoragePath(p.storedAs, true)},1,1^FS`;
     }
-    if (!cached) return `${anchor}^FD^FS`;
+    if (!cached) {
+      // Headless host (MCP sidecar) has no image store; the imported ^GFA
+      // cache is the only byte source. Rotation would need a re-raster.
+      if (gfaCacheUsable(p)) return `${anchor}${p._gfaCache}^FS`;
+      return `${anchor}^FD^FS`;
+    }
     // _gfaCache holds the upright bytes, so a rotated field regenerates fresh
     // (rasterizeMono bakes the rotation in).
     const rot = objectRotation(p);

--- a/packages/mcp-server/src/footprint.ts
+++ b/packages/mcp-server/src/footprint.ts
@@ -3,6 +3,7 @@
 import bwipjs from "bwip-js/generic";
 import { registerFootprintMeasurer } from "@zplab/core/lib/footprintProber";
 import {
+  measureBarcodeBoundsWith,
   measureBarcodeFootprintDotsWith,
   resolveForMeasure,
   type BwipEngine,
@@ -30,6 +31,14 @@ const measure = (o: LabelObject, dpmm?: number) => {
 /** Idempotent; re-registering only resets the seam's memo. */
 export function registerSidecarFootprintMeasurer(): void {
   registerFootprintMeasurer(measure);
+}
+
+/** Full measured-bounds record for the geometry report, resolved against the
+ *  active binding like `measure`. */
+export function measureBoundsEntry(o: LabelObject, dpmm: number) {
+  if (isGroup(o)) return null;
+  const resolved = binding ? resolveForMeasure(o, binding.variables, binding.clock) : o;
+  return measureBarcodeBoundsWith(engine, resolved as LeafObject, dpmm);
 }
 
 /** Run `fn` with markers resolving against the design's own bindings, the

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -35,9 +35,9 @@ export const SERVER_INSTRUCTIONS =
   "object types and their props. Build a label with create_draft (x/y in dots " +
   "from the top-left origin; props merge over defaults), then read the returned " +
   "warnings, bounds, and overlaps and iterate until nothing unintended remains. " +
-  "bounds/overlaps marked approx are headless estimates (barcodes and single-line " +
-  "text): keep extra " +
-  "clearance around them. Overlaps are neutral facts, not errors: a frame or " +
+  "Barcode bounds are probed with the app's measurement kernel; bounds/overlaps " +
+  "marked approx are headless estimates (single-line text): keep extra " +
+  "clearance around those. Overlaps are neutral facts, not errors: a frame or " +
   "reverse box overlaps its contents by design. Bring existing ZPL through " +
   "import_zpl (editable design file) or validate_zpl (lint only); both split " +
   "multi-label streams into one page per ^XA block. export_zpl returns the " +

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -81,6 +81,8 @@ describe("mcp-server tools", () => {
       if ((ObjectRegistry as Record<string, { gs1Capable?: boolean }>)[t.type]?.gs1Capable) {
         allowed.add("gs1");
       }
+      // Optional import-produced props documented on purpose (^FR reverse).
+      if (t.type === "text") allowed.add("reverse");
       for (const key of Object.keys(t.props)) {
         expect(allowed.has(key), `${t.type}.${key} is not a known prop`).toBe(true);
       }
@@ -169,7 +171,7 @@ describe("mcp-server tools", () => {
     expect(v.findings.replayRisk).toContain("^JU");
   });
 
-  it("create_draft reports per-object bounds, approx only for the barcode", () => {
+  it("create_draft reports per-object bounds; barcodes are kernel-probed exact", () => {
     const created = createDraft({
       widthMm: 100,
       heightMm: 50,
@@ -183,7 +185,127 @@ describe("mcp-server tools", () => {
     if (!created.ok) return;
     const box = created.bounds.find((b) => b.objectId === "b");
     expect(box).toMatchObject({ x: 10, y: 20, width: 200, height: 100, approx: false });
-    expect(created.bounds.find((b) => b.objectId === "c")?.approx).toBe(true);
+    const bc = created.bounds.find((b) => b.objectId === "c");
+    expect(bc?.approx).toBe(false);
+    expect(bc!.height).toBe(80);
+  });
+
+  it("reports probed barcode footprints with the full bar-rect entry", () => {
+    const created = ok(createDraft({
+      widthMm: 100,
+      heightMm: 50,
+      dpmm: 8,
+      objects: [
+        { type: "qrcode", x: 0, y: 0, id: "q", props: { content: "12345", magnification: 10 } },
+      ],
+    }));
+    const q = created.bounds.find((b) => b.objectId === "q");
+    expect(q?.approx).toBe(false);
+    // 21 modules x mag 10, not the 200x200 registry default box.
+    expect(q!.width).toBe(210);
+    expect(q!.width).toBe(q!.height);
+    // A rotated ^FT EAN anchors off the upright bar-rect, so the probed
+    // entry must carry it, not just the outer box.
+    const ean = ok(createDraft({
+      widthMm: 100, heightMm: 50, dpmm: 8,
+      objects: [{ type: "ean13", x: 400, y: 300, id: "e", positionType: "FT",
+        props: { content: "4012345678901", height: 80, rotation: "B" } }],
+    })).bounds.find((b) => b.objectId === "e");
+    expect(ean?.approx).toBe(false);
+    expect(ean!.height).toBeGreaterThan(80);
+  });
+
+  it("exports an imported image's ^GFA bytes in a headless host", () => {
+    // Without the store the imported _gfaCache is the only byte source;
+    // an empty ^FD^FS with ok:true would silently lose the graphic.
+    const gfa = "^GFA,8,8,1,00FF00FF00FF00FF";
+    const leaf = {
+      id: "img", type: "image", x: 10, y: 20, rotation: 0,
+      props: { imageId: "gone", widthDots: 8, threshold: 128, rotation: "N", _gfaCache: gfa },
+    };
+    const design = {
+      schemaVersion: 5,
+      label: { widthMm: 50, heightMm: 30, dpmm: 8 },
+      pages: [{ objects: [leaf] }],
+    };
+    const out = ok(exportZpl(design));
+    expect(out.zpl).toContain(gfa);
+    expect(ok(validateDraft(design)).warnings.some((w) => w.kind === "imageMissing")).toBe(false);
+    // A rotated field would need a re-raster no headless host can do.
+    const rotated = { ...design, pages: [{ objects: [{ ...leaf, props: { ...leaf.props, rotation: "R" } }] }] };
+    const outR = ok(exportZpl(rotated));
+    expect(outR.zpl).not.toContain(gfa);
+    expect(ok(validateDraft(rotated)).warnings.some((w) => w.kind === "imageMissing")).toBe(true);
+  });
+
+  it("emits and measures a store-less cache by its ^GFA header truth", () => {
+    // A foreign envelope may carry stale props; the header is the byte
+    // truth, so non-square images survive headless export.
+    const gfa = "^GFA,4,4,1,00FF00FF"; // 8 dots wide, 4 rows: non-square
+    const design = (widthDots: number) => ({
+      schemaVersion: 5,
+      label: { widthMm: 50, heightMm: 30, dpmm: 8 },
+      pages: [{ objects: [{
+        id: "img", type: "image", x: 0, y: 0, rotation: 0,
+        props: { imageId: "gone", widthDots, threshold: 128, rotation: "N", _gfaCache: gfa },
+      }] }],
+    });
+    expect(ok(exportZpl(design(8))).zpl).toContain(gfa);
+    // Mismatched props still export the bytes; bounds follow the header.
+    const mismatched = ok(validateDraft(design(200)));
+    expect(mismatched.warnings.some((w) => w.kind === "imageMissing")).toBe(false);
+    expect(mismatched.bounds.find((b) => b.objectId === "img"))
+      .toMatchObject({ width: 8, height: 4, approx: false });
+  });
+
+  it("keeps a preserved foreign header with an empty count slot exportable", () => {
+    // The parser preserves such headers verbatim and always sets heightDots;
+    // the empty count must not read as unusable (silent drop again).
+    const gfa = "^GFA,4,,1,00FF00FF";
+    const design = {
+      schemaVersion: 5,
+      label: { widthMm: 50, heightMm: 30, dpmm: 8 },
+      pages: [{ objects: [{
+        id: "img", type: "image", x: 0, y: 0, rotation: 0,
+        props: { imageId: "gone", widthDots: 8, heightDots: 4, threshold: 128, rotation: "N", _gfaCache: gfa },
+      }] }],
+    };
+    expect(ok(exportZpl(design)).zpl).toContain(gfa);
+    expect(ok(validateDraft(design)).bounds.find((b) => b.objectId === "img"))
+      .toMatchObject({ width: 8, height: 4 });
+    // Fractional or zero rows stay unusable (malformed header).
+    const bad = { ...design, pages: [{ objects: [{ ...design.pages[0]!.objects[0]!,
+      props: { ...design.pages[0]!.objects[0]!.props, _gfaCache: "^GFA,5,5,2,00FF00FF00" } }] }] };
+    expect(ok(exportZpl(bad)).zpl).not.toContain("^GFA,5,5,2");
+    expect(ok(validateDraft(bad)).warnings.some((w) => w.kind === "imageMissing")).toBe(true);
+  });
+
+  it("off-label preflight judges barcodes by their probed size", () => {
+    // A probed QR (210 dots) overflowing a label its 200-dot default box
+    // would still fit must warn; warnings and bounds share one measured map.
+    const nearEdge = ok(createDraft({
+      widthMm: 30, heightMm: 30, dpmm: 8, // 240 dots printable
+      objects: [{ type: "qrcode", x: 35, y: 0, id: "q",
+        props: { content: "12345", magnification: 10 } }],
+    }));
+    expect(nearEdge.warnings.some((w) => w.objectId === "q" && w.kind.startsWith("offLabel"))).toBe(true);
+  });
+
+  it("clears a stale ^GFA cache when width or threshold change without fresh bytes", () => {
+    // A prop change on a machine without the source image must invalidate
+    // the cache, not print stale bytes at a new anchor width.
+    const entry = ObjectRegistry.image;
+    const obj = {
+      id: "i", type: "image", x: 0, y: 0, rotation: 0,
+      props: { imageId: "gone", widthDots: 64, threshold: 128, rotation: "N", _gfaCache: "^GFA,8,8,1,00FF00FF00FF00FF" },
+    } as never;
+    const widthOnly = entry.normalizeChanges!(obj, { props: { widthDots: 80 } });
+    expect((widthOnly.props as { _gfaCache?: string })._gfaCache).toBeUndefined();
+    expect("_gfaCache" in (widthOnly.props as object)).toBe(true);
+    const withFresh = entry.normalizeChanges!(obj, { props: { widthDots: 80, _gfaCache: "^GFA,1,1,1,00" } });
+    expect((withFresh.props as { _gfaCache?: string })._gfaCache).toBe("^GFA,1,1,1,00");
+    const unrelated = entry.normalizeChanges!(obj, { props: { rotation: "R" } });
+    expect("_gfaCache" in (unrelated.props as object)).toBe(false);
   });
 
   it("validate_zpl reports the intersection rect of two overlapping boxes", () => {
@@ -428,9 +550,9 @@ describe("buildCurrentDesignResult", () => {
     expect(b?.approx).toBe(false);
   });
 
-  it("keeps an unmeasured barcode approx", () => {
+  it("probes a barcode the app did not measure (kernel fallback, exact)", () => {
     const result = ok(buildCurrentDesignResult({ id: 2, designFile: design }));
-    expect(result.bounds.find((x) => x.objectId === "bc1")?.approx).toBe(true);
+    expect(result.bounds.find((x) => x.objectId === "bc1")?.approx).toBe(false);
   });
 
   it("maps a malformed design to the ToolError shape", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -8,7 +8,8 @@ import {
 } from "@zplab/core/lib/designFile";
 import { generateMultiPageZPL } from "@zplab/core/lib/zplGenerator";
 import { importZplText, type ZplImportResult } from "@zplab/core/lib/zplImportService";
-import { withFootprintBinding } from "./footprint.js";
+import { measureBoundsEntry, withFootprintBinding } from "./footprint.js";
+import { isBarcode } from "@zplab/core/lib/objectBounds";
 import type { ImportReport } from "@zplab/core/lib/zplParser";
 import { computePreflight } from "@zplab/core/lib/preflight";
 import type { BoundingBoxDots, ObjectBoundsCtx } from "@zplab/core/lib/objectBounds";
@@ -16,7 +17,7 @@ import type { DesignResponse } from "./appBridge.js";
 import { computeOverlaps, leafBoxesDots, MAX_OVERLAPS, type OverlapDots } from "@zplab/core/lib/objectOverlap";
 import { getEntry, ObjectRegistry } from "@zplab/core/registry";
 import { exportableLeaves, pageLabelConfig, type LabelObject, type Page } from "@zplab/core/types/Group";
-import { DPMM_VALUES, isDpmm, type Dpmm, type JmDensity, type LabelConfig } from "@zplab/core/types/LabelConfig";
+import { effectiveDpmm, DPMM_VALUES, isDpmm, type Dpmm, type JmDensity, type LabelConfig } from "@zplab/core/types/LabelConfig";
 import type { PreflightKind, PreflightSeverity } from "@zplab/core/lib/preflight";
 import type { Variable } from "@zplab/core/types/Variable";
 
@@ -202,8 +203,9 @@ function preflightOf(
   objects: LabelObject[],
   label: LabelConfig,
   pageIndex: number,
+  measured?: ObjectBoundsCtx["measured"],
 ): PreflightWarning[] {
-  return computePreflight(exportableLeaves(objects), { label }, "mm").map((f) => ({
+  return computePreflight(exportableLeaves(objects), { label, measured }, "mm").map((f) => ({
     pageIndex,
     objectId: f.objectId,
     kind: f.kind,
@@ -214,7 +216,8 @@ function preflightOf(
 
 /** Per-object geometry so the agent can reason about size/placement without
  *  recomputing it. Dots, visual top-left. `approx` marks headless estimates
- *  (barcode footprints and single-line text), not render-exact bounds. */
+ *  (single-line text, unprobed leaves); probed barcode footprints share the
+ *  app's measurement kernel and report exact. */
 export interface ObjectBounds extends BoundingBoxDots {
   pageIndex: number;
   objectId: string;
@@ -325,6 +328,28 @@ export type ValidateDraftResult =
     }
   | ToolError;
 
+/** Probe every barcode's real bounds (the bwip kernel the app uses) so
+ *  geometry reports true sizes and anchors instead of the registry's
+ *  default boxes. Skips pages past the geometry cap. */
+function measuredBarcodes(
+  pages: PageLike[],
+  label: LabelConfig,
+  measured?: ObjectBoundsCtx["measured"],
+): ObjectBoundsCtx["measured"] {
+  const map = new Map(measured ?? []);
+  for (const page of pages) {
+    const leaves = exportableLeaves(page.objects);
+    if (leaves.length > MAX_GEOMETRY_OBJECTS) continue;
+    const dpmm = effectiveDpmm(pageLabelConfig(label, page));
+    for (const leaf of leaves) {
+      if (!isBarcode(leaf) || map.has(leaf.id)) continue;
+      const entry = measureBoundsEntry(leaf, dpmm);
+      if (entry) map.set(leaf.id, entry);
+    }
+  }
+  return map;
+}
+
 /** Preflight + geometry with markers resolved against the design's own
  *  bindings; the one report block every design-shaped tool returns. */
 function boundReport(
@@ -333,10 +358,16 @@ function boundReport(
   pages: Page[],
   measured?: ObjectBoundsCtx["measured"],
 ) {
-  return withFootprintBinding(label, variables, () => ({
-    warnings: perPage(pages, label, preflightOf),
-    ...geometryFor(pages, label, measured),
-  }));
+  return withFootprintBinding(label, variables, () => {
+    // One probe pass for both consumers, or the off-label check would judge
+    // clipping with unprobed default boxes while bounds report real sizes.
+    const probed = measuredBarcodes(pages, label, measured);
+    return {
+      warnings: perPage(pages, label, (objects, pageLabel, i) =>
+        preflightOf(objects, pageLabel, i, probed)),
+      ...geometryFor(pages, label, probed),
+    };
+  });
 }
 
 export function validateDraft(designFile: unknown): ValidateDraftResult {
@@ -551,6 +582,7 @@ const PROP_SUMMARIES: Record<string, Record<string, string>> = {
     fontHeight: "dots, glyph height",
     fontWidth: "dots, 0 = auto from height",
     rotation: "N | R | I | B (0/90/180/270)",
+    reverse: "boolean, white-on-black knockout (^FR; needs a dark shape behind)",
   },
   code128: {
     content: "string payload",

--- a/src/store/imageCacheInvalidation.test.ts
+++ b/src/store/imageCacheInvalidation.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { applyObjectChanges } from "./labelStore.internals";
+import { ObjectRegistry } from "@zplab/core/registry";
+import type { LabelObject } from "@zplab/core/types/Group";
+
+// The wiring seam between normalizeChanges and the emit fallback: a width
+// change without fresh bytes must reach toZPL as an invalidated cache.
+describe("image cache invalidation through applyObjectChanges", () => {
+  const gfa = "^GFA,8,8,1,00FF00FF00FF00FF";
+  const img = {
+    id: "i",
+    type: "image",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    props: { imageId: "gone", widthDots: 8, threshold: 128, rotation: "N", _gfaCache: gfa },
+  } as LabelObject;
+
+  it("a width-only change ends in an empty ^FD emit, not stale bytes", () => {
+    expect(ObjectRegistry.image.toZPL(img as never)).toContain(gfa);
+    const changed = applyObjectChanges(img, { props: { widthDots: 80 } });
+    const zpl = ObjectRegistry.image.toZPL(changed as never);
+    expect(zpl).not.toContain(gfa);
+    expect(zpl).toContain("^FD^FS");
+  });
+});


### PR DESCRIPTION
Image export falls back to the imported ^GFA cache, barcode bounds are probed via the footprint kernel instead of default boxes, and the schema documents text.reverse.