### PR TITLE
fix(canvas): EAN/UPC guard zone renders HRI-independently

### DIFF
--- a/src/components/Canvas/BarcodeObject.eanGuardZone.test.tsx
+++ b/src/components/Canvas/BarcodeObject.eanGuardZone.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { Stage, Layer } from "react-konva";
+import type Konva from "konva";
+import { BarcodeObject } from "./BarcodeObject";
+import { ObjectRegistry, type LeafType } from "@zplab/core/registry";
+import type { LeafObject } from "@zplab/core/registry";
+
+beforeAll(() => {
+  const noop = () => undefined;
+  HTMLCanvasElement.prototype.getContext = (() =>
+    new Proxy({
+      getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      measureText: () => ({ width: 10 }),
+    }, {
+      get: (target, prop) => (prop in target ? target[prop as keyof typeof target] : noop),
+    })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+afterEach(cleanup);
+
+const noopHandlers = {
+  isSelected: false,
+  onSelect: () => undefined,
+  onChange: () => undefined,
+  snap: (n: number) => n,
+};
+
+function renderEan(printInterpretation: boolean) {
+  const type: LeafType = "ean13";
+  const obj = {
+    id: "ean-zone",
+    type,
+    x: 10,
+    y: 10,
+    props: {
+      ...(ObjectRegistry[type].defaultProps as object),
+      content: "123456891234",
+      height: 100,
+      printInterpretation,
+    },
+  } as LeafObject;
+  const stageRef = { current: null as Konva.Stage | null };
+  render(
+    <Stage width={800} height={600} ref={(n) => { stageRef.current = n; }}>
+      <Layer>
+        <BarcodeObject
+          obj={obj}
+          scale={1}
+          dpmm={8}
+          offsetX={0}
+          offsetY={0}
+          preBindingContent="123456891234"
+          {...noopHandlers}
+        />
+      </Layer>
+    </Stage>,
+  );
+  const image = stageRef.current?.findOne<Konva.Image>("Image");
+  expect(image).toBeTruthy();
+  return {
+    height: image!.height(),
+    textNodes: stageRef.current?.find("Text").length ?? 0,
+  };
+}
+
+// Regression: HRI off squeezed the bwip bitmap into the bar rect, shortening
+// bars and guards against the print.
+describe("EAN guard zone is HRI-independent", () => {
+  it("draws the same zone-stretched image with HRI off, minus the digits", () => {
+    const withHri = renderEan(true);
+    cleanup();
+    const withoutHri = renderEan(false);
+    expect(withoutHri.height).toBeCloseTo(withHri.height, 3);
+    // 100 bar dots at scale 1 / 8 dpmm = 12.5px; the guard zone adds to that.
+    expect(withoutHri.height).toBeGreaterThan(100 / 8);
+    expect(withHri.textNodes).toBeGreaterThan(0);
+    expect(withoutHri.textNodes).toBe(0);
+  });
+});

--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -340,7 +340,9 @@ export function BarcodeObject({
       printInterpEnabled && BARCODE_1D_TYPES.has(obj.type);
     const isUprightEanUpc = isUpright && isEanUpc;
 
-    if (showHriOverlay) {
+    // EAN/UPC always takes the zone-stretched path (guard tails are HRI-
+    // independent, see renderEanUpcRawCanvas); HRI only adds the text overlay.
+    if (showHriOverlay || isEanUpc) {
       const ub = dim.upright;
       // Inner Group covers the full upright bbox so KImage + text both
       // live inside it at upright bbox-relative coords. The Group's
@@ -352,12 +354,12 @@ export function BarcodeObject({
       // sys/trail digits visible past the bar bbox; the helper returns
       // them alongside the digit nodes, gated by isUprightEanUpc at
       // the parent Group below.
-      let overlayContent: React.ReactNode;
+      let overlayContent: React.ReactNode = null;
       let eanOverlay: ReturnType<typeof buildEanUpcDigitOverlay> | null = null;
       // EAN/UPC above renders a single centered HRI line (Vera, Labelary-
       // validated at all mw), not the split sys/trail fragment layout used
       // below; route it through the generic centered-text path.
-      if (isEanUpc && !isTextAbove) {
+      if (showHriOverlay && isEanUpc && !isTextAbove) {
         // Display px per encoded module = bar width / module count, where
         // the bwip canvas is moduleCount * renderScale px wide.
         const renderScale = get1DBwipScale(moduleWidth, scale, dpmm);
@@ -380,7 +382,7 @@ export function BarcodeObject({
         // helper's bar-relative textY equals the bbox-relative one
         // here; render directly without an offset wrapper.
         overlayContent = eanOverlay.nodes;
-      } else {
+      } else if (showHriOverlay) {
         // Other 1D: centered text, optionally flanked by start/stop glyphs.
         // GS1-128 HRI prints in Font 0, not the generic HRI face.
         const fontFamily = gs1Hri

--- a/src/components/Canvas/bwipHelpers.eanGuards.test.tsx
+++ b/src/components/Canvas/bwipHelpers.eanGuards.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll } from "vitest";
+import { renderEanUpcRawCanvas } from "./bwipHelpers";
+
+const rectHeights: number[] = [];
+
+beforeAll(() => {
+  const noop = () => undefined;
+  HTMLCanvasElement.prototype.getContext = (() =>
+    new Proxy({
+      fillRect: (_x: number, _y: number, _w: number, h: number) => {
+        rectHeights.push(h);
+      },
+    }, {
+      get: (target, prop) => (prop in target ? target[prop as keyof typeof target] : noop),
+      set: () => true,
+    })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+});
+
+// Regression: guard tails were gated on printInterpretation.
+describe("EAN raw canvas guard tails", () => {
+  it("draws guard bars through the text zone unconditionally", () => {
+    rectHeights.length = 0;
+    const canvas = renderEanUpcRawCanvas({
+      type: "ean13",
+      text: "123456891234",
+      modulePxInt: 2,
+      barHeightPx: 100,
+      tailHeightPx: 13,
+    });
+    expect(canvas).not.toBeNull();
+    expect(Math.max(...rectHeights)).toBe(113);
+    expect(Math.min(...rectHeights)).toBe(100);
+  });
+});

--- a/src/components/Canvas/bwipHelpers.ts
+++ b/src/components/Canvas/bwipHelpers.ts
@@ -4,7 +4,7 @@
 
 import bwipjs from "bwip-js/browser";
 import { errorMessage } from "../../lib/errorMessage";
-import { getEntry, type LeafObject } from "@zplab/core/registry";
+import { type LeafObject } from "@zplab/core/registry";
 import { dotsToPx, pxToDots } from "@zplab/core/lib/coordinates";
 import { getObjectStringContent } from "@zplab/core/lib/variableBinding";
 import { placeholderContentFor, samplePropsFor } from "@zplab/core/registry/placeholderContent";
@@ -111,20 +111,17 @@ export interface EanUpcRawCanvasArgs {
   modulePxInt: number;
   barHeightPx: number;
   tailHeightPx: number;
-  /** False matches Zebra's HRI-off render (bars only, tails not drawn). */
-  extendGuards: boolean;
 }
 
-/** Bars + extended guard tails in one fillRect pass via bwip raw
- *  geometry. Canvas always reserves the firmware 13-dot text zone so
- *  the consumer's KImage height stays constant. */
+/** Bars + extended guard tails in one fillRect pass via bwip raw geometry.
+ *  Tails draw unconditionally: ZD230-verified the firmware keeps them with the
+ *  interpretation line off. */
 export function renderEanUpcRawCanvas({
   type,
   text,
   modulePxInt,
   barHeightPx,
   tailHeightPx,
-  extendGuards,
 }: EanUpcRawCanvasArgs): HTMLCanvasElement | null {
   const barH = Math.round(barHeightPx);
   const tailH = Math.max(0, Math.round(tailHeightPx));
@@ -145,7 +142,7 @@ export function renderEanUpcRawCanvas({
   for (const w of g.sbs) {
     const wPx = w * modulePxInt;
     if (isBar) {
-      const isGuard = extendGuards && (g.bbs?.[barIdx] ?? 0) < 0;
+      const isGuard = (g.bbs?.[barIdx] ?? 0) < 0;
       const h = isGuard ? canvas.height : barH;
       ctx.fillRect(cx, 0, wPx + RAW_BAR_SEAM, h);
       barIdx++;
@@ -310,16 +307,12 @@ export function renderBarcodeCanvas(
   }
   if (EAN_UPC_TYPES.has(obj.type)) {
     const moduleWidth = (obj.props as { moduleWidth?: number }).moduleWidth ?? 2;
-    const printInterpEnabled =
-      !getEntry(obj.type)?.interpretationLocked &&
-      !!(obj.props as { printInterpretation?: boolean }).printInterpretation;
     const canvas = renderEanUpcRawCanvas({
       type: obj.type as EanUpcType,
       text: getObjectStringContent(obj) ?? "",
       modulePxInt: get1DBwipScale(moduleWidth, scale, dpmm),
       barHeightPx: dotsToPx((obj.props as { height: number }).height, scale, dpmm),
       tailHeightPx: dotsToPx(EAN_TEXT_ZONE_DOTS, scale, dpmm),
-      extendGuards: printInterpEnabled,
     });
     return { canvas, error: canvas ? null : "EAN/UPC encode failed" };
   }


### PR DESCRIPTION
ZD230-verified: guard tails run through the text zone with or without the interpretation line; HRI off had squeezed bars and guards short.