### PR TITLE
feat(source-edit): focus-implicit session in an always-on editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,20 @@ Multiple objects can be selected by holding Shift or drawing a lasso. Position c
 
 ### 4. Print or export
 
-The **ZPL output** panel at the bottom shows the generated ZPL. It updates in real time as you edit.
+The **ZPL output** panel at the bottom shows the generated ZPL. It updates in real time as you edit, and the code itself is editable.
 
 - **Copy**: copies the ZPL to the clipboard; paste it into your printer software or send it straight to the printer
 - **Preview**: renders a preview image via [Labelary](https://labelary.com/) or, on desktop, the connected printer's own firmware (see Printer settings)
 - **Export** (File menu): downloads a `.zpl` file
 - **Print** (File menu): opens the Labelary preview and triggers the browser print dialog
+
+### Editing the ZPL source
+
+The panel is a code editor with ZPL syntax highlighting; overlong graphic payloads are folded. Selecting an object on the canvas highlights the lines it emits, and a notice above the code flags printer-persistent setup commands and device actions.
+
+The first change starts an edit session: canvas and panel editing locks (paging still works) while the canvas previews the parsed buffer live. An invalid buffer (unbalanced `^XA`/`^XZ`, too large) shows the refusal reason and is never applied.
+
+Leaving the panel applies the edit; a dialog asks first when the reparse reports findings or would drop designer-only state (groups, names, locked/hidden, export exclusions, variable bindings). `Esc` discards; a changed buffer confirms first. An applied edit counts as a new import, so [Import guarantees](#import-guarantees) apply to the result.
 
 ### Importing existing ZPL
 
@@ -138,6 +146,7 @@ Both `.zpl` and `.json` round-trip cleanly. `.zpl` preserves all printable conte
 
 - Smart alignment and spacing guides
 - Layers panel with reordering
+- Editable ZPL source: type directly in the output panel while the canvas previews the draft live ([editing the ZPL source](#editing-the-zpl-source))
 - Lossless ZPL round-trip: imported ZPL re-exports byte-for-byte, regenerating only what you edit ([import guarantees](#import-guarantees))
 - Variables: bind text and barcode fields to named defaults that emit as `^FN` slots (or `^FE` inline embeds when one field references multiple variables), round-tripping with printer-side templates
 - Batch printing: map columns to Variables from a CSV, an Excel worksheet, or a read-only database (desktop), then print or export with efficient printer-side data merge (template ships once, each row sends only its overrides)

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -33,7 +33,7 @@ test('boots, imports ZPL, adds a page, and regenerates output', async ({ page })
 
   // The output panel defaults to collapsed.
   await page.getByRole('button', { name: 'Expand' }).click();
-  const output = page.locator('pre').first();
+  const output = page.getByRole('region', { name: 'ZPL' }).getByRole('textbox');
   await expect(output).toContainText('^FDHello World');
   await expect(output).toContainText('^PW640');
 
@@ -45,7 +45,7 @@ test('boots, imports ZPL, adds a page, and regenerates output', async ({ page })
   await expect(page.getByText('2 / 2')).toBeVisible();
   await expect
     .poll(async () => {
-      const text = (await page.locator('pre').allInnerTexts()).join('');
+      const text = (await output.allInnerTexts()).join('');
       return {
         pages: text.split('^XA').length - 1,
         fields: text.split('^FDHello World').length - 1,

--- a/e2e/sourceEdit.spec.ts
+++ b/e2e/sourceEdit.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/** Real-browser coverage for the focus-implicit source-edit session: the raw
+ *  pointerdown/focusout/Escape listeners have no jsdom-faithful equivalent. */
+
+const SAMPLE_ZPL = '^XA\n^FO50,50^A0N,30,0^FDHello World^FS\n^XZ';
+
+const importSample = async (page: Page) => {
+  await page.getByRole('button', { name: 'File', exact: true }).click();
+  await page.getByRole('button', { name: 'Import ZPL' }).click();
+  await page.getByRole('textbox').fill(SAMPLE_ZPL);
+  await page.getByRole('button', { name: 'Import', exact: true }).click();
+  await expect(page.getByRole('dialog')).toBeHidden();
+  await page.getByRole('button', { name: 'Expand' }).click();
+  return page.getByRole('region', { name: 'ZPL' }).getByRole('textbox');
+};
+
+const retype = async (page: Page, output: ReturnType<Page['locator']>, zpl: string) => {
+  await output.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(zpl);
+};
+
+test('a clean edit applies on the outside click that leaves the panel', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  await retype(page, output, '^XA^FO10,10^A0N,30,30^FDedited^FS^XZ');
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+
+  await page.locator('main').click({ position: { x: 20, y: 20 } });
+  // Session over, buffer committed, no dialog.
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeHidden();
+  await expect(output).toContainText('^FDedited');
+});
+
+test('a multi-page edit applied by an outside click stays on the current page', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  await page.getByRole('button', { name: 'File', exact: true }).click();
+  await page.getByRole('button', { name: 'Add page' }).click();
+  await expect(page.getByText('2 / 2')).toBeVisible();
+
+  await retype(
+    page,
+    output,
+    '^XA^FO10,10^A0N,30,30^FDp1^FS^XZ\n^XA^FO10,10^A0N,30,30^FDp2^FS^XZ',
+  );
+  await page.locator('main').click({ position: { x: 20, y: 20 } });
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeHidden();
+  // The implicit apply must not yank the user back to page 1.
+  await expect(page.getByText('2 / 2')).toBeVisible();
+});
+
+test('Escape asks to discard and restores the export', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  await retype(page, output, '^XA^FO10,10^A0N,30,30^FDedited^FS^XZ');
+
+  await page.keyboard.press('Escape');
+  // The discard confirm is an alertdialog (destructive), unlike the apply dialog.
+  const dialog = page.getByRole('alertdialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Discard' }).click();
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeHidden();
+  await expect(output).toContainText('^FDHello World');
+  await expect(output).not.toContainText('^FDedited');
+});
+
+test('a held exit swallows the click on a real control (File menu stays closed)', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  await retype(page, output, '^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ');
+
+  // The click lands on a click-driven control; the held exit must stop it.
+  await page.getByRole('button', { name: 'File', exact: true }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Import ZPL' })).toBeHidden();
+});
+
+test('a lossy edit stops on the confirm dialog; cancel refocuses the editor', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  // ^JZY carries a replay-risk finding, which forces the confirm dialog.
+  await retype(page, output, '^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ');
+
+  await page.locator('main').click({ position: { x: 20, y: 20 } });
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(dialog).toBeHidden();
+  // Cancel means keep editing: session alive, focus back in the editor,
+  // and crucially the dialog must not loop straight back open.
+  await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible();
+  await expect(output).toBeFocused();
+});

--- a/packages/core/src/lib/zplSourceEdit.test.ts
+++ b/packages/core/src/lib/zplSourceEdit.test.ts
@@ -145,6 +145,21 @@ describe("deleting a command from the buffer clears its field", () => {
     expect(plan.next.printerProfile.headTestInterval).toBe(5);
   });
 
+  it("keeps the geometry trio when the edit deletes the sidecar (and ^PW/^LL)", () => {
+    const baseline = generateMultiPageZPL(label, pages, []);
+    const without = baseline
+      .split("\n")
+      .filter((l) => !l.includes("ZPLLAB") && !/^\^PW|^\^LL/.test(l))
+      .join("\n");
+    const plan = prepareSourceApply({ text: without, baseline, current: current() });
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    // Document identity, not a deletable command: the strip must skip it.
+    expect(plan.next.label.widthMm).toBe(70);
+    expect(plan.next.label.heightMm).toBe(40);
+    expect(plan.next.label.dpmm).toBe(8);
+  });
+
   it("keeps inherited fields when no baseline is given", () => {
     const plan = prepareSourceApply({
       text: "^XA^FO10,10^A0N,30,30^FDX^FS^XZ",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -520,15 +520,12 @@ export function AppShell() {
         className="shrink-0 border-t border-border flex flex-col bg-surface-2"
         style={{ height: outputPanel.collapsed ? "auto" : outputPanel.height }}
       >
-        <div
-          className="h-1.5 shrink-0 cursor-row-resize hover:bg-accent/30 transition-colors"
-          onMouseDown={outputPanel.onMouseDown}
-        />
         <div className="flex-1 overflow-hidden">
           <ZPLOutput
             collapsed={outputPanel.collapsed}
             onCollapse={outputPanel.collapse}
             onExpand={outputPanel.expand}
+            onResizeMouseDown={outputPanel.onMouseDown}
           />
         </div>
       </div>

--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -14,7 +14,7 @@ import { measureInkWidthPx } from "@zplab/core/lib/labelGeometry/measureTextDots
 import { outlineInset } from "../../lib/shapeGeometry";
 import { reverseShapeStyle } from "./reverseShapeStyle";
 import { useColorScheme, CANVAS_WARNING } from "../../hooks/useColorScheme";
-import { useLabelStore, selectRenderDesignLabel } from "../../store/labelStore";
+import { useLabelStore, selectRenderDesignLabel, selectRenderColumnMapping } from "../../store/labelStore";
 import { applyBindingToObject } from "@zplab/core/lib/variableBinding";
 import { usePreviewBinding } from "../../store/usePreviewBinding";
 import { ZPL_FONT_HEIGHT_TO_CSS_RATIO } from "@zplab/core/lib/labelGeometry/textPositionTransforms";
@@ -457,7 +457,9 @@ const BARCODE_TYPES = new Set([
 export function KonvaObject(props_: Props) {
   const { variables, active, clock } = usePreviewBinding();
   const dataset = useLabelStore((s) => s.dataset);
-  const columnMapping = useLabelStore((s) => s.columnMapping);
+  // Render mapping, like the binding above: the tint must classify the same
+  // document the canvas is showing (a shadow remaps onto fresh variable ids).
+  const columnMapping = useLabelStore(selectRenderColumnMapping);
   const dataRenderMode = useLabelStore((s) => s.canvasSettings.dataRenderMode);
   const obj = applyBindingToObject(props_.obj, variables, active, dataRenderMode, clock, ctrlParityFor(props_.obj));
   const renderProps = obj === props_.obj ? props_ : { ...props_, obj };

--- a/src/components/Canvas/LabelCanvas.tsx
+++ b/src/components/Canvas/LabelCanvas.tsx
@@ -265,6 +265,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const objects = useLabelStore(selectRenderObjects);
   const effDpmm = effectiveDpmm(label);
   const previewBinding = usePreviewBinding();
+  const renderVariables = previewBinding.variables;
   // Raw dataset/mapping (not just the active row): markerValueFindings
   // validates marker values across ALL CSV rows, since any row prints.
   const dataset = useLabelStore((s) => s.dataset);
@@ -412,8 +413,7 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
     const ARROW = new Set(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]);
     const onKeyDown = (e: KeyboardEvent) => {
       if (!ARROW.has(e.code)) return;
-      const tag = (e.target as HTMLElement).tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (isEditableTarget(e.target as HTMLElement)) return;
 
       const state = useLabelStore.getState();
       if (selectEditorFrozen(state)) return;
@@ -621,7 +621,9 @@ export const LabelCanvas = forwardRef<LabelCanvasHandle, Props>(function LabelCa
   const isMultiSelection = selectedIds.length > 1;
   // Snapshot (not the live map) so the frame derivations recompute when a
   // settled footprint changes; the changing snapshot reference is the signal.
-  const frameCtx = { label, measured: measuredSnapshot, variables };
+  // Render variables: anchor/preflight geometry must follow the shadow's
+  // document like the objects do (live `variables` stays for the copy actions).
+  const frameCtx = { label, measured: measuredSnapshot, variables: renderVariables };
   // Hidden leaves never render, so the old client-rect path ignored them; keep
   // them out of the model-based bounds too.
   // visibleLeaves carries the cascaded (effective) lock; read it, not the raw

--- a/src/components/Output/ZPLOutput.realCm.test.tsx
+++ b/src/components/Output/ZPLOutput.realCm.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+// Real CodeMirror (no mock): pins that the always-on pane's own value sync
+// never echoes into the session trigger. The mocked-CM suite cannot see this
+// (a controlled textarea's value change fires no onChange).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { ZPLOutput } from "./ZPLOutput";
+import { useLabelStore } from "../../store/labelStore";
+import type { LabelObject, Page } from "@zplab/core/types/Group";
+
+afterEach(cleanup);
+
+const textObject = (id: string, x: number): LabelObject =>
+  ({
+    id, type: "text", x, y: 10, rotation: 0,
+    props: { content: "hello", fontHeight: 30, fontWidth: 0, rotation: "N" },
+  }) as never;
+
+beforeEach(() => {
+  useLabelStore.setState({
+    label: { widthMm: 70, heightMm: 40, dpmm: 8 },
+    pages: [{ objects: [textObject("t1", 10)] }] as Page[],
+    variables: [],
+    currentPageIndex: 0,
+    selectedIds: [],
+    previewMode: { status: "idle" },
+    sourceEdit: { status: "off" },
+    sourceShadow: null,
+  });
+});
+
+describe("model edits against the always-on pane", () => {
+  it("do not start a source-edit session", () => {
+    render(<ZPLOutput onResizeMouseDown={() => undefined} />);
+    act(() => {
+      useLabelStore.setState({ pages: [{ objects: [textObject("t1", 99)] }] as Page[] });
+    });
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+  });
+});

--- a/src/components/Output/ZPLOutput.sourceEdit.test.tsx
+++ b/src/components/Output/ZPLOutput.sourceEdit.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup, fireEvent, screen, act, waitFor } from "@testing-library/react";
 
@@ -9,12 +10,32 @@ vi.mock("../../lib/clipboard", () => ({
     return Promise.resolve("copied");
   },
 }));
-// CodeMirror needs layout APIs jsdom lacks; value-in/onChange-out is the whole contract.
-vi.mock("./ZplCodeMirror", () => ({
-  default: ({ value, onChange, ariaLabel }: { value: string; onChange: (v: string) => void; ariaLabel: string }) => (
-    <textarea aria-label={ariaLabel} value={value} onChange={(e) => onChange(e.target.value)} />
-  ),
-}));
+// CodeMirror needs layout APIs jsdom lacks; the props plus the focus handle
+// are the whole contract (real-CM invariants live in ZplCodeMirror.test.tsx).
+vi.mock("./ZplCodeMirror", () => {
+  function MockCodeMirror({ value, onChange, ariaLabel, readOnly, highlightLines, ref }: {
+    value: string;
+    onChange: (v: string) => void;
+    ariaLabel: string;
+    readOnly?: boolean;
+    highlightLines?: ReadonlySet<number>;
+    ref?: React.Ref<{ focus(): void }>;
+  }) {
+    const el = React.useRef<HTMLTextAreaElement>(null);
+    React.useImperativeHandle(ref, () => ({ focus: () => el.current?.focus() }), []);
+    return (
+      <textarea
+        ref={el}
+        aria-label={ariaLabel}
+        value={value}
+        readOnly={readOnly}
+        data-highlights={[...(highlightLines ?? [])].sort((a, b) => a - b).join(",")}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  return { default: MockCodeMirror };
+});
 import { ZPLOutput } from "./ZPLOutput";
 import { useLabelStore } from "../../store/labelStore";
 import type { LabelObject, Page } from "@zplab/core/types/Group";
@@ -35,6 +56,7 @@ beforeEach(() => {
     selectedIds: [],
     previewMode: { status: "idle" },
     sourceEdit: { status: "off" },
+    sourceShadow: null,
   });
   useLabelStore.temporal.getState().clear();
 });
@@ -42,51 +64,72 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   copiedTexts.length = 0;
+  vi.restoreAllMocks();
 });
 
 const t = () => useLabelStore.getState().translations;
-const editButton = () => screen.getByRole("button", { name: t().output.editSource });
+const editor = () => screen.getByRole("textbox") as HTMLTextAreaElement;
+const typeDraft = (value: string) => fireEvent.change(editor(), { target: { value } });
+const panelRoot = (container: HTMLElement) => container.firstElementChild as HTMLElement;
+// The blur-apply decision is deferred a tick behind focusout. jsdom's window
+// never has focus, so the alt-tab guard is mocked to "window focused".
+const leavePanel = async (container: HTMLElement) => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  // Move focus out for real; the handler checks activeElement, not the event.
+  (document.activeElement as HTMLElement | null)?.blur?.();
+  fireEvent.focusOut(panelRoot(container));
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+};
 
-describe("the source-edit toggle", () => {
-  it("is disabled while a preview is active", () => {
+describe("the implicit session", () => {
+  it("is read-only while a preview is active", () => {
     useLabelStore.setState({ previewMode: { status: "active", url: "blob:x" } });
-    render(<ZPLOutput />);
-    expect((editButton() as HTMLButtonElement).disabled).toBe(true);
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    expect(editor().readOnly).toBe(true);
   });
 
-  it("enters edit mode with the shown export as the buffer; the footer owns the exit", () => {
-    render(<ZPLOutput />);
-    fireEvent.click(editButton());
+  it("is read-only with the refusal reason when the export trips the gate", () => {
+    const blob = {
+      id: "b1", type: "text", x: 10, y: 10, rotation: 0,
+      props: { content: "F".repeat(70_000), fontHeight: 30, fontWidth: 0, rotation: "N" },
+    } as never;
+    useLabelStore.setState({ pages: [{ objects: [blob] }] });
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    expect(editor().readOnly).toBe(true);
+    expect(screen.getByText(t().output.editSourceGateBlob)).toBeTruthy();
+  });
+
+  it("seeds the session from the shown export on the first keystroke", () => {
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    const shown = editor().value;
+    typeDraft(shown + "\n^FX added");
     const s = useLabelStore.getState().sourceEdit;
     expect(s.status).toBe("editing");
-    if (s.status === "editing") expect(s.draft).toContain("^XA");
-    expect((editButton() as HTMLButtonElement).disabled).toBe(true);
+    if (s.status === "editing") {
+      expect(s.baseline).toBe(shown);
+      expect(s.draft).toBe(shown + "\n^FX added");
+    }
   });
 });
 
 describe("the selection highlight", () => {
-  beforeEach(() => {
-    // jsdom has no scrollIntoView.
-    Element.prototype.scrollIntoView = vi.fn();
-  });
-
   it("tints exactly the selected object's emitted lines", () => {
     useLabelStore.setState({ selectedIds: ["t1"] });
-    const { container } = render(<ZPLOutput />);
-    const tinted = [...container.querySelectorAll("span.block")].filter((el) =>
-      el.className.includes("bg-accent"),
-    );
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    const lines = editor().value.split("\n");
+    const tinted = (editor().dataset.highlights ?? "")
+      .split(",")
+      .filter(Boolean)
+      .map(Number);
     expect(tinted.length).toBeGreaterThan(0);
-    expect(tinted.some((el) => el.textContent?.includes("^FDhello"))).toBe(true);
+    expect(tinted.some((i) => lines[i]?.includes("^FDhello"))).toBe(true);
   });
 
   it("tints nothing without a selection", () => {
-    const { container } = render(<ZPLOutput />);
-    expect(
-      [...container.querySelectorAll("span.block")].some((el) =>
-        el.className.includes("bg-accent"),
-      ),
-    ).toBe(false);
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    expect(editor().dataset.highlights).toBe("");
   });
 });
 
@@ -95,7 +138,7 @@ describe("the printer-impact notice", () => {
     const { importZplText } = await import("@zplab/core/lib/zplImportService");
     const imported = importZplText("^XA^JUS\n^FO10,10^A0N,30,30^FDX^FS\n^XZ", 8);
     useLabelStore.setState({ pages: imported.pages, variables: imported.variables });
-    const { container } = render(<ZPLOutput />);
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
     await waitFor(() => {
       expect(
         [...container.querySelectorAll("p")].some((p) => p.textContent?.includes("^JU")),
@@ -104,7 +147,7 @@ describe("the printer-impact notice", () => {
   });
 
   it("shows nothing for a plain design", () => {
-    const { container } = render(<ZPLOutput />);
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
     expect(
       [...container.querySelectorAll("p")].some((p) => p.textContent?.includes("^JU")),
     ).toBe(false);
@@ -113,8 +156,10 @@ describe("the printer-impact notice", () => {
 
 describe("leaving the editor", () => {
   it("applies an untouched buffer as a pure no-op", () => {
-    render(<ZPLOutput />);
-    fireEvent.click(editButton());
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    const shown = editor().value;
+    typeDraft(shown + "x");
+    typeDraft(shown);
     fireEvent.click(screen.getByRole("button", { name: t().output.editSourceApply }));
     expect(useLabelStore.getState().sourceEdit.status).toBe("off");
     expect(useLabelStore.getState().pages).toBe(pages);
@@ -122,12 +167,9 @@ describe("leaving the editor", () => {
   });
 
   it("cannot resurrect a stale confirm dialog in a new session", () => {
-    render(<ZPLOutput />);
-    fireEvent.click(editButton());
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
     // replayRisk finding forces the confirm dialog.
-    fireEvent.change(screen.getByRole("textbox"), {
-      target: { value: "^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ" },
-    });
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
     fireEvent.click(screen.getByRole("button", { name: t().output.editSourceApply }));
     expect(screen.getByRole("button", { name: t().output.editSourceConfirmApply })).toBeTruthy();
     // External document replacement ends the session under the open dialog.
@@ -140,25 +182,210 @@ describe("leaving the editor", () => {
     act(() => {
       useLabelStore.setState({ pages, label: { widthMm: 70, heightMm: 40, dpmm: 8 } });
     });
-    fireEvent.click(editButton());
+    typeDraft("^XA^FO10,10^A0N,30,30^FDY^FS^XZ");
     expect(screen.queryByRole("button", { name: t().output.editSourceConfirmApply })).toBeNull();
   });
 
   it("copies the live buffer, not the pre-edit export", () => {
-    render(<ZPLOutput />);
-    fireEvent.click(editButton());
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "^XA^FDedited^FS^XZ" } });
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^FDedited^FS^XZ");
     fireEvent.click(screen.getByRole("button", { name: t().output.copy }));
     expect(copiedTexts).toEqual(["^XA^FDedited^FS^XZ"]);
   });
 
   it("asks before discarding a modified buffer", () => {
-    render(<ZPLOutput />);
-    fireEvent.click(editButton());
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "^XA^XZ" } });
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^XZ");
     fireEvent.click(screen.getByRole("button", { name: t().app.cancel }));
     expect(useLabelStore.getState().sourceEdit.status).toBe("editing");
     fireEvent.click(screen.getByRole("button", { name: t().output.editSourceDiscard }));
     expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+  });
+});
+
+describe("focus leaving the panel", () => {
+  it("applies a clean edit", async () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^FO10,10^A0N,30,30^FDedited^FS^XZ");
+    await leavePanel(container);
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    const obj = useLabelStore.getState().pages[0]?.objects[0];
+    expect((obj as { props: { content?: string } }).props.content).toBe("edited");
+  });
+
+  it("ends an untouched session silently", async () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    const shown = editor().value;
+    typeDraft(shown + "x");
+    typeDraft(shown);
+    await leavePanel(container);
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    expect(useLabelStore.getState().pages).toBe(pages);
+    expect(useLabelStore.temporal.getState().pastStates).toHaveLength(0);
+  });
+
+  it("stops on the confirm dialog for a lossy edit instead of applying silently", async () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
+    await leavePanel(container);
+    expect(useLabelStore.getState().sourceEdit.status).toBe("editing");
+    expect(screen.getByRole("button", { name: t().output.editSourceConfirmApply })).toBeTruthy();
+    // The dialog's own focus traffic must not re-trigger the blur apply.
+    await leavePanel(container);
+    expect(screen.getAllByRole("button", { name: t().output.editSourceConfirmApply })).toHaveLength(1);
+  });
+
+  it("keeps the session on a refused buffer and refocuses so Escape works", async () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^FO10,10^A0N,30,30^FDbroken^FS");
+    await leavePanel(container);
+    expect(useLabelStore.getState().sourceEdit.status).toBe("editing");
+    // The reason lands synchronously with the click, not 300ms later.
+    expect(useLabelStore.getState().sourceShadow?.refusal).toBe("unbalanced");
+    // The refocus is deferred behind the pointerdown's default focus.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(document.activeElement).toBe(editor());
+  });
+
+  it("cancelling the dialog sticks when a focusable element outside holds focus", async () => {
+    // The focus trap restores the outside element on unmount; if that restore
+    // overrode focusEditor, the re-blur would loop the dialog straight back.
+    render(
+      <>
+        <button data-testid="outside">canvasish</button>
+        <ZPLOutput onResizeMouseDown={vi.fn()} />
+      </>,
+    );
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
+    act(() => screen.getByTestId("outside").focus());
+    fireEvent.focusOut(screen.getByRole("region"));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(screen.getByRole("button", { name: t().output.editSourceConfirmApply })).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button", { name: t().app.cancel }).at(-1)!);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(screen.queryByRole("button", { name: t().output.editSourceConfirmApply })).toBeNull();
+    expect(document.activeElement).toBe(editor());
+  });
+
+  it("re-arms the blur apply by refocusing the editor when the dialog is cancelled", async () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
+    await leavePanel(container);
+    // Focus stranded outside the panel would make this the session's last
+    // reachable focusout; refocusing restores the gesture.
+    fireEvent.click(screen.getAllByRole("button", { name: t().app.cancel }).at(-1)!);
+    expect(document.activeElement).toBe(editor());
+    await leavePanel(container);
+    expect(screen.getByRole("button", { name: t().output.editSourceConfirmApply })).toBeTruthy();
+  });
+
+  it("Escape asks before discarding", () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^XZ");
+    fireEvent.keyDown(panelRoot(container), { key: "Escape" });
+    expect(screen.getByRole("button", { name: t().output.editSourceDiscard })).toBeTruthy();
+  });
+});
+
+describe("outside pointerdown", () => {
+  it("applies synchronously, so the same click acts on the unfrozen store", () => {
+    render(
+      <>
+        <button data-testid="outside">canvasish</button>
+        <ZPLOutput onResizeMouseDown={vi.fn()} />
+      </>,
+    );
+    typeDraft("^XA^FO10,10^A0N,30,30^FDedited^FS^XZ");
+    // No timer flush: by the time the target's own handlers run, the session
+    // must already be over (a deferred apply swallowed the first click).
+    fireEvent.pointerDown(screen.getByTestId("outside"));
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+  });
+
+  it("swallows the whole gesture (pointerdown AND click) when the exit holds", async () => {
+    const pointerAction = vi.fn();
+    const clickAction = vi.fn();
+    render(
+      <>
+        <button data-testid="outside" onPointerDown={pointerAction} onClick={clickAction}>
+          canvasish
+        </button>
+        <ZPLOutput onResizeMouseDown={vi.fn()} />
+      </>,
+    );
+    // The exit stops on the confirm dialog; neither event may fire foreign UI.
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
+    fireEvent.pointerDown(screen.getByTestId("outside"));
+    fireEvent.click(screen.getByTestId("outside"));
+    expect(screen.getByRole("button", { name: t().output.editSourceConfirmApply })).toBeTruthy();
+    expect(pointerAction).not.toHaveBeenCalled();
+    expect(clickAction).not.toHaveBeenCalled();
+    // The guard is one-shot: after the gesture settles (disarm defers one
+    // tick past the click dispatch), clicks work again.
+    fireEvent.pointerUp(window);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: t().app.cancel }).at(-1)!);
+    expect(screen.queryByRole("button", { name: t().output.editSourceConfirmApply })).toBeNull();
+  });
+
+  it("lets the click through when the exit applies cleanly", () => {
+    const outsideAction = vi.fn();
+    render(
+      <>
+        <button data-testid="outside" onPointerDown={outsideAction}>canvasish</button>
+        <ZPLOutput onResizeMouseDown={vi.fn()} />
+      </>,
+    );
+    typeDraft("^XA^FO10,10^A0N,30,30^FDedited^FS^XZ");
+    fireEvent.pointerDown(screen.getByTestId("outside"));
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    expect(outsideAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds the session on panel chrome (the resize rail lives inside the root)", () => {
+    const { container } = render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^FO10,10^A0N,30,30^FDedited^FS^XZ");
+    const rail = container.querySelector(".cursor-row-resize");
+    expect(rail).not.toBeNull();
+    fireEvent.pointerDown(rail!);
+    expect(useLabelStore.getState().sourceEdit.status).toBe("editing");
+  });
+});
+
+describe("keyboard focus after button exits", () => {
+  it("returns to the editor on a clean footer apply", () => {
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^FO10,10^A0N,30,30^FDedited^FS^XZ");
+    fireEvent.click(screen.getByRole("button", { name: t().output.editSourceApply }));
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    expect(document.activeElement).toBe(editor());
+  });
+
+  it("returns to the editor on a clean cancel", () => {
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    const shown = editor().value;
+    typeDraft(shown + "x");
+    typeDraft(shown);
+    fireEvent.click(screen.getByRole("button", { name: t().app.cancel }));
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    expect(document.activeElement).toBe(editor());
+  });
+
+  it("returns to the editor after confirming a lossy apply", () => {
+    render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
+    typeDraft("^XA^JZY^FO10,10^A0N,30,30^FDX^FS^XZ");
+    fireEvent.click(screen.getByRole("button", { name: t().output.editSourceApply }));
+    fireEvent.click(screen.getByRole("button", { name: t().output.editSourceConfirmApply }));
+    expect(useLabelStore.getState().sourceEdit.status).toBe("off");
+    expect(document.activeElement).toBe(editor());
   });
 });

--- a/src/components/Output/ZPLOutput.tsx
+++ b/src/components/Output/ZPLOutput.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { CheckIcon, ClipboardDocumentIcon, ChevronDownIcon, ChevronUpIcon, EyeIcon, PencilSquareIcon } from '@heroicons/react/16/solid';
+import { useRef, useState, type ReactNode } from 'react';
+import { CheckIcon, ClipboardDocumentIcon, ChevronDownIcon, ChevronUpIcon, EyeIcon } from '@heroicons/react/16/solid';
 import { useLabelStore, selectLabelaryNoticeRequired, selectEffectivePreviewProvider, selectPreviewLocksEditor } from '../../store/labelStore';
-import { sourceRefusalText } from '../../lib/sourceEditText';
 import { useZplOutputView } from '../../hooks/useZplOutputView';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { useT } from '../../hooks/useT';
 import { LabelaryNoticeModal } from './LabelaryNoticeModal';
-import { ZplLine } from './ZplLine';
 import { ZplSourceEditor } from './ZplSourceEditor';
 import { Tooltip } from '../ui/Tooltip';
 
@@ -14,9 +12,12 @@ interface Props {
   collapsed?: boolean;
   onCollapse?: () => void;
   onExpand?: () => void;
+  /** Height-drag handler for the resize rail. The rail renders INSIDE the
+   *  panel root so panel chrome can never read as "leaving" the session. */
+  onResizeMouseDown: (e: React.MouseEvent) => void;
 }
 
-export function ZPLOutput({ collapsed, onCollapse, onExpand }: Props) {
+export function ZPLOutput({ collapsed, onCollapse, onExpand, onResizeMouseDown }: Props) {
   const t = useT();
   const labelaryEnabled = useLabelStore((s) => s.thirdParty.labelary);
   const noticeRequired = useLabelStore(selectLabelaryNoticeRequired);
@@ -24,10 +25,13 @@ export function ZPLOutput({ collapsed, onCollapse, onExpand }: Props) {
   const previewActive = useLabelStore(selectPreviewLocksEditor);
   const enterPreviewMode = useLabelStore((s) => s.enterPreviewMode);
   const exitPreviewMode = useLabelStore((s) => s.exitPreviewMode);
-  const enterSourceEdit = useLabelStore((s) => s.enterSourceEdit);
   const [showNotice, setShowNotice] = useState(false);
+  // The session's focus boundary: leaving this panel applies the buffer, so
+  // header actions (copy) stay inside it and don't count as leaving.
+  const panelRef = useRef<HTMLDivElement>(null);
 
-  const { session, zpl, gate, highlightedLines, notices } = useZplOutputView(collapsed ?? false);
+  const { session, zpl, refusal, highlightedLines, notices, shownText, crlfKey } =
+    useZplOutputView(collapsed ?? false);
 
   // The button shows when the effective provider can run: Labelary when the
   // gate is on, or the printer path (desktop only). The consent notice only
@@ -46,72 +50,52 @@ export function ZPLOutput({ collapsed, onCollapse, onExpand }: Props) {
     void enterPreviewMode();
   };
 
-  // gate is null exactly when the document emits nothing.
-  const editBlocked = previewActive || gate === null || !gate.ok;
-  const editTooltip =
-    gate !== null && !gate.ok ? sourceRefusalText(gate.reason, t) : t.output.editSource;
-
-  const actionCls = (active: boolean) =>
-    `flex items-center gap-1 font-mono text-[10px] disabled:opacity-25 disabled:cursor-not-allowed transition-colors ${
-      active ? 'text-accent hover:text-text' : 'text-muted hover:text-accent'
-    }`;
-
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full" ref={panelRef} role="region" aria-label={t.output.zplHeading}>
+      {onResizeMouseDown && (
+        <div
+          className="h-1.5 shrink-0 cursor-row-resize hover:bg-accent/30 transition-colors"
+          onMouseDown={onResizeMouseDown}
+        />
+      )}
       <OutputSection
         heading={t.output.zplHeading}
-        // The header's copy button must copy what the body shows: the live
-        // buffer during an edit, the generated export otherwise.
-        content={session ? session.draft : zpl}
+        copyContent={shownText}
         emptyMessage={t.output.noObjects}
-        highlightedLines={highlightedLines}
         notices={notices}
         collapsed={collapsed}
         // Collapsing the panel mid-edit would hide an unapplied buffer.
         onCollapseToggle={session ? undefined : collapsed ? onExpand : onCollapse}
         collapseLabel={collapsed ? t.app.expand : t.app.collapse}
         body={
-          session ? (
+          zpl !== '' || session ? (
             <ZplSourceEditor
-              draft={session.draft}
-              baseline={session.baseline}
-              session={session.session}
+              session={session}
+              zpl={zpl}
+              value={shownText}
+              crlfKey={crlfKey}
+              gateRefusal={session === null ? refusal : null}
+              highlightedLines={highlightedLines}
+              panelRef={panelRef}
             />
           ) : undefined
         }
         extraActions={
-          <>
-            <Tooltip content={editTooltip}>
+          previewAvailable && (
+            <Tooltip content={t.output.previewHeading}>
               <button
-                onClick={() => {
-                  enterSourceEdit(zpl);
-                  onExpand?.();
-                }}
-                // Disabled during the session: the footer owns every exit
-                // (including the discard confirmation), a header exit would
-                // either duplicate that flow or dead-click on a dirty buffer.
-                disabled={session !== null || editBlocked}
-                aria-pressed={session !== null}
-                className={actionCls(session !== null)}
+                onClick={togglePreview}
+                disabled={(!zpl && !previewActive) || session !== null}
+                aria-pressed={previewActive}
+                className={`flex items-center gap-1 font-mono text-[10px] disabled:opacity-25 disabled:cursor-not-allowed transition-colors ${
+                  previewActive ? 'text-accent hover:text-text' : 'text-muted hover:text-accent'
+                }`}
               >
-                <PencilSquareIcon className="w-4 h-4" />
-                {t.output.editSource}
+                <EyeIcon className="w-4 h-4" />
+                {t.output.previewHeading}
               </button>
             </Tooltip>
-            {previewAvailable && (
-              <Tooltip content={t.output.previewHeading}>
-                <button
-                  onClick={togglePreview}
-                  disabled={(!zpl && !previewActive) || session !== null}
-                  aria-pressed={previewActive}
-                  className={actionCls(previewActive)}
-                >
-                  <EyeIcon className="w-4 h-4" />
-                  {t.output.previewHeading}
-                </button>
-              </Tooltip>
-            )}
-          </>
+          )
         }
       />
 
@@ -129,13 +113,12 @@ export function ZPLOutput({ collapsed, onCollapse, onExpand }: Props) {
 }
 
 /** Single output pane: header (collapse toggle + heading + extra
- *  actions + copy button) and a `<pre>` body, or the caller's `body`
- *  replacement (the source editor). */
+ *  actions + copy button) and the caller's `body` (the source pane),
+ *  or an empty-document message. */
 function OutputSection({
   heading,
-  content,
+  copyContent,
   emptyMessage,
-  highlightedLines,
   notices,
   collapsed,
   onCollapseToggle,
@@ -144,10 +127,9 @@ function OutputSection({
   body,
 }: {
   heading: string;
-  content: string;
+  /** Feeds only the header's copy button; the body renders itself. */
+  copyContent: string;
   emptyMessage: string;
-  /** Line indices tinted as the canvas selection's emitted source. */
-  highlightedLines?: ReadonlySet<number>;
   notices?: readonly string[];
   collapsed?: boolean;
   onCollapseToggle?: () => void;
@@ -156,15 +138,7 @@ function OutputSection({
   body?: ReactNode;
 }) {
   const t = useT();
-  const { copy, copied } = useCopyToClipboard(() => content);
-  const firstHighlighted = highlightedLines?.size
-    ? Math.min(...highlightedLines)
-    : null;
-  const highlightRef = useRef<HTMLSpanElement>(null);
-  useEffect(() => {
-    // Nearest, not center: a selection click shouldn't yank a visible pane around.
-    highlightRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [firstHighlighted]);
+  const { copy, copied } = useCopyToClipboard(() => copyContent);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -188,7 +162,7 @@ function OutputSection({
           <Tooltip content={t.output.copy}>
             <button
               onClick={copy}
-              disabled={!content}
+              disabled={!copyContent}
               className="flex items-center gap-1 font-mono text-[10px] text-muted hover:text-accent disabled:opacity-25 disabled:cursor-not-allowed transition-colors"
             >
               {copied
@@ -208,18 +182,8 @@ function OutputSection({
       )}
       {!collapsed && (
         body ?? (
-          <pre className="overflow-auto p-3 font-mono text-xs leading-relaxed text-text m-0 bg-surface flex-1">
-            {content
-              ? content.split('\n').map((line, i) => (
-                  <ZplLine
-                    key={i}
-                    ref={i === firstHighlighted ? highlightRef : undefined}
-                    line={line}
-                    highlight={highlightedLines?.has(i)}
-                  />
-                ))
-              : <span className="text-muted">{emptyMessage}</span>
-            }
+          <pre className="overflow-auto p-3 font-mono text-xs leading-relaxed m-0 bg-surface flex-1">
+            <span className="text-muted">{emptyMessage}</span>
           </pre>
         )
       )}

--- a/src/components/Output/ZplCodeMirror.test.tsx
+++ b/src/components/Output/ZplCodeMirror.test.tsx
@@ -3,8 +3,25 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, cleanup, act, waitFor } from "@testing-library/react";
 import { EditorView } from "@codemirror/view";
 import ZplCodeMirror from "./ZplCodeMirror";
+import { isEditableTarget } from "../../lib/dom";
 
 afterEach(cleanup);
+
+describe("ZplCodeMirror keyboard surface", () => {
+  it("reads as an editable target from every real focus/click node", () => {
+    // Keys from the read-only scroller or the gutter must never fall
+    // through to canvas handlers.
+    const { container } = render(
+      <ZplCodeMirror value={"^XA\n^XZ"} onChange={vi.fn()} ariaLabel="zpl" readOnly />,
+    );
+    const view = EditorView.findFromDOM(container as HTMLElement);
+    expect(view).not.toBeNull();
+    expect(isEditableTarget(view!.scrollDOM as HTMLElement)).toBe(true);
+    const gutter = view!.dom.querySelector<HTMLElement>(".cm-gutters");
+    expect(gutter).not.toBeNull();
+    expect(isEditableTarget(gutter)).toBe(true);
+  });
+});
 
 describe("ZplCodeMirror line separators", () => {
   it("mounts a CRLF buffer without a write-back", () => {
@@ -41,6 +58,48 @@ describe("ZplCodeMirror line separators", () => {
     );
     expect(changes).toEqual([]);
   });
+
+  it("does not write back a prop-driven value change", () => {
+    // Regression: with onChange as the session trigger, an echoed prop sync
+    // would turn every canvas edit into a source-edit session (app freeze).
+    const changes: string[] = [];
+    const onChange = (v: string) => changes.push(v);
+    const { rerender } = render(
+      <ZplCodeMirror value={"^XA\n^FDone^FS\n^XZ"} onChange={onChange} ariaLabel="zpl" />,
+    );
+    rerender(<ZplCodeMirror value={"^XA\n^FDtwo^FS\n^XZ"} onChange={onChange} ariaLabel="zpl" />);
+    expect(changes).toEqual([]);
+  });
+});
+
+describe("ZplCodeMirror history epoch", () => {
+  it("clears the undo history when the epoch bumps", async () => {
+    const changes: string[] = [];
+    const props = (epoch: number) => ({
+      value: "^XA\n^FDone^FS\n^XZ",
+      onChange: (v: string) => changes.push(v),
+      ariaLabel: "zpl",
+      historyEpoch: epoch,
+    });
+    const { container, rerender } = render(<ZplCodeMirror {...props(0)} />);
+    const view = EditorView.findFromDOM(container as HTMLElement);
+    expect(view).not.toBeNull();
+    act(() => {
+      view!.dispatch({ changes: { from: 8, insert: "X" } });
+    });
+    expect(changes).toHaveLength(1);
+    // Store echo, then an APPLY ends the session: the new export CONTAINS the
+    // edit (unlike cancel, whose revert-splice annuls the event spatially),
+    // so the history event stays mappable and only the epoch clear kills it.
+    rerender(<ZplCodeMirror {...props(0)} value={changes[0]!} />);
+    rerender(<ZplCodeMirror {...props(1)} value={changes[0]!} />);
+    const { undo } = await import("@codemirror/commands");
+    act(() => {
+      undo(view!);
+    });
+    expect(changes).toHaveLength(1);
+    expect(view!.state.doc.toString()).toBe(changes[0]);
+  });
 });
 
 describe("ZplCodeMirror payload folding", () => {
@@ -57,6 +116,56 @@ describe("ZplCodeMirror payload folding", () => {
     await waitFor(() => {
       expect(container.querySelector(".cm-foldPlaceholder")).not.toBeNull();
     });
+  });
+
+  it("keeps folds through a small prop change (minimal splice, not full replace)", async () => {
+    const doc = (fd: string) => `^XA\n^GFA,8,8,1,${"F".repeat(3000)}^FS\n^FD${fd}^FS\n^XZ`;
+    const onChange = vi.fn();
+    const { container, rerender } = render(
+      <ZplCodeMirror value={doc("one")} onChange={onChange} ariaLabel="zpl" />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".cm-foldPlaceholder")).not.toBeNull();
+    });
+    rerender(<ZplCodeMirror value={doc("two")} onChange={onChange} ariaLabel="zpl" />);
+    // Synchronously, no waitFor: a full replace dropped the fold and only a
+    // deferred rescan restored it (visible flicker per drag/resize frame).
+    expect(container.querySelector(".cm-foldPlaceholder")).not.toBeNull();
+  });
+
+  it("skips highlight dispatches when the set content is unchanged", () => {
+    const lines = () => new Set([1]);
+    const onChange = vi.fn();
+    const { container, rerender } = render(
+      <ZplCodeMirror value={"^XA\n^FDx^FS\n^XZ"} onChange={onChange} ariaLabel="zpl" highlightLines={lines()} />,
+    );
+    const view = EditorView.findFromDOM(container as HTMLElement);
+    expect(view).not.toBeNull();
+    const dispatches = vi.spyOn(view!, "dispatch" as never);
+    // Fresh Set identity, same content: reacting to identity re-scrolled the
+    // pane on every model change while an object was selected.
+    rerender(
+      <ZplCodeMirror value={"^XA\n^FDx^FS\n^XZ"} onChange={onChange} ariaLabel="zpl" highlightLines={lines()} />,
+    );
+    expect(dispatches).not.toHaveBeenCalled();
+  });
+
+  it("re-folds a blob after a prop-driven document replace", async () => {
+    // The full-doc sync drops fold ranges; the typed-in-a-blob protection
+    // must not stop the re-fold (the replaced range contains overlong lines).
+    const blob = (fd: string) => `^XA\n^GFA,8,8,1,${"F".repeat(3000)}^FS\n^FD${fd}^FS\n^XZ`;
+    const onChange = vi.fn();
+    const { container, rerender } = render(
+      <ZplCodeMirror value={blob("one")} onChange={onChange} ariaLabel="zpl" />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".cm-foldPlaceholder")).not.toBeNull();
+    });
+    rerender(<ZplCodeMirror value={blob("two")} onChange={onChange} ariaLabel="zpl" />);
+    await waitFor(() => {
+      expect(container.querySelector(".cm-foldPlaceholder")).not.toBeNull();
+    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("auto-folds when a small paste pushes an existing blob line over the cap", async () => {

--- a/src/components/Output/ZplCodeMirror.tsx
+++ b/src/components/Output/ZplCodeMirror.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useImperativeHandle, useRef, useState, type Ref } from 'react';
 import {
   EditorView,
   ViewPlugin,
@@ -8,16 +8,20 @@ import {
   type DecorationSet,
   type ViewUpdate,
 } from '@codemirror/view';
-import { Compartment, EditorState, RangeSetBuilder, type StateEffect } from '@codemirror/state';
+import { Annotation, Compartment, EditorState, RangeSetBuilder, Transaction, type StateEffect } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import { codeFolding, foldService, foldGutter, foldKeymap, foldEffect, foldedRanges } from '@codemirror/language';
-import { zplLineHighlights, opaquePayloadFold } from '../../lib/zplCmHighlight';
+import { zplLineHighlights, opaquePayloadFold, isPureCrlf } from '../../lib/zplCmHighlight';
 import { MAX_LINE_RENDER } from '../../lib/zplTokenStyles';
 
 // Text.toString() always joins with LF; only sliceString honours the
 // lineSeparator facet, and the store buffer must get the original separators.
 const docText = (state: EditorState): string =>
   state.doc.sliceString(0, state.doc.length, state.lineBreak);
+
+// Marks prop-sync dispatches: they must not echo through onChange (which
+// would start an edit session) nor land in the undo history.
+const propSync = Annotation.define<boolean>();
 
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
@@ -104,19 +108,59 @@ const theme = EditorView.theme({
   '.cm-line': { padding: '0 12px' },
   '.cm-gutters': { backgroundColor: 'transparent', border: 'none', color: 'inherit', opacity: '0.4' },
   '.cm-activeLine': { backgroundColor: 'transparent' },
+  '.cm-zplSelectedLine': {
+    backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
+  },
 });
 
-/** CodeMirror host for the source-edit buffer: shared-tokenizer colouring, auto-folded
- *  payload blobs. A bare \r has no CM representation, so the first edit normalizes it
- *  to \n; an untouched buffer stays byte-identical. */
+function highlightDecorations(state: EditorState, lines: ReadonlySet<number>): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const idx of [...lines].sort((a, b) => a - b)) {
+    if (idx < 0 || idx >= state.doc.lines) continue;
+    builder.add(
+      state.doc.line(idx + 1).from,
+      state.doc.line(idx + 1).from,
+      Decoration.line({ class: 'cm-zplSelectedLine' }),
+    );
+  }
+  return builder.finish();
+}
+
+const NO_LINES: ReadonlySet<number> = new Set();
+
+// Compartment payloads built in ONE place each, so mount and reconfigure
+// cannot silently drift apart.
+const readOnlyExt = (ro: boolean) => [EditorState.readOnly.of(ro), EditorView.editable.of(!ro)];
+const highlightExt = (lines: ReadonlySet<number>) =>
+  EditorView.decorations.of((v) => highlightDecorations(v.state, lines));
+const ariaExt = (label: string) => EditorView.contentAttributes.of({ 'aria-label': label });
+
+export interface ZplCodeMirrorHandle {
+  focus(): void;
+}
+
+/** CodeMirror host for the source pane: shared-tokenizer colouring, auto-folded
+ *  payload blobs. A bare \r has no CM representation, so the first edit
+ *  normalizes it to \n; an untouched buffer stays byte-identical. */
 export default function ZplCodeMirror({
   value,
   onChange,
   ariaLabel,
+  readOnly = false,
+  highlightLines = NO_LINES,
+  historyEpoch = 0,
+  ref,
 }: {
   value: string;
   onChange: (value: string) => void;
   ariaLabel: string;
+  readOnly?: boolean;
+  /** 0-based doc lines tinted as the canvas selection's emitted source. */
+  highlightLines?: ReadonlySet<number>;
+  /** Bumping clears the undo history (minimal-splice syncs keep old events
+   *  mappable, so without this an undo could resurrect a closed session). */
+  historyEpoch?: number;
+  ref?: Ref<ZplCodeMirrorHandle>;
 }) {
   const host = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -126,31 +170,43 @@ export default function ZplCodeMirror({
   });
   const lastEmitted = useRef(value);
   const [ariaCompartment] = useState(() => new Compartment());
+  const [readOnlyCompartment] = useState(() => new Compartment());
+  const [highlightCompartment] = useState(() => new Compartment());
+  const [historyCompartment] = useState(() => new Compartment());
+
+  useImperativeHandle(ref, () => ({ focus: () => viewRef.current?.focus() }), []);
 
   useEffect(() => {
     if (!host.current) return;
-    // Pure-CRLF only: the facet keeps CRLF buffers byte-identical, but under it a bare
-    // \n would not split, collapsing a mixed document's LF pages into one line each.
-    const crlf = /\r\n/.test(value) && !/(?<!\r)\n/.test(value);
+    const crlf = isPureCrlf(value);
     const state = EditorState.create({
       doc: value,
       extensions: [
         ...(crlf ? [EditorState.lineSeparator.of('\r\n')] : []),
         lineNumbers(),
-        history(),
+        historyCompartment.of(history()),
         codeFolding(),
         zplFolding,
         foldGutter(),
         zplHighlighter,
         theme,
-        ariaCompartment.of(EditorView.contentAttributes.of({ 'aria-label': ariaLabel })),
+        readOnlyCompartment.of(readOnlyExt(readOnly)),
+        highlightCompartment.of(highlightExt(highlightLines)),
+        ariaCompartment.of(ariaExt(ariaLabel)),
         keymap.of([...defaultKeymap, ...historyKeymap, ...foldKeymap]),
         EditorView.updateListener.of((u) => {
           if (!u.docChanged) return;
-          const text = docText(u.state);
-          lastEmitted.current = text;
-          onChangeRef.current(text);
-          const folds = foldsForInsertedBlobs(u);
+          const synced = u.transactions.some((tr) => tr.annotation(propSync));
+          if (!synced) {
+            const text = docText(u.state);
+            lastEmitted.current = text;
+            onChangeRef.current(text);
+          }
+          // A sync is a fresh document, so it re-folds like a mount; the
+          // typed-in-an-unfolded-blob protection only applies to user edits.
+          const folds = synced
+            ? blobFoldEffects(u.state, 0, u.state.doc.length)
+            : foldsForInsertedBlobs(u);
           if (folds.length > 0) {
             // Deferred out of the update cycle.
             setTimeout(() => {
@@ -161,13 +217,10 @@ export default function ZplCodeMirror({
       ],
     });
     const view = new EditorView({ parent: host.current, state });
-    // Doc length, not string length: they differ under a normalized separator.
-    view.dispatch({ selection: { anchor: view.state.doc.length } });
     viewRef.current = view;
     // Fold the payload blobs up front; foldService alone only powers the gutter.
     const folds = blobFoldEffects(view.state, 0, view.state.doc.length);
     if (folds.length > 0) view.dispatch({ effects: folds });
-    view.focus();
     return () => {
       viewRef.current = null;
       view.destroy();
@@ -180,12 +233,18 @@ export default function ZplCodeMirror({
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
-    view.dispatch({
-      effects: ariaCompartment.reconfigure(
-        EditorView.contentAttributes.of({ 'aria-label': ariaLabel }),
-      ),
-    });
+    view.dispatch({ effects: ariaCompartment.reconfigure(ariaExt(ariaLabel)) });
   }, [ariaLabel, ariaCompartment]);
+
+  const mountEpoch = useRef(historyEpoch);
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || historyEpoch === mountEpoch.current) return;
+    mountEpoch.current = historyEpoch;
+    // Removing the extension destroys its state field; re-adding starts fresh.
+    view.dispatch({ effects: historyCompartment.reconfigure([]) });
+    view.dispatch({ effects: historyCompartment.reconfigure(history()) });
+  }, [historyEpoch, historyCompartment]);
 
   useEffect(() => {
     const view = viewRef.current;
@@ -193,12 +252,59 @@ export default function ZplCodeMirror({
     // Echo guard doubling as a cheap identity check on multi-MB buffers: the
     // doc already holds this text (mount value or its own last emit).
     if (value === lastEmitted.current) return;
-    if (docText(view.state) !== value) {
+    // Unconditionally, or a doc-equal value (bare-\r normalization) leaves a
+    // stale guard that later short-circuits a real sync.
+    lastEmitted.current = value;
+    const old = docText(view.state);
+    if (old !== value) {
+      // Minimal splice, not a full replace: folds, selection and scroll then
+      // survive by mapping (a live resize regenerates the export per frame).
+      // String offsets equal doc positions only without the CRLF facet.
+      let from = 0;
+      let oldEnd = old.length;
+      let newEnd = value.length;
+      if (view.state.lineBreak === '\n') {
+        const minLen = Math.min(oldEnd, newEnd);
+        while (from < minLen && old.charCodeAt(from) === value.charCodeAt(from)) from++;
+        while (oldEnd > from && newEnd > from && old.charCodeAt(oldEnd - 1) === value.charCodeAt(newEnd - 1)) {
+          oldEnd--;
+          newEnd--;
+        }
+      }
       view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: value },
+        changes: { from, to: view.state.doc.length - (old.length - oldEnd), insert: value.slice(from, newEnd) },
+        // Undo must not reach back into synced exports.
+        annotations: [propSync.of(true), Transaction.addToHistory.of(false)],
       });
     }
   }, [value]);
 
-  return <div ref={host} className="flex-1 min-h-0 overflow-hidden" />;
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({ effects: readOnlyCompartment.reconfigure(readOnlyExt(readOnly)) });
+  }, [readOnly, readOnlyCompartment]);
+
+  // After the value sync above, so line positions resolve on the fresh doc.
+  // Compared by CONTENT: the producer hands a fresh Set per model change, and
+  // reacting to identity re-scrolled the pane every drag/resize frame.
+  const shownLines = useRef<ReadonlySet<number>>(NO_LINES);
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const prev = shownLines.current;
+    if (prev.size === highlightLines.size && [...highlightLines].every((l) => prev.has(l))) return;
+    shownLines.current = highlightLines;
+    const effects: StateEffect<unknown>[] = [highlightCompartment.reconfigure(highlightExt(highlightLines))];
+    const first = highlightLines.size ? Math.min(...highlightLines) : null;
+    if (first !== null && first < view.state.doc.lines) {
+      // Nearest, not center: a selection click shouldn't yank a visible pane around.
+      effects.push(EditorView.scrollIntoView(view.state.doc.line(first + 1).from, { y: 'nearest' }));
+    }
+    view.dispatch({ effects });
+  }, [highlightLines, highlightCompartment]);
+
+  // isEditableTarget's contract; on the HOST because focus/clicks can land
+  // outside .cm-content (see the marker's JSDoc in lib/dom.ts).
+  return <div ref={host} data-text-surface className="flex-1 min-h-0 overflow-hidden" />;
 }

--- a/src/components/Output/ZplLine.tsx
+++ b/src/components/Output/ZplLine.tsx
@@ -1,21 +1,13 @@
 import { tokenizeZplLine } from "../../lib/zplTokenize";
 import { TOKEN_CLASS, MAX_LINE_RENDER } from "../../lib/zplTokenStyles";
 
-/** One line of rendered ZPL, syntax-highlighted per token. Shared between
- *  the per-label ZPL pane and the Setup-Script preview pane. */
-export function ZplLine({
-  line,
-  highlight,
-  ref,
-}: {
-  line: string;
-  highlight?: boolean;
-  ref?: React.Ref<HTMLSpanElement>;
-}) {
+/** One line of rendered ZPL, syntax-highlighted per token (the Setup-Script
+ *  preview pane; the output panel renders through CodeMirror). */
+export function ZplLine({ line }: { line: string }) {
   const truncated = line.length > MAX_LINE_RENDER;
   const tokens = tokenizeZplLine(truncated ? line.slice(0, MAX_LINE_RENDER) : line);
   return (
-    <span ref={ref} className={highlight ? "block bg-accent/10" : "block"}>
+    <span className="block">
       {/* A blank line collapses to zero height inside <pre>; keep its row. */}
       {tokens.length === 0
         ? "\n"

--- a/src/components/Output/ZplSourceEditor.tsx
+++ b/src/components/Output/ZplSourceEditor.tsx
@@ -1,96 +1,183 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { hasEditorLoss } from '@zplab/core/lib/editorStateDiff';
-import { prepareSourceApply, type SourceApplyOk } from '@zplab/core/lib/zplSourceEdit';
-import { sourceRefusalText } from '../../lib/sourceEditText';
-import { useLabelStore } from '../../store/labelStore';
+import { prepareSourceApply } from '@zplab/core/lib/zplSourceEdit';
+import type { SourceApplyOk } from '@zplab/core/lib/zplSourceEdit';
+import { sourceRefusalText, type SourceRefusal } from '../../lib/sourceEditText';
+import { useLabelStore, selectPreviewLocksEditor, selectSourceDocumentState } from '../../store/labelStore';
+import type { SourceEditMode } from '../../store/slices/sourceEditSlice';
 import { SourceApplyConfirmDialog } from './SourceApplyConfirmDialog';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { useSessionExit } from '../../hooks/useSessionExit';
 import { useT } from '../../hooks/useT';
-// Eager on purpose: ~10% bundle buys an instant, failure-free editor toggle.
-import ZplCodeMirror from './ZplCodeMirror';
+import ZplCodeMirror, { type ZplCodeMirrorHandle } from './ZplCodeMirror';
 
-/** One edit session's buffer and apply flow. Mounted only while the session
- *  is live, so plan/error/confirm state dies with it; the session id rides on
- *  every apply, which refuses a mismatch. */
+type SessionState = Extract<SourceEditMode, { status: 'editing' }>;
+
+/** The always-mounted source pane: the first modifying keystroke seeds a
+ *  session from the shown export (focus is the mode: one person either types
+ *  here or works the canvas). Leaving the panel applies; Escape discards. */
 export function ZplSourceEditor({
-  draft,
-  baseline,
   session,
+  zpl,
+  value,
+  crlfKey,
+  gateRefusal,
+  highlightedLines,
+  panelRef,
 }: {
-  draft: string;
-  baseline: string;
-  session: number;
+  session: SessionState | null;
+  zpl: string;
+  value: string;
+  crlfKey: boolean;
+  /** Gate refusal of the shown export; makes the pane read-only. */
+  gateRefusal: SourceRefusal | null;
+  highlightedLines: ReadonlySet<number>;
+  panelRef: RefObject<HTMLDivElement | null>;
 }) {
   const t = useT();
-  const setSourceDraft = useLabelStore((s) => s.setSourceDraft);
+  const previewActive = useLabelStore(selectPreviewLocksEditor);
+  const readOnly = previewActive || gateRefusal !== null;
+  const editorRef = useRef<ZplCodeMirrorHandle>(null);
+  const gateMsg = gateRefusal !== null ? sourceRefusalText(gateRefusal, t) : null;
+
+  // The text history belongs to the session: clear it when one ENDS, or an
+  // undo in the still-focused editor could resurrect the closed buffer.
+  // Session start stays undoable.
+  const [historyEpoch, setHistoryEpoch] = useState(0);
+  const prevSessionRef = useRef(session?.session ?? null);
+  useEffect(() => {
+    const prev = prevSessionRef.current;
+    const cur = session?.session ?? null;
+    prevSessionRef.current = cur;
+    if (prev !== null && cur === null) {
+      const id = setTimeout(() => setHistoryEpoch((e) => e + 1), 0);
+      return () => clearTimeout(id);
+    }
+  }, [session]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex flex-col flex-1 min-h-0 bg-surface-2 font-mono text-xs text-text">
+        <ZplCodeMirror
+          key={crlfKey ? 'crlf' : 'lf'}
+          ref={editorRef}
+          value={value}
+          onChange={(text) => {
+            const s = useLabelStore.getState();
+            // First modifying keystroke: the shown export becomes the baseline.
+            if (s.sourceEdit.status !== 'editing') s.enterSourceEdit(zpl);
+            s.setSourceDraft(text);
+          }}
+          ariaLabel={t.output.editSource}
+          readOnly={readOnly}
+          highlightLines={highlightedLines}
+          historyEpoch={historyEpoch}
+        />
+      </div>
+      {gateMsg !== null && (
+        <p
+          role="status"
+          title={gateMsg}
+          className="px-3 py-1.5 shrink-0 border-t border-border font-mono text-[10px] text-muted truncate"
+        >
+          {gateMsg}
+        </p>
+      )}
+      {session && (
+        <SessionChrome
+          key={session.session}
+          session={session}
+          panelRef={panelRef}
+          focusEditor={() => editorRef.current?.focus()}
+        />
+      )}
+    </div>
+  );
+}
+
+/** One session's footer, dialogs and exit surfaces. Keyed by session id, so
+ *  plan/confirm state dies structurally with the session. */
+function SessionChrome({
+  session,
+  panelRef,
+  focusEditor,
+}: {
+  session: SessionState;
+  panelRef: RefObject<HTMLDivElement | null>;
+  /** Re-focuses the editor; cancelling a dialog means "keep editing", and
+   *  without it focus strands outside the panel and blur-apply never re-arms. */
+  focusEditor: () => void;
+}) {
+  const t = useT();
   const cancelSourceEdit = useLabelStore((s) => s.cancelSourceEdit);
   const applyZplSource = useLabelStore((s) => s.applyZplSource);
   // Modal-local like the import modal's result/pending: only the buffer lives
   // in the store, the in-flight plan does not survive its session anyway.
   const [pendingPlan, setPendingPlan] = useState<SourceApplyOk | null>(null);
-  const [applyError, setApplyError] = useState<string | null>(null);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
-  // The shadow parse already knows whether applying would refuse; surfacing it
-  // live saves the user the dead Apply click.
+  // The shadow slot is the ONE refusal source; it follows every edit, so it
+  // can never go stale the way a local error state did.
   const liveRefusal = useLabelStore((s) => s.sourceShadow?.refusal ?? null);
+  const liveMsg = liveRefusal !== null ? sourceRefusalText(liveRefusal, t) : null;
 
-  const dirty = draft !== baseline;
+  const dirty = session.draft !== session.baseline;
   const requestCancel = () => {
     if (dirty) {
       setConfirmDiscard(true);
       return;
     }
     cancelSourceEdit();
+    // Session chrome (this trigger included) unmounts; without a successor
+    // a keyboard user lands on document.body. Blur exits never come here.
+    focusEditor();
   };
 
-  const handleApply = () => {
+  /** Returns whether the session ended (a held session swallows the click). */
+  const handleApply = (): boolean => {
     // An untouched buffer must not commit: the reparse would still rename
     // variables and replace ids, pure loss for a no-op edit.
     if (!dirty) {
       cancelSourceEdit();
-      return;
+      return true;
     }
     const state = useLabelStore.getState();
     const plan = prepareSourceApply({
-      text: draft,
-      baseline,
-      current: {
-        label: state.label,
-        pages: state.pages,
-        variables: state.variables,
-        printerProfile: state.printerProfile,
-        columnMapping: state.columnMapping,
-      },
+      text: session.draft,
+      baseline: session.baseline,
+      current: selectSourceDocumentState(state),
     });
     if (!plan.ok) {
-      setApplyError(sourceRefusalText(plan.reason, t));
-      return;
+      // The debounced shadow sync would lag the click by up to 300ms.
+      state.setSourceRefusal(plan.reason);
+      // Deferred past the pointerdown's default focus, so Escape keeps working.
+      setTimeout(focusEditor, 0);
+      return false;
     }
-    setApplyError(null);
     // Feedback through state change, like the import modal: only stop on a
     // dialog when there is something the user could not otherwise see.
     if (plan.report.findings.length === 0 && !hasEditorLoss(plan.loss)) {
-      applyZplSource(plan, session);
-      return;
+      applyZplSource(plan, session.session);
+      return true;
     }
     setPendingPlan(plan);
+    return false;
   };
 
+  useSessionExit(panelRef, {
+    onExit: handleApply,
+    onEscape: requestCancel,
+    suspended: pendingPlan !== null || confirmDiscard,
+  });
+
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex flex-col flex-1 min-h-0 bg-surface-2 border-b border-border font-mono text-xs text-text">
-        <ZplCodeMirror
-          value={draft}
-          onChange={(value) => {
-            setApplyError(null);
-            setSourceDraft(value);
-          }}
-          ariaLabel={t.output.editSource}
-        />
-      </div>
-      <div className="flex items-center justify-between px-3 py-2 shrink-0 gap-3">
-        <p className="font-mono text-[10px] text-amber-400 leading-relaxed truncate">
-          {applyError ?? (liveRefusal ? sourceRefusalText(liveRefusal, t) : null)}
+    <>
+      <div className="flex items-center justify-between px-3 py-2 shrink-0 gap-3 border-t border-border">
+        <p
+          role="status"
+          title={liveMsg ?? undefined}
+          className="font-mono text-[10px] text-amber-400 leading-relaxed truncate"
+        >
+          {liveMsg}
         </p>
         <div className="flex items-center gap-2 shrink-0">
           <button
@@ -102,8 +189,13 @@ export function ZplSourceEditor({
           </button>
           <button
             type="button"
-            onClick={handleApply}
-            disabled={draft.trim() === ''}
+            // Refocus like Cancel: a clean apply unmounts this button. On the
+            // dialog path the trap's initial focus wins afterwards, harmless.
+            onClick={() => {
+              handleApply();
+              focusEditor();
+            }}
+            disabled={session.draft.trim() === ''}
             className="px-3 py-1.5 rounded text-xs font-mono bg-accent text-bg hover:opacity-90 disabled:opacity-25 disabled:cursor-not-allowed transition-opacity"
           >
             {t.output.editSourceApply}
@@ -115,10 +207,14 @@ export function ZplSourceEditor({
         <SourceApplyConfirmDialog
           plan={pendingPlan}
           onApply={() => {
-            applyZplSource(pendingPlan, session);
+            applyZplSource(pendingPlan, session.session);
             setPendingPlan(null);
+            focusEditor();
           }}
-          onCancel={() => setPendingPlan(null)}
+          onCancel={() => {
+            setPendingPlan(null);
+            focusEditor();
+          }}
         />
       )}
 
@@ -128,10 +224,16 @@ export function ZplSourceEditor({
           confirmLabel={t.output.editSourceDiscard}
           cancelLabel={t.app.cancel}
           destructive
-          onConfirm={cancelSourceEdit}
-          onCancel={() => setConfirmDiscard(false)}
+          onConfirm={() => {
+            cancelSourceEdit();
+            focusEditor();
+          }}
+          onCancel={() => {
+            setConfirmDiscard(false);
+            focusEditor();
+          }}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -87,7 +87,13 @@ export function useFocusTrap(
     container.addEventListener('keydown', handleKey);
     return () => {
       container.removeEventListener('keydown', handleKey);
-      previouslyFocused?.focus?.();
+      // A close handler that already moved focus elsewhere must win, or the
+      // restore re-blurs its target and can re-trigger blur handlers.
+      // Contract: such handlers redirect SYNCHRONOUSLY, or they lose to this.
+      const active = document.activeElement;
+      if (active === null || active === document.body || container.contains(active)) {
+        previouslyFocused?.focus?.();
+      }
     };
   }, [containerRef]);
 }

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useLabelStore, useHistory, getCurrentObjects, selectEditorFrozen } from "../store/labelStore";
+import { useLabelStore, useHistory, getCurrentObjects, selectEditorFrozen, selectRenderPages } from "../store/labelStore";
 import { nextRotation } from "../components/Canvas/rotationGeometry";
 import { isEditableTarget } from "../lib/dom";
 
@@ -17,17 +17,33 @@ export function useGlobalShortcuts() {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      // Preview overlay or an open source buffer freezes the design; every
-      // shortcut here either edits the model or changes the selection
-      // /page, both of which would visibly drift away from the frozen
-      // snapshot. Block them wholesale.
-      if (selectEditorFrozen(useLabelStore.getState())) return;
       const mod = e.metaKey || e.ctrlKey;
 
       // Editable targets keep their native undo/redo, copy/paste and
       // select-all; every document shortcut below (incl. Ctrl+Z) applies only
       // outside text fields, so typing in an input isn't hijacked by the model.
       if (isEditableTarget(e.target as HTMLElement)) return;
+
+      // Paging is view-only, so it mirrors the pager buttons: the store's own
+      // setCurrentPage guard decides (blocked by a preview, open in a session).
+      if (e.code === "PageUp") {
+        e.preventDefault();
+        const { currentPageIndex } = useLabelStore.getState();
+        if (currentPageIndex > 0) setCurrentPage(currentPageIndex - 1);
+        return;
+      }
+      if (e.code === "PageDown") {
+        e.preventDefault();
+        const { currentPageIndex } = useLabelStore.getState();
+        if (currentPageIndex < selectRenderPages(useLabelStore.getState()).length - 1)
+          setCurrentPage(currentPageIndex + 1);
+        return;
+      }
+
+      // Preview overlay or an open source buffer freezes the design; every
+      // shortcut below either edits the model or changes the selection,
+      // which would visibly drift away from the frozen snapshot.
+      if (selectEditorFrozen(useLabelStore.getState())) return;
 
       if (mod && e.code === "KeyZ") {
         e.preventDefault();
@@ -86,16 +102,6 @@ export function useGlobalShortcuts() {
         e.preventDefault();
         const current = useLabelStore.getState().canvasSettings.viewRotation;
         setCanvasSettings({ viewRotation: nextRotation(current) });
-      }
-      if (e.code === "PageUp") {
-        e.preventDefault();
-        const { currentPageIndex } = useLabelStore.getState();
-        if (currentPageIndex > 0) setCurrentPage(currentPageIndex - 1);
-      }
-      if (e.code === "PageDown") {
-        e.preventDefault();
-        const { currentPageIndex, pages } = useLabelStore.getState();
-        if (currentPageIndex < pages.length - 1) setCurrentPage(currentPageIndex + 1);
       }
     };
     window.addEventListener("keydown", onKeyDown);

--- a/src/hooks/useSessionExit.ts
+++ b/src/hooks/useSessionExit.ts
@@ -1,0 +1,76 @@
+import { useEffect, useLayoutEffect, useRef, type RefObject } from 'react';
+
+/** The source-edit session's exit surface on a panel root. Not useDismiss:
+ *  capture phase, focusout fallback, and a held exit (onExit false: refusal
+ *  or confirm dialog) swallows the click so nothing fires under it. */
+export function useSessionExit(
+  panelRef: RefObject<HTMLElement | null>,
+  handlers: { onExit: () => boolean; onEscape: () => void; suspended: boolean },
+): void {
+  // Latest closures for the raw DOM listeners (mounted once per session).
+  // Layout effect: synced before paint, so no user event sees a stale closure.
+  const handlersRef = useRef(handlers);
+  useLayoutEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    const root = panelRef.current;
+    if (!root) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Capture-phase, so the exit lands BEFORE the target's own handlers and
+    // chrome/stage clicks act on the unfrozen store in the same click. (A
+    // click on a canvas OBJECT still needs a second one: the apply re-ids
+    // the Konva node under the pointer mid-gesture.)
+    const onPointerDown = (e: PointerEvent) => {
+      if (handlersRef.current.suspended) return;
+      const target = e.target as Element | null;
+      if (!target || root.contains(target)) return;
+      if (!handlersRef.current.onExit()) {
+        e.preventDefault();
+        e.stopPropagation();
+        // Cancelling pointerdown does NOT suppress the gesture's click (it is
+        // its own event after pointerup), so onClick targets like menu
+        // triggers or the pager would still fire under the held session.
+        const swallowClick = (ce: Event) => {
+          ce.preventDefault();
+          ce.stopPropagation();
+        };
+        document.addEventListener('click', swallowClick, true);
+        const disarm = () =>
+          // After the click dispatch, which runs synchronously on pointerup.
+          setTimeout(() => document.removeEventListener('click', swallowClick, true), 0);
+        window.addEventListener('pointerup', disarm, { once: true, capture: true });
+        window.addEventListener('pointercancel', disarm, { once: true, capture: true });
+      }
+    };
+    // Fallback for non-pointer focus moves (Tab out, programmatic focus).
+    const onFocusOut = () => {
+      clearTimeout(timer);
+      // Deferred: focusout fires before the new activeElement settles. A
+      // window blur (alt-tab) keeps the session; only focus moving elsewhere
+      // in the app is "the one person now works the canvas".
+      timer = setTimeout(() => {
+        if (handlersRef.current.suspended) return;
+        if (!document.hasFocus()) return;
+        const active = document.activeElement;
+        if (active && root.contains(active)) return;
+        handlersRef.current.onExit();
+      }, 0);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      // CM's simplifySelection consumes Escape for ANY non-empty selection,
+      // so discarding then takes a second press (standard editor behavior).
+      if (e.key === 'Escape' && !e.defaultPrevented) handlersRef.current.onEscape();
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    root.addEventListener('focusout', onFocusOut);
+    root.addEventListener('keydown', onKeyDown);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      root.removeEventListener('focusout', onFocusOut);
+      root.removeEventListener('keydown', onKeyDown);
+    };
+  }, [panelRef]);
+}

--- a/src/hooks/useSourceEditShadow.ts
+++ b/src/hooks/useSourceEditShadow.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { prepareSourceApply, MAX_SOURCE_CHARS } from "@zplab/core/lib/zplSourceEdit";
 import { walkObjects, type Page } from "@zplab/core/types/Group";
-import { useLabelStore } from "../store/labelStore";
+import { useLabelStore, selectSourceDocumentState } from "../store/labelStore";
 
 const DEBOUNCE_MS = 300;
 
@@ -36,7 +36,7 @@ export function useSourceShadowSync(): void {
     }
     if (draft.length > MAX_SOURCE_CHARS) {
       const id = setTimeout(() => {
-        shadow({ doc: useLabelStore.getState().sourceShadow?.doc ?? null, refusal: "tooLarge" });
+        useLabelStore.getState().setSourceRefusal("tooLarge");
       }, 0);
       return () => clearTimeout(id);
     }
@@ -45,13 +45,7 @@ export function useSourceShadowSync(): void {
       const plan = prepareSourceApply({
         text: draft,
         baseline,
-        current: {
-          label: s.label,
-          pages: s.pages,
-          variables: s.variables,
-          printerProfile: s.printerProfile,
-          columnMapping: s.columnMapping,
-        },
+        current: selectSourceDocumentState(s),
       });
       if (plan.ok) {
         stampShadowIds(plan.next.pages);
@@ -65,7 +59,7 @@ export function useSourceShadowSync(): void {
           refusal: null,
         });
       } else {
-        shadow({ doc: s.sourceShadow?.doc ?? null, refusal: plan.reason });
+        s.setSourceRefusal(plan.reason);
       }
     }, DEBOUNCE_MS);
     return () => clearTimeout(id);

--- a/src/hooks/useZplOutputView.ts
+++ b/src/hooks/useZplOutputView.ts
@@ -3,6 +3,7 @@ import { generateMultiPageZplWithMap } from "@zplab/core/lib/zplGenerator";
 import { sourceEditGate } from "@zplab/core/lib/zplSourceEdit";
 import { useLabelStore, useCurrentObjects, selectDocumentEmits } from "../store/labelStore";
 import { spanCoveredLines } from "../lib/emitSpanHighlight";
+import { isPureCrlf } from "../lib/zplCmHighlight";
 import { printerImpactNotices } from "../lib/exportImpact";
 import { usePrinterImpact } from "./usePrinterImpact";
 import { useT } from "./useT";
@@ -29,6 +30,7 @@ export function useZplOutputView(collapsed: boolean) {
     : { text: "", spans: [] };
   const zpl = emitted.text;
   const gate = zpl === "" ? null : sourceEditGate(zpl);
+  const refusal = gate !== null && !gate.ok ? gate.reason : null;
 
   const viewVisible = !collapsed && session === null;
   const highlightedLines = viewVisible
@@ -43,5 +45,11 @@ export function useZplOutputView(collapsed: boolean) {
   const impact = usePrinterImpact(zpl, viewVisible);
   const notices = impact ? printerImpactNotices(impact, t) : NO_NOTICES;
 
-  return { session, zpl, gate, highlightedLines, notices };
+  // What the pane shows (and copy copies): the live buffer during a session.
+  const shownText = session ? session.draft : zpl;
+  // The separator class pins the editor's CRLF facet at mount; keyed on the
+  // baseline so the class cannot flip mid-session.
+  const crlfKey = isPureCrlf(session ? session.baseline : zpl);
+
+  return { session, zpl, refusal, highlightedLines, notices, shownText, crlfKey };
 }

--- a/src/lib/dom.test.ts
+++ b/src/lib/dom.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { isEditableTarget } from "./dom";
+
+describe("isEditableTarget", () => {
+  it.each(["INPUT", "TEXTAREA", "SELECT"])("accepts a %s", (tag) => {
+    expect(isEditableTarget(document.createElement(tag))).toBe(true);
+  });
+
+  it("accepts every focusable node of a marked editor host", () => {
+    // Real CM shape: read-only focus lands on the scroller ABOVE the
+    // role=textbox content, gutters beside it; only the host marker covers them.
+    const host = document.createElement("div");
+    host.setAttribute("data-text-surface", "");
+    const scroller = document.createElement("div");
+    const content = document.createElement("div");
+    content.setAttribute("role", "textbox");
+    content.setAttribute("contenteditable", "false");
+    const gutter = document.createElement("div");
+    scroller.appendChild(content);
+    host.append(gutter, scroller);
+    document.body.appendChild(host);
+    expect(isEditableTarget(scroller)).toBe(true);
+    expect(isEditableTarget(content)).toBe(true);
+    expect(isEditableTarget(gutter)).toBe(true);
+    host.remove();
+  });
+
+  it("rejects plain elements", () => {
+    expect(isEditableTarget(document.createElement("div"))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -1,9 +1,16 @@
 /** Returns `true` when `el` is a text-input surface that should
  *  intercept keyboard events the global shortcuts and canvas
  *  handlers would otherwise act on (Backspace → delete object,
- *  Ctrl+A → select all objects, etc.). */
+ *  Ctrl+A → select all objects, etc.). `data-text-surface` marks editor
+ *  HOSTS whose focus target is not contenteditable itself (the read-only
+ *  CodeMirror pane focuses .cm-scroller; gutters sit beside .cm-content). */
 export function isEditableTarget(el: HTMLElement | null): boolean {
-  if (!el) return false;
+  // Listeners on window/document pass whatever `e.target` is; only elements
+  // can be editable (and only they have `closest`).
+  if (!el || !(el instanceof Element)) return false;
   const tag = el.tagName;
-  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+  return (
+    tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
+    el.isContentEditable || el.closest("[data-text-surface]") !== null
+  );
 }

--- a/src/lib/sourceEditText.ts
+++ b/src/lib/sourceEditText.ts
@@ -1,12 +1,12 @@
 import { MAX_SOURCE_PAGES, type SourceApplyPlan } from '@zplab/core/lib/zplSourceEdit';
 import type { Translations } from '../locales';
 
-type Refusal = Extract<SourceApplyPlan, { ok: false }>['reason'];
+export type SourceRefusal = Extract<SourceApplyPlan, { ok: false }>['reason'];
 
-/** The one reason→message mapping, shared by the editor's error line and the
- *  edit toggle's tooltip. ZPL command names stay out of the locale strings
- *  (translator safety) and interpolate here. */
-export function sourceRefusalText(reason: Refusal, t: Translations): string {
+/** The one reason→message mapping for every refusal surface. ZPL command
+ *  names stay out of the locale strings (translator safety) and
+ *  interpolate here. */
+export function sourceRefusalText(reason: SourceRefusal, t: Translations): string {
   switch (reason) {
     case 'empty':
       return t.importModal.errPasteFirst;

--- a/src/lib/zplCmHighlight.ts
+++ b/src/lib/zplCmHighlight.ts
@@ -46,3 +46,9 @@ export function opaquePayloadFold(
   }
   return null;
 }
+
+/** Pure-CRLF test for the editor's lineSeparator facet: only a buffer with no
+ *  bare \n may pin CRLF, else the LF parts collapse into one editor line. The
+ *  facet is fixed at mount, so the mount key and the mount read MUST agree. */
+export const isPureCrlf = (text: string): boolean =>
+  /\r\n/.test(text) && !/(?<!\r)\n/.test(text);

--- a/src/store/labelStore.selectors.ts
+++ b/src/store/labelStore.selectors.ts
@@ -5,6 +5,7 @@ import type { Dataset } from './slices/dataSlice';
 import type { ColumnMapping } from '@zplab/core/types/Variable';
 import type { LabelState } from './labelStore';
 import type { PageState } from './labelStore.internals';
+import type { SourceDocumentState } from '@zplab/core/lib/zplSourceEdit';
 import { designAsPageLabel, PER_LABEL_ZPL_FIELDS, type JmDensity, type LabelConfig, type PageLabel } from '@zplab/core/types/LabelConfig';
 
 export const currentObjects = (state: PageState): LabelObject[] =>
@@ -52,9 +53,25 @@ export const selectRenderDesignLabel = (s: LabelState): LabelConfig =>
 export const selectRenderColumnMapping = (s: LabelState) =>
   s.sourceShadow?.doc ? s.sourceShadow.doc.columnMapping : s.columnMapping;
 
+/** The document as prepareSourceApply consumes it: shadow parse and apply
+ *  MUST build it identically or the preview drifts from the commit. */
+export const selectSourceDocumentState = (s: LabelState): SourceDocumentState => ({
+  label: s.label,
+  pages: s.pages,
+  variables: s.variables,
+  printerProfile: s.printerProfile,
+  columnMapping: s.columnMapping,
+});
+
+/** THE landing rule when a page set shrinks under a kept index: stay, else
+ *  clamp to the last page. Shared by the shadow render, the source apply and
+ *  page removal, so preview and commit can never land on different pages. */
+export const clampPageIndex = (index: number, pageCount: number): number =>
+  Math.min(index, pageCount - 1);
+
 /** The shadow can have fewer pages than the live index points at. */
 export const selectRenderPageIndex = (s: LabelState): number =>
-  Math.min(s.currentPageIndex, selectRenderPages(s).length - 1);
+  clampPageIndex(s.currentPageIndex, selectRenderPages(s).length);
 
 export const selectRenderObjects = (s: LabelState): LabelObject[] =>
   selectRenderPages(s)[selectRenderPageIndex(s)]?.objects ?? [];

--- a/src/store/labelStore.ts
+++ b/src/store/labelStore.ts
@@ -67,6 +67,7 @@ export {
   selectRenderPageIndex,
   selectRenderObjects,
   selectRenderPageLabel,
+  selectSourceDocumentState,
   selectHasPerLabelOverrides,
   selectBatchInputs,
   selectCanBatchExport,

--- a/src/store/slices/objectSlice.ts
+++ b/src/store/slices/objectSlice.ts
@@ -25,7 +25,7 @@ import {
   freshPasteCopies,
   updateCurrentObjects,
 } from '../labelStore.internals';
-import { selectEditorFrozen, selectPreviewLocksEditor, selectRenderPages, currentObjects, currentPageLabel } from '../labelStore.selectors';
+import { selectEditorFrozen, selectPreviewLocksEditor, selectRenderPages, clampPageIndex, currentObjects, currentPageLabel } from '../labelStore.selectors';
 import type { LabelState } from '../labelStore';
 
 import { newId } from "@zplab/core/lib/ids";
@@ -544,7 +544,7 @@ export const createObjectSlice: StateCreator<LabelState, [], [], ObjectSlice> = 
       if (index < state.currentPageIndex) {
         newIndex = state.currentPageIndex - 1;
       } else if (index === state.currentPageIndex) {
-        newIndex = Math.min(state.currentPageIndex, newPages.length - 1);
+        newIndex = clampPageIndex(state.currentPageIndex, newPages.length);
       }
       return {
         pages: newPages,

--- a/src/store/slices/sourceEditSlice.test.ts
+++ b/src/store/slices/sourceEditSlice.test.ts
@@ -75,6 +75,33 @@ describe("applyZplSource", () => {
     expect(useLabelStore.temporal.getState().pastStates.length).toBe(depth + 1);
   });
 
+  it("stays on the user's page (clamped) instead of jumping to page 1", () => {
+    useLabelStore.setState({
+      pages: [basePages[0]!, { objects: [textObject("t2", "p2")] }],
+      currentPageIndex: 1,
+    });
+    applyCurrentZpl();
+    expect(useLabelStore.getState().currentPageIndex).toBe(1);
+    // A draft that dropped pages clamps to the last one, like the shadow.
+    applyCurrentZpl((zpl) => zpl.split("^XZ").slice(0, 1).join("") + "^XZ");
+    expect(useLabelStore.getState().pages).toHaveLength(1);
+    expect(useLabelStore.getState().currentPageIndex).toBe(0);
+  });
+
+  it("cancel clamps a page index that only the shadow had", () => {
+    useLabelStore.getState().enterSourceEdit("^XA^FDone^FS^XZ");
+    // The session allows paging through shadow pages the live doc lacks.
+    useLabelStore.setState({
+      sourceShadow: {
+        doc: { label: { widthMm: 70, heightMm: 40, dpmm: 8 }, pages: [basePages[0]!, { objects: [] }], variables: [], columnMapping: null },
+        refusal: null,
+      },
+      currentPageIndex: 1,
+    });
+    useLabelStore.getState().cancelSourceEdit();
+    expect(useLabelStore.getState().currentPageIndex).toBe(0);
+  });
+
   it("keeps the dataset and remaps the mapping onto the new variable ids", () => {
     const dataset = {
       headers: ["lot"],

--- a/src/store/slices/sourceEditSlice.ts
+++ b/src/store/slices/sourceEditSlice.ts
@@ -3,7 +3,7 @@ import type { SourceApplyPlan, SourceApplyOk } from '@zplab/core/lib/zplSourceEd
 import type { LabelConfig } from '@zplab/core/types/LabelConfig';
 import type { Page } from '@zplab/core/types/Group';
 import type { ColumnMapping, Variable } from '@zplab/core/types/Variable';
-import { selectEditorFrozen } from '../labelStore.selectors';
+import { selectEditorFrozen, clampPageIndex } from '../labelStore.selectors';
 import type { LabelState } from '../labelStore';
 
 export type SourceEditMode =
@@ -35,9 +35,11 @@ export interface SourceEditSlice {
    *  preview lock. */
   enterSourceEdit: (currentZpl: string) => void;
   setSourceDraft: (draft: string) => void;
-  /** Written only by the shadow-parse effect; ignored outside a session so a
-   *  late parse cannot resurrect a preview after the session ended. */
+  /** Written by the shadow-parse effect and by a refused apply; ignored
+   *  outside a session so a late parse cannot resurrect a preview. */
   setSourceShadow: (shadow: SourceShadow) => void;
+  /** Refusal only, keeping the last good doc: the one "set a refusal" op. */
+  setSourceRefusal: (refusal: SourceShadow['refusal']) => void;
   cancelSourceEdit: () => void;
   /** Commits a prepared plan as ONE undo step. Unlike loadDesign this keeps
    *  history and dataset: the document keeps its identity, only its ZPL
@@ -79,9 +81,24 @@ export const createSourceEditSlice: StateCreator<LabelState, [], [], SourceEditS
   setSourceShadow: (shadow) =>
     set((state) => (state.sourceEdit.status === 'editing' ? { sourceShadow: shadow } : {})),
 
+  setSourceRefusal: (refusal) =>
+    set((state) =>
+      state.sourceEdit.status === 'editing'
+        ? { sourceShadow: { doc: state.sourceShadow?.doc ?? null, refusal } }
+        : {},
+    ),
+
   cancelSourceEdit: () =>
     set((state) =>
-      state.sourceEdit.status === 'off' ? {} : { sourceEdit: { status: 'off' }, sourceShadow: null },
+      state.sourceEdit.status === 'off'
+        ? {}
+        : {
+            sourceEdit: { status: 'off' },
+            sourceShadow: null,
+            // The session allowed paging through shadow-only pages; the live
+            // document may not have them.
+            currentPageIndex: clampPageIndex(state.currentPageIndex, state.pages.length),
+          },
     ),
 
   applyZplSource: (plan, session) => {
@@ -96,7 +113,8 @@ export const createSourceEditSlice: StateCreator<LabelState, [], [], SourceEditS
       variables: plan.next.variables,
       printerProfile: plan.next.printerProfile,
       columnMapping: plan.next.columnMapping,
-      currentPageIndex: 0,
+      // The implicit blur-apply must not yank a multi-page edit to page 1.
+      currentPageIndex: clampPageIndex(get().currentPageIndex, plan.next.pages.length),
       selectedIds: [],
       // Mapping drafts seed from variable ids and the settings modal from the
       // profile, both at mount; the apply replaces both sources. Unlike


### PR DESCRIPTION
The output panel is always the CodeMirror editor; the first modifying keystroke starts the session, leaving the panel applies (dialog on loss, refusal holds), Escape discards.