### PR TITLE
fix(parser): byte-counted raw binary ^GF/~DY payloads

### DIFF
--- a/docs/zpl-roadmap.md
+++ b/docs/zpl-roadmap.md
@@ -134,7 +134,7 @@ The Printer Settings Modal (Media & Feed / Print Quality / Clock & Time / Encodi
 | `[x]` | `^GD` | diagonal line | |
 | `[x]` | `^GE` | ellipse | |
 | `[x]` | `^GC` | circle | |
-| `[x]` | `^GF` | monochrome bitmap (^GFA and B64/Z64-wrapped B/C; raw binary skipped) | |
+| `[x]` | `^GF` | monochrome bitmap (A hex/RLE, B64/Z64 wrappers, raw binary B; raw C preserved) | |
 | `[x]` | `^GS` | graphic symbol (printer resident chars) | |
 | `[ ]` | `^IL` | image load | `Native build` |
 | `[ ]` | `^IM` | image move | `Native build` |

--- a/packages/core/src/lib/binaryText.ts
+++ b/packages/core/src/lib/binaryText.ts
@@ -1,0 +1,26 @@
+/** Byte-per-char codecs. Manual on purpose: TextDecoder's latin1 labels
+ *  alias windows-1252, not byte-identical in 0x80-0x9F. */
+
+const FROM_CHAR_CODE_CHUNK = 0x8000;
+
+export function latin1ToBytes(s: string): Uint8Array {
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < out.length; i++) out[i] = s.charCodeAt(i) & 0xff;
+  return out;
+}
+
+export function bytesToLatin1(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i += FROM_CHAR_CODE_CHUNK) {
+    s += String.fromCharCode(...bytes.subarray(i, i + FROM_CHAR_CODE_CHUNK));
+  }
+  return s;
+}
+
+/** Control bytes that mark true binary junk. High bytes are NOT included:
+ *  they are legitimate text (UTF-8 or byte-per-char) outside counted spans. */
+// eslint-disable-next-line no-control-regex
+export const CONTROL_BYTES_RE = /[\0-\b\v\f\x0E-\x1F\x7F]/;
+
+/** Chars above 0xFF: not a byte-per-char read, latin1 would corrupt them. */
+export const NON_LATIN1_RE = /[\u0100-\uffff]/;

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -1,4 +1,7 @@
 import { mmToDots } from './coordinates';
+import { CONTROL_BYTES_RE } from './binaryText';
+import { unsafeRawFieldSpans } from './zplParser/helpers';
+import { rewriteRawFieldSpans } from './zplParser/decoders/gfa';
 import { getEntry, usesPlainCode128Escape, BARCODE_1D_TYPES } from '../registry';
 import { fdField, stripZplCommandChars, GRAPHIC_ANCHOR_TYPES, printerAnchoredX } from '../registry/zplHelpers';
 import {
@@ -23,7 +26,7 @@ import { isOverlayConsistent, MIN_JM_SPAN, type FormatHead, type JmSpan } from '
 import { reconstructBlockHead } from './zplHeadScan';
 import { objectBoundsDots, type ObjectBoundsCtx } from './objectBounds';
 import { formatFontDownloadFromPath } from './customFonts';
-import { imageEmitDims, type ImageProps } from '../registry/image';
+import { inlineGfaFor, imageEmitDims, type ImageProps } from '../registry/image';
 import { formatStoragePath } from './storagePath';
 
 function formatDownloadObject(m: CustomFontMapping): string | undefined {
@@ -169,9 +172,11 @@ function formatSetOffset(
 
 /** ~DY for a graphic upload. Format letter is preserved so :Z64: stays paired with C. */
 function formatGraphicUpload(p: ImageProps): string | undefined {
-  if (!p.storedAs || !p._gfaCache) return undefined;
+  if (!p.storedAs) return undefined;
+  const cache = p._gfaCache ?? inlineGfaFor(p);
+  if (!cache) return undefined;
   // Byte-count headers are optional in ^GF, hence \d* not \d+.
-  const m = /^\^GF([ABC]),(\d*),(\d*),(\d+),([\s\S]*)$/.exec(p._gfaCache);
+  const m = /^\^GF([ABC]),(\d*),(\d*),(\d+),([\s\S]*)$/.exec(cache);
   if (!m) return undefined;
   const format = m[1];
   const total = m[2];
@@ -380,10 +385,53 @@ function emitPageBlock(
     else if (sawNew) return generateZplBlock(label, page.objects, variables);
   }
 
-  const dirtyLeaves = exportable.filter((l) => segmentIds.has(l.id) && l.dirty);
+  // Unsafe counted spans: linked segments re-emit from their wrapped model
+  // bytes, unlinked ones (e.g. a ~DY no ^XG consumes) rewrite in place.
+  // Detection runs on the joined block so earlier-segment remaps thread.
+  const unsafeSpans = unsafeRawFieldSpans(overlay.segments.map((seg) => seg.text).join(''));
+  const binarySegIds = new Set<string>();
+  const rewrittenSegs = new Map<number, string>();
+  let fullRegen = false;
+  let segOffset = 0;
+  overlay.segments.forEach((seg, i) => {
+    const from = segOffset;
+    const to = (segOffset += seg.text.length);
+    const inSeg = unsafeSpans.filter((sp) => sp.start < to && sp.end > from);
+    if (inSeg.some((sp) => sp.start < from || sp.end > to)) {
+      fullRegen = true;
+      return;
+    }
+    if (seg.kind === 'object') {
+      if (inSeg.length > 0 || CONTROL_BYTES_RE.test(seg.text)) binarySegIds.add(seg.objectId);
+      return;
+    }
+    if (inSeg.length === 0 && !CONTROL_BYTES_RE.test(seg.text)) return;
+    const rewritten = rewriteRawFieldSpans(
+      seg.text,
+      inSeg.map((sp) => ({
+        ...sp,
+        start: sp.start - from,
+        dataStart: sp.dataStart - from,
+        formatStart: sp.formatStart - from,
+        formatEnd: sp.formatEnd - from,
+        end: sp.end - from,
+      })),
+    );
+    // Residual control junk outside counted fields has no safe form.
+    if (CONTROL_BYTES_RE.test(rewritten)) {
+      fullRegen = true;
+      return;
+    }
+    rewrittenSegs.set(i, rewritten);
+  });
+  if (fullRegen) return generateZplBlock(label, page.objects, variables);
+
+  const dirtyLeaves = exportable.filter(
+    (l) => segmentIds.has(l.id) && (l.dirty || binarySegIds.has(l.id)),
+  );
   const newLeaves = exportable.filter((l) => !segmentIds.has(l.id));
 
-  // A verbatim 0-edit replay is always byte-safe; a regeneration in a
+  // A verbatim replay of text-safe segments is byte-safe; a regeneration in a
   // non-regenSafe block is not, so fall back wholesale the moment an edit
   // (dirty or new) exists there.
   if ((dirtyLeaves.length > 0 || newLeaves.length > 0) && !overlay.regenSafe) {
@@ -418,15 +466,15 @@ function emitPageBlock(
     if (headerLines.length > 0) out.push(`${headerLines.join('\n')}\n`);
   };
 
-  for (const seg of overlay.segments) {
+  for (const [i, seg] of overlay.segments.entries()) {
     if (seg.kind === 'raw' || seg.kind === 'config') {
-      out.push(seg.text);
+      out.push(rewrittenSegs.get(i) ?? seg.text);
       continue;
     }
     // object segment
     const live = exportableById.get(seg.objectId);
     if (!live) continue; // deleted or hidden
-    if (!live.dirty) {
+    if (!live.dirty && !binarySegIds.has(seg.objectId)) {
       out.push(seg.text); // untouched -> verbatim
       continue;
     }
@@ -656,7 +704,7 @@ function generateZplBlock(
   for (const obj of flattenObjects(objects)) {
     if (obj.type !== 'image') continue;
     const p = obj.props as ImageProps;
-    if (!p.storedAs || !p._gfaCache) continue;
+    if (!p.storedAs) continue;
     // Recall-only: bytes uploaded out-of-band; ZPL only emits ^XG references.
     if (p.storedAs.embedInZpl === false) continue;
     const key = formatStoragePath(p.storedAs, false);

--- a/packages/core/src/lib/zplHeadScan.ts
+++ b/packages/core/src/lib/zplHeadScan.ts
@@ -21,7 +21,7 @@ interface HeadToken {
 export interface PrefixState {
   caretChar: string;
   tildeChar: string;
-  delim: string;
+  delimiterChar: string;
 }
 
 /** Tokenize from `fromOffset` with the live caret/delimiter per token, applying
@@ -30,11 +30,11 @@ export interface PrefixState {
 function* headTokens(zpl: string, fromOffset: number, st: PrefixState): Generator<HeadToken> {
   for (const t of tokenize(zpl.slice(fromOffset), st)) {
     const arg = t.rest[0];
-    if (t.cmd === "CC") { if (acceptsPrefixRemap(arg, st.tildeChar, st.delim)) st.caretChar = arg; continue; }
-    if (t.cmd === "CT") { if (acceptsPrefixRemap(arg, st.caretChar, st.delim)) st.tildeChar = arg; continue; }
-    if (t.cmd === "CD") { if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delim = arg; continue; }
+    if (t.cmd === "CC") { if (acceptsPrefixRemap(arg, st.tildeChar, st.delimiterChar)) st.caretChar = arg; continue; }
+    if (t.cmd === "CT") { if (acceptsPrefixRemap(arg, st.caretChar, st.delimiterChar)) st.tildeChar = arg; continue; }
+    if (t.cmd === "CD") { if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delimiterChar = arg; continue; }
     const start = fromOffset + t.start;
-    yield { cmd: t.cmd, rest: t.rest, start, isCaret: zpl[start] === st.caretChar, caret: st.caretChar, delim: st.delim };
+    yield { cmd: t.cmd, rest: t.rest, start, isCaret: zpl[start] === st.caretChar, caret: st.caretChar, delim: st.delimiterChar };
   }
 }
 
@@ -47,7 +47,7 @@ export function lookaheadJmDensity(
   delimiter: string,
 ): JmDensity | undefined {
   let density: JmDensity | undefined;
-  const st: PrefixState = { caretChar: chars.caretChar, tildeChar: chars.tildeChar, delim: delimiter };
+  const st: PrefixState = { caretChar: chars.caretChar, tildeChar: chars.tildeChar, delimiterChar: delimiter };
   for (const t of headTokens(zpl, fromOffset, st)) {
     if (t.cmd === "FS" || t.cmd === "XZ") break;
     if (t.cmd === "XA" && t.start > fromOffset) break;
@@ -101,7 +101,7 @@ export function reconstructBlockHead(block: string): {
   density: JmDensity | undefined;
   head: FormatHead | undefined;
 } {
-  return scanBlockHead(block, { caretChar: "^", tildeChar: "~", delim: "," }, false);
+  return scanBlockHead(block, { caretChar: "^", tildeChar: "~", delimiterChar: "," }, false);
 }
 
 /** Per-block head density and FormatHead for a legacy stream, threading ^CC/^CT/^CD
@@ -110,7 +110,7 @@ export function reconstructBlockHead(block: string): {
 export function reconstructLegacyBlockHeads(
   blocks: readonly (string | undefined)[],
 ): { density: JmDensity | undefined; head: FormatHead | undefined }[] {
-  const st: PrefixState = { caretChar: "^", tildeChar: "~", delim: "," };
+  const st: PrefixState = { caretChar: "^", tildeChar: "~", delimiterChar: "," };
   let carried: JmDensity | undefined;
   return blocks.map((block) => {
     if (block === undefined) return { density: carried, head: undefined };
@@ -130,7 +130,7 @@ export function scanBareStream(
 ): { hasXa: boolean; density: JmDensity | undefined } {
   let density: JmDensity | undefined;
   let inHead = true;
-  const st: PrefixState = { caretChar: chars.caretChar, tildeChar: chars.tildeChar, delim: delimiter };
+  const st: PrefixState = { caretChar: chars.caretChar, tildeChar: chars.tildeChar, delimiterChar: delimiter };
   for (const t of headTokens(zpl, 0, st)) {
     if (t.cmd === "XA") return { hasXa: true, density: undefined };
     if (t.cmd === "FS" || t.cmd === "XZ") { inHead = false; continue; }

--- a/packages/core/src/lib/zplParser/decoders/crc.ts
+++ b/packages/core/src/lib/zplParser/decoders/crc.ts
@@ -1,4 +1,5 @@
 import { BITS_PER_BYTE } from "./constants";
+import { bytesToLatin1 } from "../../binaryText";
 
 const CRC16_POLY = 0x1021;
 const CRC16_MSB_MASK = 0x8000;
@@ -22,6 +23,13 @@ function crc16Xmodem(s: string): number {
     }
   }
   return crc;
+}
+
+/** Bytes -> `:B64:<base64>:<crc>` wrapper (spec p.1602): the text-safe form
+ *  of a raw binary payload, decoded identically by firmware and re-import. */
+export function wrapGfB64(bytes: Uint8Array): string {
+  const b64 = btoa(bytesToLatin1(bytes));
+  return `:B64:${b64}:${crc16Xmodem(b64).toString(16).padStart(CRC_HEX_DIGITS, "0").toUpperCase()}`;
 }
 
 type GfWrapperKind = "b64" | "z64";

--- a/packages/core/src/lib/zplParser/decoders/gfa.ts
+++ b/packages/core/src/lib/zplParser/decoders/gfa.ts
@@ -1,5 +1,28 @@
 import { unzlibSync } from "fflate";
-import { parseGfWrapper } from "./crc";
+import { parseGfWrapper, wrapGfB64 } from "./crc";
+import { latin1ToBytes, NON_LATIN1_RE } from "../../binaryText";
+import type { UnsafeRawFieldSpan } from "../helpers";
+
+/** Rewrite unsafe byte-counted spans text-safe, in place: the payload
+ *  re-wraps as `:B64:` and format B transcodes to A (the spec pairing for
+ *  wrapped data, p.1602/181); C keeps its letter. */
+export function rewriteRawFieldSpans(
+  text: string,
+  spans: readonly UnsafeRawFieldSpan[],
+): string {
+  let out = "";
+  let cursor = 0;
+  for (const sp of spans) {
+    const letter = sp.format === "B" ? "A" : text.slice(sp.formatStart, sp.formatEnd);
+    out +=
+      text.slice(cursor, sp.formatStart) +
+      letter +
+      text.slice(sp.formatEnd, sp.dataStart) +
+      wrapGfB64(latin1ToBytes(text.slice(sp.dataStart, sp.end)));
+    cursor = sp.end;
+  }
+  return out + text.slice(cursor);
+}
 
 /** Inflate `:Z64:` zlib payload; null on malformed deflate stream. */
 function tryInflateZlib(input: Uint8Array): Uint8Array | null {
@@ -24,23 +47,49 @@ function gfaHexToBytes(hex: string): Uint8Array {
 interface GfPayloadDecoded {
   data: Uint8Array;
   crcOk: boolean;
+  /** Decoded from a raw byte-counted binary payload (format B). */
+  raw?: boolean;
 }
 
-/** :B64:/:Z64: -> base64 (+inflate); format=A -> RLE-hex; B/C w/o wrapper -> null. */
+/** Text-safe data slot for a preserved raw field: a byte-counted binary
+ *  payload re-wraps as `:B64:` (data-identical to the device, survives UTF-8
+ *  write-out and CRLF normalization); anything else stays verbatim. */
+export function preserveGfData(
+  rawData: string,
+  format: "A" | "B" | "C",
+  byteCount: number,
+): string {
+  if (format === "A" || rawData.length !== byteCount || NON_LATIN1_RE.test(rawData)) {
+    return rawData;
+  }
+  const t = rawData.trimStart();
+  if (t.startsWith(":B64:") || t.startsWith(":Z64:")) return rawData;
+  return wrapGfB64(latin1ToBytes(rawData));
+}
+
+/** :B64:/:Z64: -> base64 (+inflate); A -> RLE-hex; raw B -> latin1 bytes
+ *  (length must match the count). C: only :Z64: decodes (ZDesigner form,
+ *  the inflate result IS the raster); raw/:B64: C stays compressed -> null. */
 export function gfPayloadToBytes(
   rawData: string,
   format: "A" | "B" | "C",
   bytesPerRow: number,
+  byteCount: number,
 ): GfPayloadDecoded | null {
   const wrapper = parseGfWrapper(rawData);
   if (wrapper) {
+    if (format === "C" && wrapper.kind === "b64") return null;
     const bytes =
       wrapper.kind === "z64" ? tryInflateZlib(wrapper.bytes) : wrapper.bytes;
     if (!bytes) return null;
     return { data: bytes, crcOk: wrapper.crcOk };
   }
+  if (format === "C") return null;
   if (format === "A") {
     return { data: gfaHexToBytes(decompressGFA(rawData, bytesPerRow)), crcOk: true };
+  }
+  if (rawData.length === byteCount && !NON_LATIN1_RE.test(rawData)) {
+    return { data: latin1ToBytes(rawData), crcOk: true, raw: true };
   }
   return null;
 }

--- a/packages/core/src/lib/zplParser/decoders/graphic.ts
+++ b/packages/core/src/lib/zplParser/decoders/graphic.ts
@@ -1,6 +1,7 @@
 import { putImage } from "../../imageCache";
 import { BITS_PER_BYTE } from "./constants";
 import { gfPayloadToBytes } from "./gfa";
+import { wrapGfB64 } from "./crc";
 import type { DecodedGraphic } from "../types";
 
 import { newId } from "../../ids";
@@ -22,7 +23,12 @@ export function decodeGraphicToImage(
   // Headless (Node/MCP): no canvas to paint the bitmap; degrade to the same
   // browserLimit path as an undecodable payload.
   if (typeof document === "undefined") return null;
-  const decoded = gfPayloadToBytes(rawData, format, bytesPerRow);
+  const decoded = gfPayloadToBytes(
+    rawData,
+    format,
+    bytesPerRow,
+    Number.parseInt(totalBytesHeader, 10),
+  );
   if (!decoded) return null;
   const widthDots = bytesPerRow * BITS_PER_BYTE;
   const heightDots = Math.floor(decoded.data.length / bytesPerRow);
@@ -62,7 +68,11 @@ export function decodeGraphicToImage(
     imageId,
     widthDots,
     heightDots,
-    gfaCache: `^GF${format},${totalBytesHeader},${dataBytesHeader},${bytesPerRow},${rawData}`,
+    // Raw binary re-encodes as A + :B64: of the raster (the ZDesigner-proven
+    // spec form, p.1602); b then equals c per the uncompressed convention.
+    gfaCache: decoded.raw
+      ? `^GFA,${decoded.data.length},${decoded.data.length},${bytesPerRow},${wrapGfB64(decoded.data)}`
+      : `^GF${format},${totalBytesHeader},${dataBytesHeader},${bytesPerRow},${rawData}`,
     crcOk: decoded.crcOk,
   };
 }

--- a/packages/core/src/lib/zplParser/handlers/graphics.ts
+++ b/packages/core/src/lib/zplParser/handlers/graphics.ts
@@ -6,6 +6,7 @@ import { loadFontBytesSync } from "../../fontCache";
 import { formatStoragePath, parseStoragePath } from "../../storagePath";
 import { getPosType, pushBrowserLimit, type ParserState } from "../context";
 import { decodeGraphicToImage } from "../decoders/graphic";
+import { preserveGfData } from "../decoders/gfa";
 import { extractQrSidecar } from "../../qrGraphic";
 import type { QrCodeProps } from "../../../registry/qrcode";
 import { dotsFor, ftTopLeft, int, makeObj, readColor, readRotation } from "../helpers";
@@ -179,11 +180,15 @@ export function createGraphicsHandlers(
     },
     GF(_, rest) {
       commitPendingReverseBg();
+      // Byte-counted payloads can be multi-KB binary; cap the finding text.
+      const gfSummary =
+        rest.length > IMPORT_FINDING_PAYLOAD_LIMIT
+          ? `^GF${rest.trimEnd().slice(0, IMPORT_FINDING_PAYLOAD_LIMIT)}…`
+          : `^GF${rest}`;
       // ^GF{A|B|C},{totalBytes},{totalBytes},{bytesPerRow},{payload}
-      // Payload: raw hex (fmt A, RLE-optional) or `:B64:` / `:Z64:` wrappers.
       const format = rest[0]?.toUpperCase();
       if (format !== "A" && format !== "B" && format !== "C") {
-        pushBrowserLimit(s.result, `^GF${rest}`);
+        pushBrowserLimit(s.result, gfSummary);
         return;
       }
 
@@ -197,7 +202,7 @@ export function createGraphicsHandlers(
         if (commaPos === -1) break;
       }
       if (commaPos === -1) {
-        pushBrowserLimit(s.result, `^GF${rest}`);
+        pushBrowserLimit(s.result, gfSummary);
         return;
       }
 
@@ -207,7 +212,7 @@ export function createGraphicsHandlers(
       const gfRawData = gfRest.slice(commaPos + 1);
 
       if (gfBytesPerRow <= 0) {
-        pushBrowserLimit(s.result, `^GF${rest}`);
+        pushBrowserLimit(s.result, gfSummary);
         return;
       }
 
@@ -241,7 +246,7 @@ export function createGraphicsHandlers(
             widthDots: opaqueWidth,
             heightDots: opaqueH,
             threshold: 128,
-            rawGf: `^GF${format},${gfParams[0]},${gfParams[1]},${gfParams[2]},${gfRawData}`,
+            rawGf: `^GF${format},${gfParams[0]},${gfParams[1]},${gfParams[2]},${preserveGfData(gfRawData, format, int(gfParams[0], -1))}`,
           } satisfies ImageProps,
           takeComment(),
         );

--- a/packages/core/src/lib/zplParser/helpers.ts
+++ b/packages/core/src/lib/zplParser/helpers.ts
@@ -3,6 +3,7 @@ import { isZplRotation, type ZplRotation } from "../../registry/rotation";
 import { opensImmediateCommand } from "../zplImmediate";
 
 import { newId } from "../ids";
+import { NON_LATIN1_RE } from "../binaryText";
 /** Validated ZplRotation or `fallback` (default 'N'). */
 export function readRotation(
   raw: string | undefined,
@@ -41,11 +42,104 @@ export function acceptsPrefixRemap(
   return !!char && char > " " && char !== "\x7F" && char !== roleA && char !== roleB;
 }
 
-/** Live command-prefix chars; the tokenizer reads these on every char
- *  scan so ^CC/^CT mutations take effect on the very next command. */
+/** Live command-prefix and delimiter chars; the tokenizer reads these on
+ *  every scan so ^CC/^CT/^CD mutations take effect on the next command. */
 export interface TokenizerChars {
   caretChar: string;
   tildeChar: string;
+  delimiterChar: string;
+}
+
+/** Raw-binary payload commands: header slots before data, format/count slot
+ *  indices, `formats` = letters whose count is the transmitted byte count
+ *  (^GF b: B and C, p.215; ~DY t is the decompressed size for C, p.182). */
+const BINARY_PAYLOAD_SPECS: Record<
+  string,
+  { params: number; format: number; count: number; formats: readonly string[] }
+> = {
+  GF: { params: 4, format: 0, count: 1, formats: ["B", "C"] },
+  DY: { params: 5, format: 1, count: 3, formats: ["B"] },
+};
+
+/** Sanity cap on the header span scanned for delimiters; real headers are a
+ *  path plus a few numerics, so a longer span means delimiter-less junk. */
+const BINARY_HEADER_CAP = 128;
+
+const UNSAFE_PAYLOAD_RE = /[^ -~]/;
+
+export interface UnsafeRawFieldSpan extends BinaryPayloadSpan {
+  start: number;
+}
+
+/** Byte-counted raw fields (^CC/^CT/^CD threaded like the parser) whose
+ *  counted payload cannot survive a UTF-8 decode collapse, CRLF
+ *  normalization, or a verbatim overlay replay. */
+export function unsafeRawFieldSpans(text: string): UnsafeRawFieldSpan[] {
+  const st: TokenizerChars = { caretChar: "^", tildeChar: "~", delimiterChar: "," };
+  const spans: UnsafeRawFieldSpan[] = [];
+  for (const t of tokenize(text, st)) {
+    const arg = t.rest[0];
+    if (t.cmd === "CC") { if (acceptsPrefixRemap(arg, st.tildeChar, st.delimiterChar)) st.caretChar = arg; continue; }
+    if (t.cmd === "CT") { if (acceptsPrefixRemap(arg, st.caretChar, st.delimiterChar)) st.tildeChar = arg; continue; }
+    if (t.cmd === "CD") { if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delimiterChar = arg; continue; }
+    if (t.cmd !== "GF" && t.cmd !== "DY") continue;
+    const span = binaryPayloadEnd(text, t.cmd, t.start + 3, st.delimiterChar);
+    if (!span) continue;
+    const payload = text.slice(span.dataStart, span.end);
+    // Chars above 0xFF (paste path) have no byte truth left to wrap; the
+    // verbatim string is the only faithful preserve (see preserveGfData).
+    if (UNSAFE_PAYLOAD_RE.test(payload) && !NON_LATIN1_RE.test(payload)) {
+      spans.push({ start: t.start, ...span });
+    }
+  }
+  return spans;
+}
+
+export interface BinaryPayloadSpan {
+  dataStart: number;
+  end: number;
+  /** Slot bounds of the format letter, for a text-safe transcode. */
+  formatStart: number;
+  formatEnd: number;
+  format: "B" | "C";
+}
+
+/** Data span of a byte-counted raw binary payload; null keeps the
+ *  prefix-scan boundary (ASCII formats, wrappers, broken headers, and a
+ *  count past the end of input, where the device would sit waiting). */
+function binaryPayloadEnd(
+  zpl: string,
+  cmd: string,
+  restStart: number,
+  delimiter: string,
+): BinaryPayloadSpan | null {
+  const spec = BINARY_PAYLOAD_SPECS[cmd];
+  if (!spec) return null;
+  const params: string[] = [];
+  let p = restStart;
+  let formatStart = restStart;
+  let formatEnd = restStart;
+  for (let n = 0; n < spec.params; n++) {
+    const next = zpl.indexOf(delimiter, p);
+    if (next === -1 || next - restStart > BINARY_HEADER_CAP) return null;
+    params.push(zpl.slice(p, next));
+    if (n === spec.format) {
+      formatStart = p;
+      formatEnd = next;
+    }
+    p = next + 1;
+  }
+  const format = params[spec.format]?.trim().toUpperCase();
+  if ((format !== "B" && format !== "C") || !spec.formats.includes(format)) return null;
+  // Only genuine wrappers opt out; a raster whose first byte is ":" must
+  // still be read byte-counted. parseGfWrapper trims, so skip whitespace too.
+  let q = p;
+  while (q < zpl.length && /\s/.test(zpl[q] ?? "")) q++;
+  if (zpl.startsWith(":B64:", q) || zpl.startsWith(":Z64:", q)) return null;
+  const count = Number.parseInt(params[spec.count] ?? "", 10);
+  if (count <= 0 || Number.isNaN(count)) return null;
+  const end = p + count;
+  return end <= zpl.length ? { dataStart: p, end, formatStart, formatEnd, format } : null;
 }
 
 /** Command-name alphabet: a prefix char outside it can never be part of a
@@ -117,6 +211,12 @@ export function* tokenize(
       const argChar = zpl[cmdStart + 3] ?? "";
       pos = cmdStart + 4;
       yield { cmd, rest: argChar, start: cmdStart, end: pos };
+      continue;
+    }
+    const bin = binaryPayloadEnd(zpl, cmd, cmdStart + 3, chars.delimiterChar);
+    if (bin !== null) {
+      pos = bin.end;
+      yield { cmd, rest: zpl.slice(cmdStart + 3, bin.end), start: cmdStart, end: bin.end };
       continue;
     }
     const boundary = PAYLOAD_CMDS.has(cmd) ? isCmdStartInPayload : isCmdStart;

--- a/packages/core/src/registry/image.ts
+++ b/packages/core/src/registry/image.ts
@@ -129,6 +129,14 @@ function gfaCacheUsable(p: ImageProps): boolean {
   return !!p._gfaCache && objectRotation(p) === 'N' && gfaHeaderDims(p._gfaCache) !== null;
 }
 
+/** Fresh upright ^GFA from the image store, for emit sites that need bytes
+ *  after a cache-clearing edit (canvas resize regens only via the panel). */
+export function inlineGfaFor(p: ImageProps): string | undefined {
+  const img = getImage(p.imageId);
+  if (!img) return undefined;
+  return gfaSync(img.dataUrl, p.widthDots, p.threshold, 'N') || undefined;
+}
+
 export const image: ObjectTypeCore<ImageProps> = {
   label: 'Image',
   icon: 'img',

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -415,12 +415,14 @@ describe("mcp-server tools", () => {
     expect(created.geometryTruncated).toBeUndefined();
   });
 
-  it("counts the size cap in bytes, not UTF-16 code units", () => {
-    // ~200k '€' = 200k code units but ~600k UTF-8 bytes, over the 256 KB cap.
-    const multibyte = "^XA^FO10,10^FD" + "€".repeat(200_000) + "^FS^XZ";
-    expect(multibyte.length).toBeLessThan(256 * 1024);
-    const v = validateZpl(multibyte);
-    expect(v.ok).toBe(false);
+  it("admits a byte-per-char binary stream up to the full cap", () => {
+    // The cap counts code units: UTF-8 byteLength would double-count latin1
+    // binary payloads and reject valid streams at half the documented limit.
+    const bin = String.fromCharCode(0x80).repeat(200_000);
+    const v = validateZpl(`^XA^FO0,0^GFB,200000,200000,250,${bin}^FS^XZ`);
+    expect(v.ok).toBe(true);
+    const over = validateZpl("^XA^FO10,10^FD" + "x".repeat(262_144) + "^FS^XZ");
+    expect(over.ok).toBe(false);
   });
 
   it("counts group children against the object cap (no smuggling via subtree)", () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -432,16 +432,16 @@ export function exportZpl(designFile: unknown): ExportZplResult {
 const DEFAULT_WIDTH_MM = 100;
 const DEFAULT_HEIGHT_MM = 50;
 
-/** Byte budget for a raw ZPL stream. Import retains overlay bytes and
- *  re-serializes, so an oversized stream costs several copies plus O(n²)
- *  geometry; real labels are far under this. */
-const MAX_ZPL_BYTES = 256 * 1024;
+/** Size budget (UTF-16 code units) for a raw ZPL stream. Import retains
+ *  overlay bytes and re-serializes, so an oversized stream costs several
+ *  copies plus O(n²) geometry; real labels are far under this. */
+const MAX_ZPL_CHARS = 256 * 1024;
 
 function oversizeError(zpl: string): ToolError | null {
-  // Byte length, not zpl.length: multibyte ^FD content is up to ~4x the code
-  // unit count, which would slip past the memory budget the cap protects.
-  return Buffer.byteLength(zpl, "utf8") > MAX_ZPL_BYTES
-    ? { ok: false, errors: [`ZPL exceeds the ${MAX_ZPL_BYTES}-byte limit`] }
+  // Code units, not UTF-8 bytes: cost scales with units, and byteLength
+  // would double-count byte-per-char binary payloads.
+  return zpl.length > MAX_ZPL_CHARS
+    ? { ok: false, errors: [`ZPL exceeds the ${MAX_ZPL_CHARS}-character limit`] }
     : null;
 }
 

--- a/src/components/Output/ZplImportModal.tsx
+++ b/src/components/Output/ZplImportModal.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { XMarkIcon, ClipboardDocumentIcon, CheckIcon, FolderOpenIcon } from '@heroicons/react/16/solid';
 import { importZplText, routeSetupCommands, mergeSetupFonts, rebaseAppendedPageDensity, replaceImportLabel, type ZplImportResult, type SetupCommandChoice } from '@zplab/core/lib/zplImportService';
-import { readFileAsText } from '../../lib/readFile';
+import { readFileAsZplText } from '../../lib/readFile';
 import { useLabelStore } from '../../store/labelStore';
 import type { Page } from '@zplab/core/types/Group';
 import type { LabelConfig } from '@zplab/core/types/LabelConfig';
@@ -142,7 +142,7 @@ export function ZplImportModal({ onClose }: Props) {
     setError(null);
     let text: string;
     try {
-      text = await readFileAsText(file);
+      text = await readFileAsZplText(file);
     } catch {
       setError(t.importModal.errFileRead);
       return;

--- a/src/lib/readFile.test.ts
+++ b/src/lib/readFile.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { zplBytesToText } from "./readFile";
+
+describe("zplBytesToText", () => {
+  it("decodes valid UTF-8 normally", () => {
+    const bytes = new TextEncoder().encode("^XA^FDÄhreü^FS^XZ");
+    expect(zplBytesToText(bytes)).toBe("^XA^FDÄhreü^FS^XZ");
+  });
+
+  it("reads a raw binary field byte-per-char even when the file is valid UTF-8", () => {
+    // C3 A9 is a valid UTF-8 pair; collapsing it to one char would shift the
+    // byte-counted payload span.
+    const head = "^XA^FO0,0^GFB,8,8,1,";
+    const tail = "^FS^XZ";
+    const payload = [0xc3, 0xa9, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46];
+    const bytes = new Uint8Array([
+      ...Array.from(head, (c) => c.charCodeAt(0)),
+      ...payload,
+      ...Array.from(tail, (c) => c.charCodeAt(0)),
+    ]);
+    const text = zplBytesToText(bytes);
+    expect(text.length).toBe(bytes.length);
+    expect(text.charCodeAt(head.length)).toBe(0xc3);
+  });
+
+  it("threads ^CD remaps when sniffing raw binary fields", () => {
+    // A remapped delimiter must not hide the field from the byte-per-char
+    // decision; the sniffer walks the same tokenizer as the parser.
+    const head = "^XA^CD;^GFB;8;8;1;";
+    const tail = "^FS^XZ";
+    const payload = [0xc3, 0xa9, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46];
+    const bytes = new Uint8Array([
+      ...Array.from(head, (c) => c.charCodeAt(0)),
+      ...payload,
+      ...Array.from(tail, (c) => c.charCodeAt(0)),
+    ]);
+    expect(zplBytesToText(bytes).length).toBe(bytes.length);
+  });
+
+  it("decodes text gaps as UTF-8 while payload spans stay byte-per-char", () => {
+    // Mixed stream: the ^FD text keeps its encoding, the counted payload its
+    // bytes; neither may bleed into the other.
+    const A_UML = [0xc3, 0x84];
+    const head = "^XA^CI28^FD";
+    const mid = "hre^FS^GFB,8,8,1,";
+    const payload = [0xc3, 0xa9, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46];
+    const tail = "^FS^XZ";
+    const bytes = new Uint8Array([
+      ...Array.from(head, (c) => c.charCodeAt(0)),
+      ...A_UML,
+      ...Array.from(mid, (c) => c.charCodeAt(0)),
+      ...payload,
+      ...Array.from(tail, (c) => c.charCodeAt(0)),
+    ]);
+    const text = zplBytesToText(bytes);
+    expect(text).toContain("^FD" + String.fromCharCode(0xc4) + "hre");
+    const at = text.indexOf("^GFB,8,8,1,") + "^GFB,8,8,1,".length;
+    expect(Array.from(text.slice(at, at + 8), (c) => c.charCodeAt(0))).toEqual(payload);
+  });
+
+  it("honours a UTF-16 BOM like readAsText did", () => {
+    const chars = "^XA^FDX^FS^XZ";
+    const bytes = new Uint8Array(2 + chars.length * 2);
+    bytes[0] = 0xff;
+    bytes[1] = 0xfe;
+    for (let i = 0; i < chars.length; i++) bytes[2 + i * 2] = chars.charCodeAt(i);
+    expect(zplBytesToText(bytes)).toBe(chars);
+  });
+
+  it("falls back to byte-per-char for invalid UTF-8 (raw binary payloads)", () => {
+    // 0x80-0x9F must survive identically; TextDecoder latin1 labels alias
+    // windows-1252 and would remap them.
+    const bytes = new Uint8Array([0x5e, 0x47, 0x46, 0x42, 0x80, 0x9f, 0xff, 0x00]);
+    const text = zplBytesToText(bytes);
+    expect(Array.from(text, (c) => c.charCodeAt(0))).toEqual(Array.from(bytes));
+  });
+});

--- a/src/lib/readFile.ts
+++ b/src/lib/readFile.ts
@@ -1,8 +1,51 @@
+import { bytesToLatin1 } from "@zplab/core/lib/binaryText";
+import { unsafeRawFieldSpans } from "@zplab/core/lib/zplParser/helpers";
+
 export function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => resolve(e.target?.result as string);
     reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
     reader.readAsText(file);
+  });
+}
+
+/** UTF-8 when valid, else byte-per-char. */
+function decodeTextGap(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return bytesToLatin1(bytes);
+  }
+}
+
+/** BOM-declared encoding first (readAsText sniffed these too); raw counted
+ *  payload spans stay byte-per-char (a valid-UTF-8 pair must not collapse to
+ *  one char), the text between them decodes normally. */
+export function zplBytesToText(bytes: Uint8Array): string {
+  if (bytes[0] === 0xff && bytes[1] === 0xfe) return new TextDecoder("utf-16le").decode(bytes);
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) return new TextDecoder("utf-16be").decode(bytes);
+  const raw = bytesToLatin1(bytes);
+  const spans = unsafeRawFieldSpans(raw);
+  if (spans.length === 0) return decodeTextGap(bytes);
+  let out = "";
+  let cursor = 0;
+  for (const sp of spans) {
+    out += decodeTextGap(bytes.subarray(cursor, sp.dataStart));
+    out += raw.slice(sp.dataStart, sp.end);
+    cursor = sp.end;
+  }
+  return out + decodeTextGap(bytes.subarray(cursor));
+}
+
+/** ZPL streams may carry raw binary ^GF/~DY payloads that readAsText would
+ *  destroy. */
+export function readFileAsZplText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) =>
+      resolve(zplBytesToText(new Uint8Array(e.target?.result as ArrayBuffer)));
+    reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
+    reader.readAsArrayBuffer(file);
   });
 }

--- a/src/lib/zplImportService.test.ts
+++ b/src/lib/zplImportService.test.ts
@@ -616,6 +616,72 @@ describe('routeSetupCommands', () => {
   });
 });
 
+describe('raw binary payloads across import -> export', () => {
+  it('re-emits a raw binary ^GFB text-safe instead of replaying raw bytes', () => {
+    // A verbatim replay of the raw binary span would be corrupted by the
+    // UTF-8 write-out; it must re-emit from the wrapped model bytes.
+    const bin = String.fromCharCode(0x5e, 0x46, 0x53, 0x2c, 0x7e, 0x80, 0xff, 0x0a);
+    const zpl = `^XA^FO0,0^GFB,8,8,1,${bin}^FS^XZ`;
+    const imported = importZplText(zpl, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    const out = generateMultiPageZPL(label, imported.pages);
+    expect(out).toContain(':B64:');
+    expect(/[^\t\n\r\x20-\x7E]/.test(out)).toBe(false);
+  });
+});
+
+describe('byte-counted text-safe payloads across import -> export', () => {
+  it('re-emits a LF-bearing byte-counted ^GFB wrapped instead of verbatim', () => {
+    // The bytes survive our own write, but any CRLF-normalizing hop would
+    // shift the count; the model cache is wrapped, the replay must use it.
+    const bin = 'AB' + String.fromCharCode(10) + 'CD' + String.fromCharCode(10) + 'EF';
+    const imported = importZplText(`^XA^FO0,0^GFB,8,8,1,${bin}^FS^XZ`, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    const out = generateMultiPageZPL(label, imported.pages);
+    expect(out).toContain(':B64:');
+  });
+
+  it('replays untouched non-ASCII text segments verbatim (no false binary flag)', () => {
+    // Non-ASCII is legitimate ^FD text; regenerating it would drop original
+    // syntax like the ^CD remap alongside it.
+    const src = '^XA^CD;^FO10;10^A0N;30;0^FDÄhre^FS^XZ';
+    const imported = importZplText(src, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    const out = generateMultiPageZPL(label, imported.pages);
+    expect(out).toContain('^CD;');
+    expect(out).toContain('^FDÄhre');
+  });
+
+  it('keeps an orphan raw ~DY upload text-safe on export (no ^XG consumer)', () => {
+    // No model object carries the upload; the raw segment itself must,
+    // rewritten to the A + :B64: form instead of dropped by a full regen.
+    const bin = String.fromCharCode(0x5e, 0x00, 0xff, 0x2c);
+    const imported = importZplText(`^XA~DYR:ORPH,B,G,4,1,${bin}^FO10,10^A0N,20,0^FDx^FS^XZ`, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    const out = generateMultiPageZPL(label, imported.pages);
+    expect(out).toContain('~DYR:ORPH,A,G,4,1,:B64:');
+    expect(/[^\t\n\r\x20-\x7E]/.test(out)).toBe(false);
+  });
+
+  it('leaves a pasted non-latin1 payload verbatim instead of masking bytes', () => {
+    // U+20AC has no byte truth left; a latin1 wrap would silently turn it
+    // into 0xAC.
+    const src = '^XA~DYR:EURO,B,G,4,1,€ABC^FO10,10^A0N,20,0^FDx^FS^XZ';
+    const imported = importZplText(src, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    const out = generateMultiPageZPL(label, imported.pages);
+    expect(out).toContain('~DYR:EURO,B,G,4,1,€ABC');
+    expect(out).not.toContain(':B64:');
+  });
+
+  it('applies the wrap rule behind a ^CD delimiter remap too', () => {
+    const bin = 'AB' + String.fromCharCode(10) + 'CD' + String.fromCharCode(10) + 'EF';
+    const imported = importZplText(`^XA^CD;^FO0;0^GFB;8;8;1;${bin}^FS^XZ`, 8);
+    const label = { widthMm: 100, heightMm: 60, dpmm: 8, ...imported.labelConfig } as LabelConfig;
+    expect(generateMultiPageZPL(label, imported.pages)).toContain(':B64:');
+  });
+});
+
 describe('replay-risk report helpers', () => {
   it('replayRiskFindings selects only the replayRisk kind', () => {
     const { report } = importZplText('^XA^KNfoo^FO0,0^A@N,20,0,E:A.TTF^FDx^FS^XZ', 8);

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -5,6 +5,7 @@ import { generateZPL } from '@zplab/core/lib/zplGenerator';
 import { formatLabelMetaComment } from '@zplab/core/lib/zplLabelMeta';
 import { ObjectRegistry } from '@zplab/core/registry';
 import { defined, props, serialOf, parseSingle, commandsOf } from '../test/helpers';
+import { parseGfWrapper } from '@zplab/core/lib/zplParser/decoders/crc';
 
 // Drift guard for the bare-^BY hazard set. Every 1D and postal barcode emits a
 // ^BY on regen, so it must be classified ^BY-consuming; a forgotten new one
@@ -1286,6 +1287,156 @@ describe('parseZPL — ^FX label metadata sidecar', () => {
   });
 });
 
+// ── raw binary ^GF payloads (byte-counted) ───────────────────────────────────
+
+describe('parseZPL — raw binary ^GF payloads', () => {
+  // Contains a literal "^FS", the delimiter, a tilde and high bytes: every
+  // way a prefix-scanned tokenizer would split the field early.
+  const BIN = String.fromCharCode(0x5e, 0x46, 0x53, 0x2c, 0x7e, 0x80, 0xff, 0x0a);
+
+  it('decodes a raw ^GFB payload and keeps parsing after it', () => {
+    const { objects, findings } = parseSingle(
+      `^XA^FO0,0^GFB,8,8,1,${BIN}^FS^FO0,20^A0N,30,30^FDAFTER^FS^XZ`,
+      8,
+    );
+    expect(objects).toHaveLength(2);
+    const img = props(objects[0]);
+    expect(objects[0]?.type).toBe('image');
+    expect(img.widthDots).toBe(8);
+    expect(img.heightDots).toBe(8);
+    expect(img.imageId).toBeTruthy();
+    // The cache re-encodes the raster as A + :B64: (the ZDesigner-proven spec
+    // form); UTF-8 write-out of the emitted ZPL must not corrupt it.
+    expect(img._gfaCache).toMatch(/^\^GFA,8,8,1,:B64:/);
+    const wrapped = parseGfWrapper(String(img._gfaCache).slice('^GFA,8,8,1,'.length));
+    expect(wrapped?.crcOk).toBe(true);
+    expect(Array.from(wrapped?.bytes ?? [])).toEqual(
+      Array.from(BIN, (c) => c.charCodeAt(0)),
+    );
+    expect(props(objects[1]).content).toBe('AFTER');
+    expect(commandsOf({ findings }, 'browserLimit')).toHaveLength(0);
+    expect(commandsOf({ findings }, 'partial')).not.toContain('^GF');
+  });
+
+  it('preserves a raw ^GFC payload byte-counted and text-safe', () => {
+    // Zebra's compressed-binary scheme is proprietary: no raster, but the
+    // bytes survive as a :B64:-wrapped rawGf and the stream keeps parsing.
+    const bin = String.fromCharCode(0x5e, 0x58, 0x5a, 0x81); // literal "^XZ" + high byte
+    const { objects, findings } = parseSingle(`^XA^FO0,0^GFC,4,16,2,${bin}^FS^XZ`, 8);
+    expect(objects).toHaveLength(1);
+    const p = props(objects[0]);
+    expect(p.widthDots).toBe(16);
+    expect(p.heightDots).toBe(8);
+    expect(String(p.rawGf)).toMatch(/^\^GFC,4,16,2,:B64:/);
+    const wrapped = parseGfWrapper(String(p.rawGf).slice('^GFC,4,16,2,'.length));
+    expect(Array.from(wrapped?.bytes ?? [])).toEqual(
+      Array.from(bin, (c) => c.charCodeAt(0)),
+    );
+    expect(commandsOf({ findings }, 'partial')).toContain('^GF');
+  });
+
+  it('does not latch a ^JM density from bytes inside a binary payload', () => {
+    // "^JMB," parses as a clean ^JM token when the payload is prefix-scanned.
+    const jmBin = '^JMB,' + String.fromCharCode(0x80, 0x81, 0x82);
+    const { labelConfig } = parseSingle(`^XA^FO0,0^GFB,8,8,1,${jmBin}^FS^XZ`, 8);
+    expect(labelConfig.jmDensity).toBeUndefined();
+  });
+
+  it('keeps the prefix-scan boundary when the byte count is invalid', () => {
+    // b missing/zero means the device ignores the command; the payload is
+    // ASCII here, so the verbatim preserve stays byte-exact (no wrapper).
+    const { objects } = parseSingle('^XA^FO0,0^GFB,0,8,1,AB^FS^XZ', 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).rawGf).toBe('^GFB,0,8,1,AB');
+  });
+
+  it('reads a raw payload whose first byte is a colon byte-counted', () => {
+    // Only genuine :B64:/:Z64: wrappers opt out of the byte-counted read.
+    const bin = ':' + String.fromCharCode(0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86);
+    const { objects } = parseSingle(`^XA^FO0,0^GFB,8,8,1,${bin}^FS^XZ`, 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).imageId).toBeTruthy();
+  });
+
+  it('honours a wrapper behind leading whitespace (no byte-counted read)', () => {
+    // parseGfWrapper trims, so the opt-out must too.
+    const b64 = btoa(String.fromCharCode(0, 255, 0, 255));
+    const field = ':B64:' + b64 + ':' + testCrc16(b64);
+    const nl = String.fromCharCode(10);
+    const { objects } = parseSingle('^XA^FO0,0^GFB,4,4,1,' + nl + field + '^FS^XZ', 8);
+    expect(objects).toHaveLength(1);
+    expect(props(objects[0]).imageId).toBeTruthy();
+  });
+
+  it('wraps a byte-counted payload of text-safe bytes too (CRLF hazard)', () => {
+    // LF bytes are load-bearing data here; an unwrapped emit would break on
+    // newline normalization.
+    const bin = 'AB' + String.fromCharCode(10) + 'CD' + String.fromCharCode(10) + 'EF';
+    const { objects } = parseSingle(`^XA^FO0,0^GFB,8,8,1,${bin}^FS^XZ`, 8);
+    expect(props(objects[0])._gfaCache).toMatch(/^\^GFA,8,8,1,:B64:/);
+  });
+
+  it('keeps a format-A cache verbatim even with a stray control byte', () => {
+    // The NUL is noise in hex text; wrapping would base64 the hex CHARS as
+    // if they were raster bytes and silently replace the bitmap.
+    const { objects } = parseSingle(`^XA^FO0,0^GFA,6,6,1,FF00FF00FF00${String.fromCharCode(0)}^FS^XZ`, 8);
+    const cache = String(props(objects[0])._gfaCache);
+    expect(cache).not.toContain(':B64:');
+    expect(cache).toContain('FF00FF00FF00');
+  });
+
+  it('never decodes format C, wrapper or not (data stays Zebra-compressed)', () => {
+    const b64 = btoa('AAAA');
+    const field = `:B64:${b64}:${testCrc16(b64)}`;
+    const { objects, findings } = parseSingle(`^XA^FO0,0^GFC,4,16,2,${field}^FS^XZ`, 8);
+    expect(props(objects[0]).rawGf).toBe(`^GFC,4,16,2,${field}`);
+    expect(props(objects[0]).imageId).toBeFalsy();
+    expect(commandsOf({ findings }, 'partial')).toContain('^GF');
+  });
+
+  it('preserves a non-byte-per-char payload verbatim (paste path)', () => {
+    // Chars above 0xFF cannot round-trip through latin1; the exact string is
+    // the only faithful preserve.
+    const field = '€ABC';
+    const { objects } = parseSingle(`^XA^FO0,0^GFC,4,16,2,${field}^FS^XZ`, 8);
+    expect(props(objects[0]).rawGf).toBe(`^GFC,4,16,2,${field}`);
+  });
+
+  it('does not byte-count a compressed ~DY (t is the decompressed size)', () => {
+    // Spec p.182: for b=C, t counts bytes AFTER decompression; trusting it
+    // would swallow following labels.
+    const zpl =
+      `~DYR:LOGO,C,G,20,1,ABCD
+` +
+      '^XA^FO10,10^A0N,20,0^FDfirst^FS^XZ^XA^FO10,10^A0N,20,0^FDsecond^FS^XZ';
+    const r = parseZPL(zpl, 8);
+    expect(r.pages).toHaveLength(2);
+  });
+
+  it('caps a binary ^GF browserLimit finding instead of dumping the payload', () => {
+    // bytesPerRow=0 rejects after the byte-counted consume; the finding must
+    // not carry the whole blob.
+    const blob = String.fromCharCode(...Array.from({ length: 200 }, (_, i) => 0x80 + (i % 64)));
+    const { findings } = parseSingle(`^XA^FO0,0^GFB,200,200,0,${blob}^FS^XZ`, 8);
+    const gf = commandsOf({ findings }, 'browserLimit').find((c) => c.startsWith('^GF'));
+    expect(gf).toBeDefined();
+    expect(gf!.length).toBeLessThan(120);
+  });
+
+  it('decodes a raw binary ~DY graphic upload for ^XG recall', () => {
+    const bin = String.fromCharCode(0x5e, 0x00, 0xff, 0x2c); // "^", NUL, high byte, ","
+    const zpl =
+      `~DYR:BLOB,B,G,4,1,${bin}
+` +
+      '^XA^FO50,80^XGR:BLOB.GRF,1,1^FS^XZ';
+    const { objects, findings } = parseSingle(zpl, 8);
+    expect(objects).toHaveLength(1);
+    expect(objects[0]?.type).toBe('image');
+    expect(props(objects[0]).widthDots).toBe(8);
+    expect(commandsOf({ findings }, 'browserLimit')).toHaveLength(0);
+  });
+});
+
 // ── ~DY graphic upload + ^XG recall ──────────────────────────────────────────
 
 describe('parseZPL — ~DY + ^XG graphic upload/recall', () => {
@@ -2538,6 +2689,8 @@ describe('parseZPL — unknown findings', () => {
   });
 
   it('preserves an undecodable ^GFB format as an opaque verbatim image', () => {
+    // b=32 overruns the stream end; the byte-counted read declines (a device
+    // would sit waiting) and the prefix scan preserves the span verbatim.
     const { objects, findings } = parseSingle('^XA^FO0,0^GFB,32,32,4,AABBCCDD^FS^XZ', 8);
     expect(objects).toHaveLength(1);
     expect(objects[0]?.type).toBe('image');


### PR DESCRIPTION
Raw ^GFB decodes to a bitmap (cache re-encoded as ^GFA + :B64:), raw ^GFC survives wrapped, the overlay replay re-emits binary spans text-safe, and the ZPL file import reads bytes so payloads reach the tokenizer intact.