### PR TITLE
fix(fonts): register FontFace from bytes, not a url(data:) source

### DIFF
--- a/packages/core/src/lib/fontCache.ts
+++ b/packages/core/src/lib/fontCache.ts
@@ -50,12 +50,28 @@ function printerNameToFamily(name: string): string {
   return 'zpl-' + name.replace(/\.[^.]+$/, '').toUpperCase();
 }
 
+/** Base64 payload of a data URL as bytes, or undefined for a malformed URL. */
+function dataUrlBytes(dataUrl: string): Uint8Array | undefined {
+  const commaIdx = dataUrl.indexOf(",");
+  if (commaIdx < 0) return undefined;
+  const binary = atob(dataUrl.slice(commaIdx + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
 /** Resolves true when the face registered, false when the bytes were rejected
  *  (invalid font, unsupported outlines) or the API is unavailable. Callers on
- *  the interactive upload path surface the failure; background paths ignore it. */
+ *  the interactive upload path surface the failure; background paths ignore it.
+ *  Binary source, NOT `url(data:...)`: the url form is a font-src fetch, which
+ *  the desktop CSP blocks (no `data:` there, deliberately). */
 async function registerFontFace(entry: CachedFont): Promise<boolean> {
   try {
-    const face = new FontFace(entry.fontFamily, `url(${entry.dataUrl})`);
+    const bytes = dataUrlBytes(entry.dataUrl);
+    if (!bytes) return false;
+    const face = new FontFace(entry.fontFamily, bytes.buffer as ArrayBuffer);
     await face.load();
     document.fonts.add(face);
     return true;
@@ -104,15 +120,7 @@ export function isEmbedLarge(printerName: string): boolean {
 export function getFontBytes(printerName: string): Uint8Array | undefined {
   const entry = cache.get(printerName.toUpperCase());
   if (!entry) return undefined;
-  const commaIdx = entry.dataUrl.indexOf(",");
-  if (commaIdx < 0) return undefined;
-  const base64 = entry.dataUrl.slice(commaIdx + 1);
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
+  return dataUrlBytes(entry.dataUrl);
 }
 
 /** Uint8Array variant; parser hands these over after decoding ~DY. */

--- a/src/lib/fontCache.test.ts
+++ b/src/lib/fontCache.test.ts
@@ -40,6 +40,30 @@ describe('fontCache', () => {
 
   // ── loadFontFile ─────────────────────────────────────────────────────────────
 
+  it('registers the FontFace from bytes, never a url() source', async () => {
+    // Regression (#356 comment): a url(data:...) source is a font-src fetch,
+    // which the desktop CSP blocks; every upload failed there.
+    const sources: unknown[] = [];
+    const Original = globalThis.FontFace;
+    class CapturingFontFace {
+      constructor(_family: string, source: unknown) {
+        sources.push(source);
+      }
+      load() {
+        return Promise.resolve(this);
+      }
+    }
+    vi.stubGlobal('FontFace', CapturingFontFace);
+    try {
+      await loadFontFile(makeFakeFile('arial.ttf'), 'ARIAL.TTF');
+    } finally {
+      vi.stubGlobal('FontFace', Original);
+    }
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toBeInstanceOf(ArrayBuffer);
+    expect(new TextDecoder().decode(sources[0] as ArrayBuffer)).toBe('fake-font-data');
+  });
+
   it('loadFontFile stores font and can be retrieved via getFont', async () => {
     const entry = await loadFontFile(makeFakeFile('arial.ttf'), 'ARIAL.TTF');
     expect(entry.name).toBe('ARIAL.TTF');


### PR DESCRIPTION
The url form is a font-src fetch the desktop CSP blocks, so every desktop upload failed (#356 comment).