### PR TITLE
fix(zpl): size single-line device-font footprints by the snapped cell

### DIFF
--- a/packages/core/src/lib/objectBounds.ts
+++ b/packages/core/src/lib/objectBounds.ts
@@ -22,7 +22,8 @@ import type { Variable } from "../types/Variable";
 import { effectiveDpmm } from "../types/LabelConfig";
 import { isAxisSwapped, objectRotation, type ZplRotation } from "../registry/rotation";
 import { resolveTextMode } from "../registry/text";
-import { blockBoundsDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, rotatedLineOffset, tbBoundsDots, zebraLineWidthDots } from "./zebraTextLayout";
+import { blockBoundsDots, blockLineWidthDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, isPrintedBlank, rotatedLineOffset, tbBoundsDots } from "./zebraTextLayout";
+import { effectiveFontHeightDots } from "./labelGeometry/deviceFonts";
 import { resolveDefaultSizeDots } from "./resolveDefaultSize";
 import { mmToDots } from "./coordinates";
 import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "./bwipConstants";
@@ -87,12 +88,20 @@ function fallbackSizeDots(
  *  snap) would center on a zero-width box left of what is drawn. */
 function singleLineEstimate(
   obj: LeafObject & { props: { content: string; fontHeight: number; fontWidth: number; rotation: ZplRotation } },
+  deviceFontId?: string,
 ): { width: number; height: number } {
   const { content, fontHeight, fontWidth, rotation } = obj.props;
-  const width = isBlankText(content)
-    ? fontHeight * EMPTY_TEXT_PLACEHOLDER_GLYPHS
-    : zebraLineWidthDots(content, fontHeight, fontWidth);
-  return rotatedFootprint(width, fontHeight, rotation);
+  // Blank keeps the raw-height placeholder the canvas draws (prints nothing,
+  // and the off-label check skips it); printed content uses the effective
+  // cell so device fonts don't over-report by the snap delta.
+  if (isPrintedBlank(content, deviceFontId)) {
+    return rotatedFootprint(fontHeight * EMPTY_TEXT_PLACEHOLDER_GLYPHS, fontHeight, rotation);
+  }
+  return rotatedFootprint(
+    blockLineWidthDots(content, fontHeight, fontWidth, deviceFontId),
+    effectiveFontHeightDots(deviceFontId, fontHeight),
+    rotation,
+  );
 }
 
 /** True when a QR emits as a rotated ^GFA (no ^BQ firmware shifts, plain
@@ -325,7 +334,9 @@ function objectBoxDots(obj: LabelObject, ctx: ObjectBoundsCtx): BoundingBoxDots 
       }
       // Measured is the already-rotated footprint (the producer rotates it); the
       // fallback estimate computes upright and rotates itself.
-      const fp = ctx.measured?.get(obj.id) ?? singleLineEstimate(obj);
+      const fp =
+        ctx.measured?.get(obj.id) ??
+        singleLineEstimate(obj, resolveDeviceFontId(p.fontId, p.printerFontName, ctx.label));
       const off = rotatedLineOffset(p.rotation, fp.width, fp.height);
       return { x: obj.x + off.x, y: obj.y + off.y, width: fp.width, height: fp.height };
     }

--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -6,6 +6,7 @@ import {
   type ObjectBoundsCtx,
 } from "./objectBounds";
 import { emittedAnchorDots } from "./emittedAnchor";
+import { resolveDeviceFontId } from "./customFonts";
 import { suspiciousCharDetail } from "./suspiciousChars";
 import { GS1_GS, parseGs1ToSegments, typedGs1Parts, typedGs1Shape, validateGs1Segment, validateGs1SegmentResolved } from "./gs1";
 import { DATAMATRIX_FD_ESCAPE, typedGs1ToDataMatrixFd } from "./dataMatrixFd";
@@ -18,7 +19,7 @@ import { classifyField, isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
 import { fnConsumerBuckets, isModeDLeaf } from "./gs1ModeDFns";
-import { isBlankText } from "./zebraTextLayout";
+import { isPrintedBlank } from "./zebraTextLayout";
 import { resolveTextMode } from "../registry/text";
 import type { ColumnMapping, Variable } from "../types/Variable";
 import type { Unit } from "./units";
@@ -347,10 +348,17 @@ export function computePreflight(
     }
     const content = getObjectStringContent(leaf);
     const box = objectBoundsDots(leaf, ctx);
-    // A blank text field draws a placeholder (its bounds) but emits an empty
-    // ^FD, so it prints nothing: skip off-label here, the emptyContent check
-    // below owns the blank-field signal.
-    const blankText = leaf.type === "text" && content !== undefined && isBlankText(content);
+    const textProps = leaf.type === "text"
+      ? (leaf.props as { fontId?: string; printerFontName?: string })
+      : undefined;
+    const deviceFontId = textProps
+      ? resolveDeviceFontId(textProps.fontId, textProps.printerFontName, ctx.label)
+      : undefined;
+    // A printed-blank text field draws a placeholder but emits nothing
+    // visible: skip off-label here, the emptyContent check below owns the
+    // blank-field signal.
+    const blankText =
+      leaf.type === "text" && content !== undefined && isPrintedBlank(content, deviceFontId);
     if (!blankText) {
       const placement = offLabelPlacement(
         emittedAnchorDots(leaf, ctx, box),
@@ -418,10 +426,12 @@ export function computePreflight(
           severity: PREFLIGHT_SEVERITY.suspiciousChars,
           detail,
         });
-      } else if (content.trim() === "") {
-        // Raw content on purpose: markers make content non-empty, so bound and
-        // template fields never fire here; a blank literal (or serial seed) is
-        // the never-configured state that prints a gap.
+      } else if (
+        leaf.type === "text" ? isPrintedBlank(content, deviceFontId) : content.trim() === ""
+      ) {
+        // Markers survive the check (case folding protects them), so bound and
+        // template fields never fire here; a blank literal, serial seed or a
+        // case-folded-empty device-font field is the state that prints a gap.
         findings.push({
           objectId: leaf.id,
           kind: "emptyContent",

--- a/packages/core/src/lib/zebraTextLayout.ts
+++ b/packages/core/src/lib/zebraTextLayout.ts
@@ -2,7 +2,7 @@
 // compute against fixed advance to match Labelary.
 
 import { dotsToPx, pxToDots } from "./coordinates";
-import { deviceFontInkWidthDots, deviceFontSnappedHeightDots, deviceFontSnappedWidthDots, effectiveFontHeightDots } from "./labelGeometry/deviceFonts";
+import { applyDeviceFontCase, deviceFontInkWidthDots, deviceFontSnappedHeightDots, deviceFontSnappedWidthDots, effectiveFontHeightDots } from "./labelGeometry/deviceFonts";
 import { EM_TOP_ABOVE_CAP } from "./labelGeometry/textPositionTransforms";
 import { isAxisSwapped, type ZplRotation } from "../registry/rotation";
 
@@ -40,6 +40,13 @@ const A0_CHAR_ADVANCE: Record<string, number> = {
 
 export function zebraGlyphAdvanceDots(fontHeight: number, fontWidth: number): number {
   return fontWidth > 0 ? fontWidth : fontHeight * A0_DEFAULT_ASPECT;
+}
+
+/** True when a text field prints no glyphs: blank content, or content a
+ *  device font's case folding drops entirely (font H strips lowercase).
+ *  The one blank decision canvas, bounds and preflight share. */
+export function isPrintedBlank(content: string, deviceFontId?: string): boolean {
+  return isBlankText(applyDeviceFontCase(deviceFontId, content));
 }
 
 /** Line width in the basis the firmware advances: device cells for A-H,

--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -22,8 +22,9 @@ import { selectionHandlers, shapeHitProps, useBlankFieldWarns, CAPTURE_CHROME, P
 import { setMeasuredBounds, clearMeasuredBounds } from "./measuredBoundsCache";
 import { DEFAULT_GS_SYMBOL_META, GS_SYMBOLS } from "@zplab/core/registry/symbol";
 import { GS_SYMBOL_PATHS, GS_VECTOR_CODES, type GsVectorCode } from "../../registry/gsSymbolPaths";
-import { blockBoundsDots, blockJustifyWordPositions, blockLineStartDots, blockLineStepDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, tbBoundsDots, tbLineStepDots, wrapBlockLines, zebraAlignOffsetDots, zebraHangingIndentOffsetDots, zebraJustifyGapDots, zebraLineWidthDots, type ZplRotation } from "@zplab/core/lib/zebraTextLayout";
+import { isPrintedBlank, blockBoundsDots, blockJustifyWordPositions, blockLineStartDots, blockLineStepDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isBlankText, tbBoundsDots, tbLineStepDots, wrapBlockLines, zebraAlignOffsetDots, zebraHangingIndentOffsetDots, zebraJustifyGapDots, zebraLineWidthDots, type ZplRotation } from "@zplab/core/lib/zebraTextLayout";
 import { resolveTextMode } from "@zplab/core/registry/text";
+import { effectiveFontHeightDots } from "@zplab/core/lib/labelGeometry/deviceFonts";
 import { isAxisSwapped } from "@zplab/core/registry/rotation";
 import { ctrlParityFor, type LeafObject } from "@zplab/core/registry";
 import type { TextProps } from "@zplab/core/registry/text";
@@ -552,10 +553,17 @@ function KonvaObjectInner({
   const isSingleLineText =
     obj.type === "text" && !!textMetrics && resolveTextMode(obj.props) === "normal";
   const inkWidthDots = textMetrics?.inkWidthDots ?? 0;
-  const fontHeightDots = obj.type === "text" ? obj.props.fontHeight : 0;
+  // Footprint height: device fonts occupy their snapped cell, not the
+  // requested height, so bounds/right-anchor math must use the same.
+  const fontHeightDots =
+    obj.type === "text"
+      ? effectiveFontHeightDots(textMetrics?.deviceFontId, obj.props.fontHeight)
+      : 0;
   // Whitespace-only content has a non-zero ink advance but draws the placeholder,
   // so gate on the same blank test the placeholder does, not on inkWidth alone.
-  const blankSingleLine = isSingleLineText && isBlankText(textMetrics?.content ?? "");
+  const blankSingleLine =
+    isSingleLineText &&
+    isPrintedBlank((obj.props as TextProps).content ?? "", textMetrics?.deviceFontId);
   const rotation = obj.type === "text" ? obj.props.rotation : "N";
   const isQuarterTurn = isAxisSwapped(rotation);
   // A right-justified field's x is the ZPL right edge (see rightAnchorShiftDots),

--- a/src/lib/objectBounds.test.ts
+++ b/src/lib/objectBounds.test.ts
@@ -100,6 +100,27 @@ describe("objectBoundsDots", () => {
     expect(b.height).toBe(160);
   });
 
+  it("text single-line device font: footprint uses the snapped cell, not the raw height", () => {
+    // ^AG h=84 snaps to 60; 'M5i' width from the cell grid: 3*48 - 4 = 140.
+    const t = leaf("text", 50, 30, {
+      content: "M5i", fontHeight: 84, fontWidth: 0, rotation: "N", fontId: "G",
+    });
+    const b = objectBoundsDots(t, ctx());
+    expect(b.height).toBe(60);
+    expect(b.width).toBe(140);
+  });
+
+  it("text single-line font H, lowercase-only: placeholder footprint like the canvas", () => {
+    // Printed-blank (see isPrintedBlank): bounds must show the placeholder
+    // box the canvas draws, not a 0-width one.
+    const t = leaf("text", 50, 30, {
+      content: "abc", fontHeight: 21, fontWidth: 0, rotation: "N", fontId: "H",
+    });
+    const b = objectBoundsDots(t, ctx());
+    expect(b.width).toBe(21 * 4);
+    expect(b.height).toBe(21);
+  });
+
   it("text ^FB block (N): blockBoundsDots footprint shifted to model space", () => {
     // lineStep = 40 + 10 = 50; linesExtent = (3-1)*50 + 40 = 140.
     const t = leaf("text", 50, 30, {

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -44,6 +44,28 @@ describe("computePreflight (off-label producer)", () => {
     ]);
   });
 
+  it("treats a lowercase-only font-H field as printing nothing", () => {
+    // Printed-blank flags emptyContent instead of being judged off-label
+    // by its placeholder box.
+    const t = {
+      id: "h", type: "text", x: 790, y: 10, rotation: 0,
+      props: { content: "abc", fontHeight: 21, fontWidth: 0, rotation: "N", fontId: "H" },
+    } as unknown as LeafObject;
+    const findings = computePreflight([t], ctx, "mm");
+    expect(findings.some((f) => f.kind.startsWith("offLabel"))).toBe(false);
+    expect(findings.some((f) => f.kind === "emptyContent")).toBe(true);
+  });
+
+  it("judges a device-font text by its snapped cell height, not the raw height", () => {
+    // ^AG h=84 prints a 60-dot cell: at y=340 on a 400-dot label the field
+    // fits exactly; the raw height (bottom 424) would falsely flag clipping.
+    const t = {
+      id: "t", type: "text", x: 50, y: 340, rotation: 0,
+      props: { content: "M", fontHeight: 84, fontWidth: 0, rotation: "N", fontId: "G" },
+    } as unknown as LeafObject;
+    expect(computePreflight([t], ctx, "mm")).toEqual([]);
+  });
+
   it("flags a fully-outside leaf as an error", () => {
     expect(computePreflight([box("a", 900, 10, 50, 50)], ctx, "mm")).toEqual([
       { objectId: "a", kind: "offLabelOutside", severity: "error" },


### PR DESCRIPTION
objectBounds fallback and the canvas measured publish used the raw fontHeight; off-label over-reported by the snap delta (~40% at ^AGN,84).