### PR TITLE
fix(code49): ^B4 h is a row-height multiplier, f is N/A/B

### DIFF
--- a/packages/core/src/lib/barcodeDims.ts
+++ b/packages/core/src/lib/barcodeDims.ts
@@ -51,7 +51,13 @@ import {
 } from "./barcodeRawGeometry";
 import { code11CheckDigits } from "./barcodeCheckDigits";
 import { barcodeTextZoneDots, barcodeZoneAbove } from "./barcodeHri";
+import { code49Module, code49RowMultiplier } from "../registry/code49";
 import { placeholderContentFor, samplePropsFor } from "../registry/placeholderContent";
+
+/** bwip rowheight in modules. Not shared with code49: there the module is
+ *  what the BYTES carry, here it is a render detail (^B7/^BB/^BF h are dots). */
+const bwipRowModules = (rowHeightDots: number, moduleWidth: number, min: number): number =>
+  Math.max(min, Math.round(rowHeightDots / Math.max(moduleWidth, 1)));
 
 /** The bwip-js surface the kernel needs; any build satisfies it. */
 export interface BwipEngine {
@@ -286,10 +292,9 @@ export function buildBwipOptions(
     }
     case "code49": {
       const p = obj.props;
-      const scale = bwipScale1D(p.moduleWidth, renderScale, renderDpmm);
-      // Clamp to bwip's 8..50 range; guards JSON loads that bypass registry.
-      const rawRow = Math.round(p.height / Math.max(p.moduleWidth, 1));
-      const rowheight = Math.min(50, Math.max(8, rawRow));
+      const mw = code49Module(p.moduleWidth);
+      const scale = bwipScale1D(mw, renderScale, renderDpmm);
+      const rowheight = code49RowMultiplier(p.height, mw);
       opts = {
         bcid,
         text: p.content || "0",
@@ -458,10 +463,7 @@ export function buildBwipOptions(
         bcid,
         text: p.content || " ",
         scale: BWIP_SCALE,
-        rowheight: Math.max(
-          1,
-          Math.round(p.rowHeight / Math.max(p.moduleWidth, 1)),
-        ),
+        rowheight: bwipRowModules(p.rowHeight, p.moduleWidth, 1),
         columns,
         // ZPL securityLevel 0 = auto → ECC level 0 (minimum). 1–8 map directly
         // to bwip eclevel 1–8 (empirically validated against Labelary).
@@ -511,10 +513,7 @@ export function buildBwipOptions(
         scale: BWIP_SCALE,
         columns: version.columns,
         rows: version.rows,
-        rowheight: Math.max(
-          1,
-          Math.round(p.rowHeight / Math.max(p.moduleWidth, 1)),
-        ),
+        rowheight: bwipRowModules(p.rowHeight, p.moduleWidth, 1),
       };
       break;
     }
@@ -530,10 +529,7 @@ export function buildBwipOptions(
         // firmware counts characters, so numeric data stacks into fewer rows on
         // the printer (codablock stays "unverified").
         columns: Math.max(CODABLOCK_PREVIEW_COLUMNS_MIN, clampCodablockColumns(p.columns)),
-        rowheight: Math.max(
-          8,
-          Math.round(p.rowHeight / Math.max(p.moduleWidth, 1)),
-        ),
+        rowheight: bwipRowModules(p.rowHeight, p.moduleWidth, 8),
       };
       break;
     }
@@ -730,15 +726,14 @@ function getUprightDisplaySize(
       return { w, h };
     }
     case "code49": {
-      // Labelary only renders HRI for ^B4; bwip is ground truth (same as ^BB).
+      // bwip's canvas already carries the separator rows (ZD230-verified);
+      // the firmware-reserved HRI band rides on top like the other 1Ds.
       const p = obj.props;
-      const rawRow = Math.round(p.height / Math.max(p.moduleWidth, 1));
-      const rowheightUnits = Math.min(50, Math.max(8, rawRow));
-      const modulePx = dotsToPx(p.moduleWidth, scale, dpmm);
-      const bwipSc = get1DBwipScale(p.moduleWidth, scale, dpmm);
-      const numRows = Math.max(1, Math.round(ch / (rowheightUnits * bwipSc)));
+      const mw = code49Module(p.moduleWidth);
+      const modulePx = dotsToPx(mw, scale, dpmm);
+      const bwipSc = get1DBwipScale(mw, scale, dpmm);
       const w = (cw / bwipSc) * modulePx;
-      const h = numRows * dotsToPx(rowheightUnits * p.moduleWidth, scale, dpmm);
+      const h = (ch / bwipSc) * modulePx + dotsToPx(barcodeTextZoneDots(obj), scale, dpmm);
       return { w, h };
     }
     case "code39":
@@ -806,10 +801,7 @@ function getUprightDisplaySize(
     }
     case "codablock": {
       const p = obj.props;
-      const specRowheight = Math.max(
-        8,
-        Math.round(p.rowHeight / Math.max(p.moduleWidth, 1)),
-      );
+      const specRowheight = bwipRowModules(p.rowHeight, p.moduleWidth, 8);
       const w =
         (cw / BWIP_SCALE + CODABLOCK_FIRMWARE_MODULE_OFFSET) *
         dotsToPx(p.moduleWidth, scale, dpmm);

--- a/packages/core/src/lib/barcodeHri.test.ts
+++ b/packages/core/src/lib/barcodeHri.test.ts
@@ -22,7 +22,6 @@ const UNMEASURED_HRI_ZONE: ReadonlySet<string> = new Set([
   "plessey",
   "planet",
   "postal",
-  "code49",
   "gs1databar",
 ]);
 

--- a/packages/core/src/lib/barcodeHri.ts
+++ b/packages/core/src/lib/barcodeHri.ts
@@ -51,6 +51,7 @@ export const HRI_LINE_TYPES: ReadonlySet<string> = new Set([
   "codabar",
   "industrial2of5",
   "standard2of5",
+  "code49",
 ]);
 
 /** HRI line height in dots, Labelary-measured at 6 and 8 dpmm over module
@@ -73,6 +74,9 @@ export function barcodeTextZoneDots(obj: LeafObject): number {
   const printsHri = HRI_LINE_TYPES.has(obj.type) && p.printInterpretation === true;
   if (!printsHri) return 0;
   const moduleWidth = p.moduleWidth ?? 2;
+  // A measured per-type band wins over the generic module-scaled line.
+  const own = ObjectRegistry[obj.type]?.hri?.zoneDots;
+  if (own) return own(moduleWidth, resolveHriAbove(obj));
   // The registry predicate, not a raw props read: a type that cannot carry GS1
   // must not claim the taller band off a stray flag.
   return isGs1Active(ObjectRegistry[obj.type], obj.props)

--- a/packages/core/src/lib/zplParser/context.ts
+++ b/packages/core/src/lib/zplParser/context.ts
@@ -186,6 +186,8 @@ export interface FieldState {
   /** ^BC m=D (UCC/EAN) → GS1-128; consumed by the code128 case in flushField. */
   bcGs1: boolean;
   bcCode49Mode: Code49Props["mode"];
+  /** ^B4 h as sent, or null when omitted; resolved at ^FS. */
+  bcCode49Mult: number | null;
   // ^GS symbol pending
   symRot: ZplRotation;
   symH: number;
@@ -433,6 +435,7 @@ export function freshFieldState(): FieldState {
     bcRotation: "N",
     bcGs1: false,
     bcCode49Mode: "A",
+    bcCode49Mult: null,
     symRot: "N",
     symH: 30,
     symW: 30,

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -31,7 +31,7 @@ import type { DataMatrixProps } from "../../registry/datamatrix";
 import type { Barcode1DProps } from "../../registry/barcode1d";
 import type { Gs1DatabarProps } from "../../registry/gs1databar";
 import type { Pdf417Props } from "../../registry/pdf417";
-import type { Code49Props } from "../../registry/code49";
+import { code49Module, code49SnapHeight, type Code49Props } from "../../registry/code49";
 import {
   DEFAULT_GS_SYMBOL,
   GS_SYMBOL_CODES,
@@ -55,6 +55,17 @@ import {
 } from "./context";
 
 import { newId } from "../ids";
+
+/** Resolved at ^FS, where the ^BY module is final. The h-less form sizes the
+ *  WHOLE symbol, so its row count is a content-dependent approximation. */
+function code49HeightDots(s: ParserState): number {
+  const mw = code49Module(s.defaults.byModuleWidth);
+  const mult = s.field.bcCode49Mult;
+  const raw = mult === null ? ((s.defaults.byHeight || 20) - 3 * mw) / 2 : mult * mw;
+  const height = code49SnapHeight(raw, mw);
+  if (mult === null || height !== raw) s.result.partialCmds.add("^B4");
+  return height;
+}
 /** Cross-family deps flushField borrows from graphics (^GB+^FR) and parseZPL (^FX). */
 export interface FlushFieldDeps {
   commitPendingReverseBg: () => void;
@@ -551,9 +562,10 @@ export function createFlushField(
             s.field.y,
             {
               content,
-              height: s.field.bcHeight,
+              height: code49HeightDots(s),
               moduleWidth: s.defaults.byModuleWidth,
               printInterpretation: s.field.bcInterp,
+              printInterpretationAbove: s.field.bcInterpAbove,
               mode: s.field.bcCode49Mode,
               rotation: s.field.bcRotation,
             } satisfies Code49Props,

--- a/packages/core/src/lib/zplParser/handlers/barcodes.ts
+++ b/packages/core/src/lib/zplParser/handlers/barcodes.ts
@@ -5,7 +5,7 @@ import type { Gs1DatabarProps } from "../../../registry/gs1databar";
 import { clampMaxicodeAppend, type MaxicodeProps } from "../../../registry/maxicode";
 import { GS1_DATABAR_DEFAULT_SEGMENTS } from "../../gs1";
 import type { ParserState } from "../context";
-import { dotsFor, int, readRotation } from "../helpers";
+import { dotsFor, int, readRotation, strParam } from "../helpers";
 import type { Handler } from "../types";
 
 /** ^B* barcode commands + shared ^BY defaults. Touches `field` and `defaults`. */
@@ -77,8 +77,14 @@ export function createBarcodeHandlers(s: ParserState): Record<string, Handler> {
     B4(p) {
       s.field.fieldType = "code49";
       s.field.bcRotation = readRotation(p[0]);
-      s.field.bcHeight = dots(p[1], defaults.byHeight || 20);
-      s.field.bcInterp = (p[2] ?? "N") === "Y";
+      const mult = int(p[1], NaN);
+      s.field.bcCode49Mult = Number.isNaN(mult) ? null : mult;
+      // f knows only N/A/B (ZD230-measured); flag the rest, because our own
+      // pre-fix exports wrote Y for "on" and now read as HRI-off.
+      const f = strParam(p[2]) || "N";
+      s.field.bcInterp = f === "A" || f === "B";
+      s.field.bcInterpAbove = f === "A";
+      if (!["N", "A", "B"].includes(f)) s.result.partialCmds.add("^B4");
       const m = (p[3] ?? "A").toUpperCase();
       s.field.bcCode49Mode = /^[A0-5]$/.test(m)
         ? (m as Code49Props["mode"])

--- a/packages/core/src/registry/code49.ts
+++ b/packages/core/src/registry/code49.ts
@@ -1,6 +1,6 @@
 import type { ObjectTypeCore } from '../types/ObjectType';
 import { fieldPos1d, fdFieldFor } from './zplHelpers';
-import { commitBarcodeWidthHeightTransform } from './transformHelpers';
+import { commitBarcodeWidthHeightTransform, stackRowCount } from './transformHelpers';
 import { limitedSupportPreflight } from '../lib/barcodeScannability';
 import { type ZplRotation } from './rotation';
 
@@ -9,15 +9,38 @@ export type Code49Mode = 'A' | '0' | '1' | '2' | '3' | '4' | '5';
 
 export const CODE49_MODES: readonly Code49Mode[] = ['A', '0', '1', '2', '3', '4', '5'];
 
-// bwip-js rejects code49 rowheight outside 8..50 modules.
-export const code49MinHeight = (moduleWidth: number) => 8 * Math.max(moduleWidth, 1);
-export const code49MaxHeight = (moduleWidth: number) => 50 * Math.max(moduleWidth, 1);
+/** bwip-js rejects a code49 rowheight outside this module window. */
+const ROW_MODULES = { min: 8, max: 50 };
+
+export const code49MinHeight = (moduleWidth: number) => ROW_MODULES.min * code49Module(moduleWidth);
+export const code49MaxHeight = (moduleWidth: number) => ROW_MODULES.max * code49Module(moduleWidth);
+
+/** ^B4 divides the height by the module the bytes carry, so ^BY emits whole
+ *  dots and every reader rounds the same way. */
+export const code49Module = (moduleWidth: number) => Math.max(1, Math.round(moduleWidth));
+
+/** ^B4 h is a whole row-height multiplier (spec p. 74), within bwip's window.
+ *  The one derivation: a second spelling would answer differently. */
+export const code49RowMultiplier = (height: number, moduleWidth: number): number => {
+  const raw = Math.round(height / code49Module(moduleWidth));
+  return Math.min(ROW_MODULES.max, Math.max(ROW_MODULES.min, Number.isFinite(raw) ? raw : 8));
+};
+
+/** The nearest height the bytes can actually carry. */
+export const code49SnapHeight = (height: number, moduleWidth: number): number =>
+  code49RowMultiplier(height, moduleWidth) * code49Module(moduleWidth);
+
+/** Rows behind a measured stack; reads the SNAPPED start height, the one bwip
+ *  actually drew. Rows hold still through a resize. */
+const code49Rows = (start: { rowHeight: number; nodeHeight: number }, mw: number): number =>
+  Math.max(2, Math.round(stackRowCount(start.nodeHeight, code49SnapHeight(start.rowHeight, mw), mw)));
 
 export interface Code49Props {
   content: string;
   height: number;
   moduleWidth: number;
   printInterpretation: boolean;
+  printInterpretationAbove: boolean;
   mode: Code49Mode;
   rotation: ZplRotation;
 }
@@ -30,56 +53,66 @@ export const code49: ObjectTypeCore<Code49Props> = {
   barcodeClass: '1d',
   bindable: true,
   preflight: limitedSupportPreflight<Code49Props>('moduleWidth'),
+  // ZD230-measured at module widths 2/3/4: 26/35/44 above, 20/27/34 below.
+  hri: { zoneDots: (mw, above) => (above ? 9 : 7) * code49Module(mw) + (above ? 8 : 6) },
   defaultProps: {
     content: '',
     height: 20,
     moduleWidth: 2,
     printInterpretation: true,
+    printInterpretationAbove: false,
     mode: 'A',
     rotation: 'N',
   },
   placeholderContent: 'CODE49',
   defaultSize: { width: 300, height: 120 },
 
-  // Clamp height into bwip's range so drag past the limit lands in
-  // props (not just in the render); otherwise ZPL h drifts from
-  // the visible bars.
+  // Snap so a drag past the limit lands in props, not just in the render.
   commitTransform: (obj, ctx) => {
     const next = commitBarcodeWidthHeightTransform(obj, ctx);
     const mw = next.moduleWidth ?? obj.props.moduleWidth;
     const rawH = next.height ?? obj.props.height;
-    return {
-      ...next,
-      height: Math.min(code49MaxHeight(mw), Math.max(code49MinHeight(mw), rawH)),
-    };
+    return { ...next, height: code49SnapHeight(rawH, mw) };
   },
 
-  // Re-clamp height when moduleWidth shifts the valid range (the
-  // height input's own min/max only guards its own field). Skip on
-  // non-positive moduleWidth so JSON-import / undo with garbage
-  // doesn't anchor the clamp.
+  // The height input's min/max guards only its own field. Non-positive
+  // widths (JSON import, undo with garbage) must not anchor the clamp.
   normalizeChanges: (obj, changes) => {
     const nextProps = changes.props as Partial<Code49Props> | undefined;
-    if (!nextProps || nextProps.moduleWidth === undefined) return changes;
-    const newMw = nextProps.moduleWidth;
-    if (!Number.isFinite(newMw) || newMw < 1) return changes;
+    if (!nextProps) return changes;
+    const mwChanged = nextProps.moduleWidth !== undefined;
+    const heightChanged = nextProps.height !== undefined;
+    if (!mwChanged && !heightChanged) return changes;
+    const mw = nextProps.moduleWidth ?? obj.props.moduleWidth;
+    if (!Number.isFinite(mw) || mw < 1) return changes;
     const curH = nextProps.height ?? obj.props.height;
-    const clampedH = Math.min(
-      code49MaxHeight(newMw),
-      Math.max(code49MinHeight(newMw), curH),
-    );
-    return clampedH === curH
+    // Only a height edit snaps here; a width-only sweep would otherwise
+    // ratchet the height up pass by pass. (Release still snaps, via commit.)
+    const nextH = heightChanged
+      ? code49SnapHeight(curH, mw)
+      : Math.min(code49MaxHeight(mw), Math.max(code49MinHeight(mw), curH));
+    return nextH === curH
       ? changes
-      : { ...changes, props: { ...nextProps, height: clampedH } };
+      : { ...changes, props: { ...nextProps, height: nextH } };
   },
+
+  // A one-module separator sits above, below and between the rows.
+  barStack: (start, props) => {
+    const gapDots = code49Module(props.moduleWidth);
+    return { rows: code49Rows(start, gapDots), gapDots };
+  },
+
+  constrainProps: (props) => ({ height: code49SnapHeight(props.height, props.moduleWidth) }),
 
   toZPL: (obj, ctx) => {
     const p = obj.props;
-    const interp = p.printInterpretation ? 'Y' : 'N';
+    const mw = code49Module(p.moduleWidth);
+    const h = code49RowMultiplier(p.height, mw);
+    const interp = p.printInterpretation ? (p.printInterpretationAbove ? 'A' : 'B') : 'N';
     return [
-      `^BY${p.moduleWidth}`,
+      `^BY${mw}`,
       fieldPos1d(obj, ctx),
-      `^B4${p.rotation},${p.height},${interp},${p.mode}`,
+      `^B4${p.rotation},${h},${interp},${p.mode}`,
       fdFieldFor(p.content, ctx),
     ]
       .filter(Boolean)

--- a/packages/core/src/registry/transformHelpers.ts
+++ b/packages/core/src/registry/transformHelpers.ts
@@ -96,6 +96,24 @@ export function commitBarcodeWidthHeightTransform<
   return out as Partial<P>;
 }
 
+/** A row stack: `extent = rows x rowHeight + (rows+1) x gapDots`. The three
+ *  directions live together so no consumer re-derives one of them. */
+export const stackExtentDots = (
+  stack: { rows: number; gapDots: number },
+  rowHeightDots: number,
+): number => stack.rows * rowHeightDots + (stack.rows + 1) * stack.gapDots;
+
+export const stackRowHeightDots = (
+  stack: { rows: number; gapDots: number },
+  extentDots: number,
+): number => (extentDots - (stack.rows + 1) * stack.gapDots) / stack.rows;
+
+export const stackRowCount = (
+  extentDots: number,
+  rowHeightDots: number,
+  gapDots: number,
+): number => (extentDots - gapDots) / (rowHeightDots + gapDots);
+
 interface Stacked2DProps {
   rowHeight: number;
   moduleWidth: number;

--- a/packages/core/src/types/ObjectType.ts
+++ b/packages/core/src/types/ObjectType.ts
@@ -91,6 +91,12 @@ export interface ObjectTypeCore<P extends object = object> {
   /** ^BY moduleWidth lower bound for stacked-2D resize (default 1); CODABLOCK A
    *  requires 2. Drives both the drag-time snap and the release commit. */
   moduleWidthMin?: number;
+  /** Row-stacked 1D (^B4): the height prop holds ONE row, so the reflow
+   *  converts through stackExtentDots. Absent = the prop IS the extent. */
+  barStack?: (
+    start: { rowHeight: number; nodeHeight: number },
+    props: P,
+  ) => { rows: number; gapDots: number };
   /** Further 1-10 module-width props (TLC39's ^BT w2) so the density rescale
    *  scales them like moduleWidth without a per-type special case. */
   extraModuleWidthProps?: readonly (keyof P & string)[];
@@ -101,6 +107,9 @@ export interface ObjectTypeCore<P extends object = object> {
   fdTransform?: (
     obj: LabelObjectBase & { props: P },
   ) => ((payload: string) => string) | undefined;
+  /** Props that constrain each other (^B4 ties the height to the module
+   *  grid), independent of which edit arrived: batch paths call it directly. */
+  constrainProps?: (props: P) => Partial<P>;
   /** Pure hook for type-specific clamp/invariant on incoming changes. */
   normalizeChanges?: (
     obj: LabelObjectBase & { props: P },

--- a/packages/core/src/types/ZplEmit.ts
+++ b/packages/core/src/types/ZplEmit.ts
@@ -47,6 +47,9 @@ export interface HriFormatProps {
 export interface HriBehavior {
   /** HRI sits above bars (logmars, ^BS). */
   textAbove?: boolean;
+  /** Firmware-reserved band in dots when the generic module-scaled line does
+   *  not match it (^B4 differs above vs below). */
+  zoneDots?: (moduleWidth: number, above: boolean) => number;
   /** Bar-to-text gap in dots; function form for moduleWidth dependence (^BS). */
   aboveGapDots?: number | ((moduleWidth: number) => number);
   /** Transform raw content for display; default identity. `props` is the

--- a/packages/mcp-server/src/barcodeHriZone.test.ts
+++ b/packages/mcp-server/src/barcodeHriZone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { HRI_LINE_TYPES, hriZoneDots } from "@zplab/core/lib/barcodeHri";
+import { HRI_LINE_TYPES, barcodeTextZoneDots, hriZoneDots } from "@zplab/core/lib/barcodeHri";
 import { registerSidecarFootprintMeasurer } from "./footprint";
 import { createDraft } from "./tools";
 
@@ -25,9 +25,25 @@ function height(type: string, printInterpretation: boolean): number {
 
 describe("HRI zone", () => {
   it("adds the measured band for every type that prints an interpretation line", () => {
+    // An independent constant, or the loop would only compare the kernel
+    // against itself; ^B4 has its own measured band and is pinned below.
     const zone = hriZoneDots(2);
     for (const type of HRI_LINE_TYPES) {
+      if (type === "code49") continue;
       expect(height(type, true) - height(type, false), `${type} zone`).toBe(zone);
+    }
+  });
+
+  it("reserves ^B4's measured band on the side the line prints", () => {
+    // ZD230 at mw 2/3/4: 26/35/44 above the bars, 20/27/34 below.
+    for (const [mw, above, below] of [[2, 26, 20], [3, 35, 27], [4, 44, 34]] as const) {
+      const zone = (printInterpretationAbove: boolean) =>
+        barcodeTextZoneDots({
+          id: "z", type: "code49", x: 0, y: 0,
+          props: { moduleWidth: mw, printInterpretation: true, printInterpretationAbove },
+        } as never);
+      expect(zone(true), `mw ${mw} above`).toBe(above);
+      expect(zone(false), `mw ${mw} below`).toBe(below);
     }
   });
 

--- a/packages/mcp-server/src/boundary.ts
+++ b/packages/mcp-server/src/boundary.ts
@@ -461,6 +461,15 @@ export const PROP_SUMMARIES: Record<string, Record<string, string>> = {
     blockLineSpacing: "dots added between lines",
     blockJustify: "L | C | R | J inside the block",
   },
+  code49: {
+    content: "string payload",
+    height: "height of ONE row in dots; the symbol stacks 2-8 of them",
+    moduleWidth: "narrow-bar width in dots",
+    printInterpretation: "boolean, show human-readable text",
+    printInterpretationAbove: "boolean, put that text above the bars",
+    mode: "A (auto) or 0-5 starting mode",
+    rotation: "N | R | I | B",
+  },
   code128: {
     content: "string payload",
     height: "bar height in dots",

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -2,6 +2,7 @@ import { useRef, useEffect, useLayoutEffect } from "react";
 import { flushSync } from "react-dom";
 import type Konva from "konva";
 import { dotsToPx, pxToDots } from "@zplab/core/lib/coordinates";
+import { stackExtentDots, stackRowHeightDots } from "@zplab/core/registry/transformHelpers";
 import { blockBoundsDots, blockGlyphAnchorPoint, blockReflowGeometry, tbBoundsDots, tbReflowGeometry, type BlockJustify, type ZplRotation } from "@zplab/core/lib/zebraTextLayout";
 import { resolveDeviceFontId } from "@zplab/core/lib/customFonts";
 import { getCurrentObjects, useLabelStore } from "../../../store/labelStore";
@@ -121,6 +122,19 @@ function applyResizeObjectSnap(
 /** Invisible rect at the selection's model union; the transformer attaches to
  *  it for multi-resize so member nodes never stretch live. */
 export const MULTI_RESIZE_PROXY_ID = "multi-resize-proxy";
+
+/** The row geometry a stacked 1D symbology drags against; null when the prop
+ *  already IS the bar extent. One drag-start pair serves both axes. */
+function rowStackOf(
+  entry: ReturnType<typeof getEntry>,
+  br: { uprightH0?: number; snapshot: { height?: number } },
+  props: unknown,
+): { rows: number; gapDots: number } | null {
+  const nodeHeight = br.uprightH0 ?? 0;
+  const rowHeight = br.snapshot.height ?? 0;
+  if (!entry?.barStack || !(nodeHeight > 0) || !(rowHeight > 0)) return null;
+  return entry.barStack({ rowHeight, nodeHeight }, props as never);
+}
 
 /** Shapes whose reflow is center-aware (box/ellipse); line resizes via endpoint
  *  handles, not this reflow, so it stays out. One source for both the arming and
@@ -284,6 +298,8 @@ export function useKonvaTransformer({
     | (BarcodeHeightReflowStart & {
         mode: "height";
         uprightW0: number;
+        /** Bar extent at drag start, dots; pairs with snapshot.height. */
+        uprightH0: number;
         snapshot: { x: number; y: number; height: number };
         changed: boolean;
         lastCentered: boolean;
@@ -758,7 +774,9 @@ export function useKonvaTransformer({
           rightX: leftX + dotsToPx(cache.width, scale, dpmm),
           bottomY: topY + dotsToPx(cache.height, scale, dpmm),
         };
-        const uprightH0 = cache.uprightBarHDots ?? p.height ?? 0;
+        // The props fallback would be off by the row count here.
+        const rowStacked = !!getEntry(obj.type)?.barStack;
+        const uprightH0 = cache.uprightBarHDots ?? (rowStacked ? 0 : (p.height ?? 0));
         const mwAxisActive = swapped ? edges.top || edges.bottom : edges.left || edges.right;
         const heightAxisActive = swapped ? edges.left || edges.right : edges.top || edges.bottom;
         if (mwAxisActive && typeof p.moduleWidth === "number" && p.moduleWidth > 0) {
@@ -795,6 +813,7 @@ export function useKonvaTransformer({
             edges,
             ...box,
             zonePx: Math.max(0, dotsToPx(axisFootprintDots - uprightH0, scale, dpmm)),
+            uprightH0,
             uprightW0: cache.uprightBarWDots ?? 0,
             snapshot: { x: obj.x, y: obj.y, height: p.height },
             changed: false,
@@ -999,12 +1018,19 @@ export function useKonvaTransformer({
           // axis keeps its pre-drag model value (mirrors the end commit's
           // snapAxis), else the bar-zone offset (above-HRI, rotated EAN) that
           // the FO inversion ignores would corrupt the stored anchor coordinate.
+          // A row-stacked type re-rounds its rows against the new module, so
+          // its stack extent moves during a WIDTH drag too.
+          const widened = { ...cur.props, moduleWidth: geo.moduleWidth };
+          const mwStack = rowStackOf(getEntry(cur.type), br, widened);
+          const stackH = mwStack
+            ? stackExtentDots(mwStack, br.snapshot.height ?? 0)
+            : br.uprightH0;
           const model = modelPositionFromRenderedTopLeft(
             cur,
             pxToDots(geo.targetXPx - objectsOffsetX, scale, dpmm),
             pxToDots(geo.targetYPx - labelOffsetY, scale, dpmm),
             br.uprightW0 * ratio,
-            br.uprightH0,
+            stackH,
           );
           // TLC39's second module width follows the same ratio so the
           // composite keeps its proportions mid-drag.
@@ -1045,10 +1071,15 @@ export function useKonvaTransformer({
       const frameExtentPx = swapped ? natural.width * sx : natural.height * sy;
       const geo = barcodeHeightReflowGeometry(br, frameExtentPx, centered);
       if (!geo) return;
-      const newHeightDots = pxToDots(geo.barExtentPx, scale, dpmm);
+      const measuredBarDots = pxToDots(geo.barExtentPx, scale, dpmm);
+      const entry = getEntry(cur.type);
+      const stack = rowStackOf(entry, br, cur.props);
+      const newHeightDots = stack
+        ? stackRowHeightDots(stack, measuredBarDots)
+        : measuredBarDots;
       const hCurrent = (cur.props as { height?: number }).height;
       if (!(newHeightDots >= 1)) return;
-      const commitFn = getEntry(cur.type)?.commitTransform;
+      const commitFn = entry?.commitTransform;
       const candidate = { ...cur, props: { ...cur.props, height: newHeightDots } } as typeof cur;
       const committed = commitFn?.(candidate, {
         sx: 1,
@@ -1059,7 +1090,9 @@ export function useKonvaTransformer({
         resizeMode: blockResizeModeRef.current,
       }) as { height?: number } | undefined;
       const hNext = committed?.height ?? newHeightDots;
-      const pin = barcodeHeightReflowGeometry(br, dotsToPx(hNext, scale, dpmm), centered);
+      // Everything below places the BARS, so a per-row height maps back first.
+      const barNext = stack ? stackExtentDots(stack, hNext) : hNext;
+      const pin = barcodeHeightReflowGeometry(br, dotsToPx(barNext, scale, dpmm), centered);
       if (!pin) return;
       if (hNext !== hCurrent || modeFlip) {
         const model = modelPositionFromRenderedTopLeft(
@@ -1067,7 +1100,7 @@ export function useKonvaTransformer({
           pxToDots(pin.targetXPx - objectsOffsetX, scale, dpmm),
           pxToDots(pin.targetYPx - labelOffsetY, scale, dpmm),
           br.uprightW0,
-          hNext,
+          barNext,
         );
         flushSync(() => {
           updateObject(id, {

--- a/src/components/Properties/HriAboveRow.tsx
+++ b/src/components/Properties/HriAboveRow.tsx
@@ -1,0 +1,23 @@
+import { CheckboxRow } from './CheckboxRow';
+import { useT } from '../../hooks/useT';
+
+/** The "text above the bars" toggle every HRI-capable symbology shows. */
+export function HriAboveRow({
+  checked,
+  onChange,
+  cmd,
+}: {
+  checked: boolean | undefined;
+  onChange: (printInterpretationAbove: boolean) => void;
+  cmd: string;
+}) {
+  const t = useT();
+  return (
+    <CheckboxRow
+      checked={checked ?? false}
+      onChange={onChange}
+      label={t.registry.text.hriAbove}
+      cmd={cmd}
+    />
+  );
+}

--- a/src/lib/densityRescale.test.ts
+++ b/src/lib/densityRescale.test.ts
@@ -455,3 +455,18 @@ describe("derived label field sets", () => {
     ]);
   });
 });
+
+describe("code49 keeps its module grid across a rescale", () => {
+  it("re-snaps the height the independently scaled module invalidated", () => {
+    // 6->8 dpmm scales 40 dots to 53 and the module to 3: h would emit as 18
+    // and print 54, so state, bytes and re-import each hold a different number.
+    const c49 = leaf("c", "code49", 10, 10, {
+      content: "CODE49", height: 40, moduleWidth: 2, printInterpretation: false,
+      printInterpretationAbove: false, mode: "A", rotation: "N",
+    });
+    const r = rescaleDesign(page(c49), label, 6, 8, { dpmm: 8 });
+    const out = r.pages[0]!.objects[0] as typeof c49;
+    expect(out.props.moduleWidth).toBe(3);
+    expect(out.props.height).toBe(54);
+  });
+});

--- a/src/lib/densityRescale.ts
+++ b/src/lib/densityRescale.ts
@@ -162,6 +162,10 @@ function rescaleLeaf(leaf: LeafObject, factor: number, warnings: RescaleWarning[
     if (r.clamped) warn(usp.name, usp.name === "dimension" ? "dimensionClamped" : "magnificationClamped");
   }
 
+  // Height and module were scaled independently above, so a type whose props
+  // constrain each other re-establishes that here.
+  Object.assign(next, entry?.constrainProps?.(next as never) ?? {});
+
   // Device fonts A-H render at discrete magnifications, so a non-integer factor
   // makes the printed size snap rather than scale exactly.
   if (leaf.type === "text" && factor !== 1) {

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -4,7 +4,7 @@ import { generateZPL, generateMultiPageZPL, generateBatchZpl } from '@zplab/core
 import { parseZPL } from '@zplab/core/lib/zplParser';
 import type { LabelConfig, PageLabel } from '@zplab/core/types/LabelConfig';
 import type { GroupObject, LabelObject } from '@zplab/core/types/Group';
-import { defined, parseSingle, props, serialOf } from '../test/helpers';
+import { defined, parseSingle, props, serialOf, commandsOf } from '../test/helpers';
 import { NON_EMITTING_CONFIG_KEYS } from '../store/labelStore.internals';
 import { putImage } from '@zplab/core/lib/imageCache';
 
@@ -1219,25 +1219,82 @@ describe('generateZPL — parse/generate roundtrip', () => {
   });
 
   it('round-trips a ^B4 Code 49 with default mode A', () => {
-    const original = parseSingle('^XA^FO10,10^B4N,20,Y,A^FDCODE49^FS^XZ', 8);
+    // h=20 at the default ^BY2 module is 40 dots per row; f=Y prints NO line.
+    const original = parseSingle('^XA^FO10,10^B4N,20,B,A^FDCODE49^FS^XZ', 8);
     const regenerated = generateZPL(BASE_LABEL, original.objects);
+    expect(regenerated).toContain('^B4N,20,B,A');
     const reparsed = parseSingle(regenerated, 8);
     const bc = defined(reparsed.objects.find((o) => o.type === 'code49'));
     expect(props(bc).content).toBe('CODE49');
-    expect(props(bc).height).toBe(20);
+    expect(props(bc).height).toBe(40);
     expect(props(bc).printInterpretation).toBe(true);
+    expect(props(bc).printInterpretationAbove).toBe(false);
     expect(props(bc).mode).toBe('A');
+  });
+
+  it('resolves ^B4 height against the ^BY the FIELD closes with', () => {
+    // The module is only settled at ^FS; reading it at ^B4 time built one
+    // object from two different ^BY states.
+    const r = parseSingle('^XA^BY2^FO10,10^B4N,20,B,A^BY4^FDCODE49^FS^XZ', 8);
+    const bc = defined(r.objects.find((o) => o.type === 'code49'));
+    expect(props(bc).moduleWidth).toBe(4);
+    expect(props(bc).height).toBe(80);
+  });
+
+  it('clamps an out-of-range ^B4 h into the window the canvas can draw', () => {
+    // bwip refuses rows outside 8..50 modules; without the clamp the model
+    // held 400 while the canvas drew 100 and the re-emit printed 400.
+    const r = parseSingle('^XA^BY2^FO10,10^B4N,200,B,A^FDCODE49^FS^XZ', 8);
+    const bc = defined(r.objects.find((o) => o.type === 'code49'));
+    expect(props(bc).height).toBe(100);
+    expect(commandsOf(r, 'partial')).toContain('^B4');
+  });
+
+  it('emits a whole module, so a fractional ^BY cannot inflate the height', () => {
+    const zpl = generateZPL(BASE_LABEL, [{
+      id: 'c', type: 'code49', x: 10, y: 10, rotation: 0,
+      props: { content: 'CODE49', height: 20, moduleWidth: 2.5, printInterpretation: false,
+        printInterpretationAbove: false, mode: 'A', rotation: 'N' },
+    }] as never);
+    expect(zpl).toContain('^BY3');
+    const bc = defined(parseSingle(zpl, 8).objects.find((o) => o.type === 'code49'));
+    expect(props(bc).moduleWidth).toBe(3);
+    // 20 dots is below the 8-module floor at mw 3, so it lands on it.
+    expect(props(bc).height).toBe(24);
+  });
+
+  it('reads ^B4 f: A is above, the invalid Y prints no line (ZD230)', () => {
+    const above = parseSingle('^XA^FO10,10^B4N,20,A,A^FDCODE49^FS^XZ', 8);
+    const bcA = defined(above.objects.find((o) => o.type === 'code49'));
+    expect(props(bcA).printInterpretation).toBe(true);
+    expect(props(bcA).printInterpretationAbove).toBe(true);
+    const y = parseSingle('^XA^FO10,10^B4N,20,Y,A^FDCODE49^FS^XZ', 8);
+    const bcY = defined(y.objects.find((o) => o.type === 'code49'));
+    expect(props(bcY).printInterpretation).toBe(false);
   });
 
   it('round-trips ^B4 explicit mode + rotation + moduleWidth', () => {
     const original = parseSingle('^XA^BY3^FO10,10^B4R,30,N,2^FD12345^FS^XZ', 8);
     const regenerated = generateZPL(BASE_LABEL, original.objects);
+    expect(regenerated).toContain('^B4R,30,N,2');
     const reparsed = parseSingle(regenerated, 8);
     const bc = defined(reparsed.objects.find((o) => o.type === 'code49'));
     expect(props(bc).rotation).toBe('R');
     expect(props(bc).moduleWidth).toBe(3);
+    expect(props(bc).height).toBe(90);
     expect(props(bc).mode).toBe('2');
     expect(props(bc).printInterpretation).toBe(false);
+  });
+
+  it('reads a missing ^B4 h as the ^BY TOTAL height, two-row approximation', () => {
+    // ZD230: without h the ^BY height IS the whole symbol (40 -> 40 dots);
+    // the row height lands on the grid so the import survives re-export.
+    const zpl = '^XA^BY2,3,40^FO10,10^B4N,,N,A^FDCODE49^FS^XZ';
+    const r = parseSingle(zpl, 8);
+    const bc = defined(r.objects.find((o) => o.type === 'code49'));
+    expect(props(bc).height).toBe(18);
+    const again = parseSingle(generateZPL(BASE_LABEL, r.objects), 8);
+    expect(props(defined(again.objects.find((o) => o.type === 'code49'))).height).toBe(18);
   });
 
   it('falls back to mode A when ^B4 receives an unknown mode', () => {

--- a/src/registry/barcode1d.panel.tsx
+++ b/src/registry/barcode1d.panel.tsx
@@ -12,6 +12,7 @@ import { fieldMode, boundDefaultOrContent, fieldVariableRefs, fieldHasVariable, 
 import { gs1EnablePatch } from '@zplab/core/registry/gs1FieldSpec';
 import { Gs1BuilderButton } from './gs1PanelControls';
 import { CheckboxRow } from '../components/Properties/CheckboxRow';
+import { HriAboveRow } from '../components/Properties/HriAboveRow';
 import { extractClockTokens } from '@zplab/core/lib/fcTemplate';
 import { SectionCard, StaticSectionCard } from '../components/Properties/SectionCard';
 import { FieldLabel } from '../components/Properties/ZplCmd';
@@ -134,10 +135,9 @@ export function createBarcode1DPanel(config: Barcode1DPanelConfig): ObjectTypeUi
             )}
 
             {!config.interpretationLocked && config.hriAboveConfigurable && p.printInterpretation && (
-              <CheckboxRow
-                checked={p.printInterpretationAbove ?? false}
+              <HriAboveRow
+                checked={p.printInterpretationAbove}
                 onChange={(printInterpretationAbove) => onChange({ printInterpretationAbove })}
-                label={t.registry.text.hriAbove}
                 cmd={config.zplCommand}
               />
             )}

--- a/src/registry/code49.panel.tsx
+++ b/src/registry/code49.panel.tsx
@@ -6,6 +6,7 @@ import { NumberInput } from '../components/Properties/NumberInput';
 import { UnitNumberInput } from '../components/Properties/UnitNumberInput';
 import { SectionCard, StaticSectionCard } from '../components/Properties/SectionCard';
 import { CheckboxRow } from '../components/Properties/CheckboxRow';
+import { HriAboveRow } from '../components/Properties/HriAboveRow';
 import { FieldLabel } from '../components/Properties/ZplCmd';
 import { Select } from '../components/ui/Select';
 import { fieldGridCols, fieldGridCell } from '../components/ui/formStyles';
@@ -70,6 +71,14 @@ export const code49Panel: ObjectTypeUi<Code49Props> = {
             label={loc.printInterpretation}
             cmd="^B4"
           />
+
+          {p.printInterpretation && (
+            <HriAboveRow
+              checked={p.printInterpretationAbove}
+              onChange={(printInterpretationAbove) => onChange({ printInterpretationAbove })}
+              cmd="^B4"
+            />
+          )}
 
           <RotationSelect value={p.rotation} onChange={(rotation) => onChange({ rotation })} zplCmd="^B4" />
         </SectionCard>

--- a/src/registry/code49.test.ts
+++ b/src/registry/code49.test.ts
@@ -1,17 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { code49 } from '@zplab/core/registry/code49';
+import { stackExtentDots, stackRowHeightDots } from '@zplab/core/registry/transformHelpers';
 import type { Code49Props } from '@zplab/core/registry/code49';
 import type { LabelObjectBase } from '@zplab/core/types/LabelObject';
 import type { PreflightCtx } from '@zplab/core/types/preflight';
 /**
- * The four-layer height-clamp contract for ^B4 Code 49:
- *   - UI:        NumberInput min/max blocks invalid typing
- *   - normalize: moduleWidth change re-clamps height across fields
- *   - commit:    Konva transformer drag past bwip's range pins to limit
- *   - render:    bwipHelpers clamps as a last-line defense for JSON loads
- *
- * The UI layer is enforced by HTML form behavior and not unit-tested
- * here; the other three layers live in pure code and get coverage below.
+ * Five paths write ^B4's height; all resolve through code49RowMultiplier.
+ * The UI row is HTML min/max and is not unit-tested here.
  */
 
 const baseObj = (
@@ -27,6 +22,7 @@ const baseObj = (
     height: 20,
     moduleWidth: 2,
     printInterpretation: true,
+    printInterpretationAbove: false,
     mode: 'A',
     rotation: 'N',
     ...overrides,
@@ -63,6 +59,19 @@ describe('code49 — normalizeChanges height clamp on moduleWidth change', () =>
     const obj = baseObj({ height: 20, moduleWidth: 2 });
     const changes = { props: { moduleWidth: 0 } };
     expect(code49.normalizeChanges?.(obj, changes)).toBe(changes);
+  });
+
+  it('leaves the height alone on a width-only gesture (no ratchet)', () => {
+    // Snapping on every module change inflated the height each pass: a drag
+    // out and back would grow a 40-dot row by a third.
+    let h = 60;
+    for (const moduleWidth of [3, 4, 5, 6, 7, 6, 5, 4, 3, 2]) {
+      const changes = code49.normalizeChanges?.(baseObj({ height: h, moduleWidth: 2 }), {
+        props: { moduleWidth },
+      });
+      h = (changes?.props as Partial<Code49Props>).height ?? h;
+    }
+    expect(h).toBe(60);
   });
 
   it('respects an incoming height that is already valid for the new moduleWidth', () => {
@@ -112,10 +121,34 @@ describe('code49 — limited-support preflight', () => {
   });
 });
 
+describe('code49 — the row stack the reflow drags against', () => {
+  // 2 rows at mw 2: 2*40 + 3*2 = 86 dots of bars.
+  const start = { rowHeight: 40, nodeHeight: 86 };
+  const props = (over: Partial<Code49Props> = {}) => baseObj(over).props;
+
+  it('describes the stack the transformer converts with', () => {
+    expect(code49.barStack?.(start, props())).toEqual({ rows: 2, gapDots: 2 });
+  });
+
+  it('round-trips an extent through the row height and back', () => {
+    const stack = code49.barStack!(start, props());
+    const h = stackRowHeightDots(stack, 86);
+    expect(h).toBe(40);
+    expect(stackExtentDots(stack, h)).toBe(86);
+  });
+
+  it('counts rows from the height bwip actually drew, not the raw prop', () => {
+    // 20 dots at mw 3 renders at the 8-module floor (24), so an 8-row stack
+    // measures 8*24 + 9*3 = 219; the raw prop would imply 9 rows.
+    const stack = code49.barStack?.({ rowHeight: 20, nodeHeight: 219 }, props({ moduleWidth: 3 }));
+    expect(stack).toEqual({ rows: 8, gapDots: 3 });
+  });
+});
+
 describe('code49 — commitTransform at identity scale (live-reflow contract)', () => {
   // The barcode live reflow bakes per-tick heights and re-commits them through
-  // commitTransform with sx=sy=1 and identity snap: the call must act as a
-  // pure range clamp, and must not disturb already-valid props.
+  // commitTransform with sx=sy=1 and identity snap: the call clamps into
+  // bwip's window and snaps onto the module grid, nothing else.
   const identityCtx = { sx: 1, sy: 1, snap: (v: number) => v, nodeHeight: 0, anchor: null };
 
   it('clamps an out-of-range baked height at both bounds', () => {
@@ -125,8 +158,17 @@ describe('code49 — commitTransform at identity scale (live-reflow contract)', 
     expect(high?.height).toBe(100);
   });
 
-  it('passes valid props through unchanged', () => {
-    const result = code49.commitTransform?.(baseObj({ height: 40, moduleWidth: 3 }), identityCtx);
-    expect(result).toMatchObject({ height: 40, moduleWidth: 3 });
+  it('snaps height onto the module grid: off-grid values cannot round-trip', () => {
+    // h speaks whole multipliers; 40 at mw 3 would emit 13 and re-parse as 39,
+    // so state, bytes and model would each hold a different number.
+    const commit = code49.commitTransform?.(baseObj({ height: 40, moduleWidth: 3 }), identityCtx);
+    expect(commit).toMatchObject({ height: 39 });
+    const panel = code49.normalizeChanges?.(baseObj({ moduleWidth: 3 }), { props: { height: 40 } });
+    expect((panel?.props as Partial<Code49Props>).height).toBe(39);
+  });
+
+  it('passes grid-aligned props through unchanged', () => {
+    const result = code49.commitTransform?.(baseObj({ height: 42, moduleWidth: 3 }), identityCtx);
+    expect(result).toMatchObject({ height: 42, moduleWidth: 3 });
   });
 });


### PR DESCRIPTION
ZD230-measured: the printer renders h x module dots per row, so our emit was module-times too tall; f=Y prints no interpretation line at all. One derivation now answers dots-to-multiplier for emit, parse, canvas and commit, and the reflow drags against a row-stack descriptor.