### PR TITLE
fix(canvas): restore and harden the WebKit reverse-text fix

### DIFF
--- a/packages/core/src/lib/fontCache.ts
+++ b/packages/core/src/lib/fontCache.ts
@@ -65,8 +65,9 @@ function dataUrlBytes(dataUrl: string): Uint8Array | undefined {
 /** Resolves true when the face registered, false when the bytes were rejected
  *  (invalid font, unsupported outlines) or the API is unavailable. Callers on
  *  the interactive upload path surface the failure; background paths ignore it.
- *  Binary source, NOT `url(data:...)`: the url form is a font-src fetch, which
- *  the desktop CSP blocks (no `data:` there, deliberately). */
+ *  Binary source, NOT `url(data:...)`: WKWebView enforces font-src even on
+ *  FontFace loads, and byte registration plus `font-src data:` is the combo
+ *  that works across engines (#356). */
 async function registerFontFace(entry: CachedFont): Promise<boolean> {
   try {
     const bytes = dataUrlBytes(entry.dataUrl);
@@ -80,10 +81,27 @@ async function registerFontFace(entry: CachedFont): Promise<boolean> {
   }
 }
 
+/** Rejected bytes leave the cache entirely (fontStyle and family derive
+ *  from cache membership, so a zombie entry would read as a real face and
+ *  lose the calibrated PrintLab-bold fallback). notify() runs either way:
+ *  consumers measured against the UA fallback until the face landed. */
+function settleRegistration(entry: CachedFont): Promise<void> {
+  return registerFontFace(entry).then((ok) => {
+    if (!ok) rollbackEntry(entry);
+    notify();
+  });
+}
+
+function rollbackEntry(entry: CachedFont): void {
+  cache.delete(entry.name);
+  safeLocalStorageRemove(LS_PREFIX + entry.name);
+}
+
 hydrateLocalStoragePrefix<CachedFont>(LS_PREFIX, (entry) => {
   cache.set(entry.name, entry);
-  // Re-register asynchronously; canvas renders after React mounts.
-  void registerFontFace(entry);
+  // Async re-register; settle bumps the cache version so measurements
+  // re-run once the face is live (or the stale row is dropped).
+  void settleRegistration(entry);
 });
 
 /** Look up a cached font by printer filename (case-insensitive). */
@@ -129,8 +147,7 @@ export async function loadFontBytes(
   printerName: string,
 ): Promise<CachedFont> {
   const entry = registerBytes(bytes, printerName);
-  await registerFontFace(entry);
-  notify();
+  await settleRegistration(entry);
   return entry;
 }
 
@@ -140,7 +157,7 @@ export function loadFontBytesSync(
   printerName: string,
 ): CachedFont {
   const entry = registerBytes(bytes, printerName);
-  void registerFontFace(entry).then(notify);
+  void settleRegistration(entry);
   notify();
   return entry;
 }
@@ -179,12 +196,10 @@ export async function loadFontFile(file: File, printerName: string): Promise<Cac
   const bytes = new Uint8Array(await file.arrayBuffer());
   const entry = registerBytes(bytes, printerName);
   if (!(await registerFontFace(entry))) {
-    // Bytes rejected (e.g. an OTF the engine can't parse): roll back so the
-    // caller shows the upload error instead of a silent no-preview row. Roll
-    // back via the primitives (not removeFont) so a font that never existed
-    // doesn't fire a cache-changed notification before we throw.
-    cache.delete(entry.name);
-    safeLocalStorageRemove(LS_PREFIX + entry.name);
+    // Roll back without notify (unlike settleRegistration): the caller
+    // shows the upload error, and a font that never existed must not fire
+    // a cache-changed notification before we throw.
+    rollbackEntry(entry);
     throw new Error(`Font could not be registered: ${file.name}`);
   }
   notify();

--- a/packages/core/src/lib/labelGeometry/textRenderMetrics.ts
+++ b/packages/core/src/lib/labelGeometry/textRenderMetrics.ts
@@ -24,6 +24,11 @@ export interface TextRenderMetrics {
   /** Canvas-only resolved bitmap device font (A-H); single source for
    *  consumers that need the id beside the metrics (line pitch, bounds). */
   deviceFontId?: string;
+  /** Style the render and the measure share. Bold only for the PrintLab
+   *  Font-0 substitute (real bold face, calibrated so); device substitutes
+   *  and custom TTFs render at their real weight like the printer, and
+   *  synthetic bold hollows out under WebKit's 'difference' (#356). */
+  fontStyle: "normal" | "bold";
 }
 
 /** Parser feeds these (no obj at parse time). */
@@ -40,9 +45,6 @@ export interface TextMetricsInput {
   /** Canvas-only bitmap device-font size/scale (A-H snap to magnifications). */
   fontSizeDots?: number;
   scaleXOverride?: number;
-  /** Canvas-only: device fonts paint at this weight, so inkWidth must measure
-   *  it too (emit/parse omit it and keep the default bold). */
-  measureFontStyle?: string;
   /** Canvas-only device-font inter-char spacing folded into inkWidth so the
    *  reverse-box / ^FPR width matches the letter-spaced render. */
   letterSpacingDots?: number;
@@ -53,31 +55,43 @@ const DEFAULT_FONT_FAMILY = "'PrintLab ZPL', sans-serif";
 export function computeTextRenderMetrics(input: TextMetricsInput): TextRenderMetrics {
   const { content, fontHeight, fontWidth, printerFontName, defaultPrinterFontName } = input;
   const effectiveFontName = printerFontName || defaultPrinterFontName;
-  const fontFamily =
-    input.fontFamilyOverride ??
-    (effectiveFontName
-      ? (getFontFamily(effectiveFontName) ?? DEFAULT_FONT_FAMILY)
-      : DEFAULT_FONT_FAMILY);
+  const cachedFamily = effectiveFontName ? getFontFamily(effectiveFontName) : undefined;
+  const fontFamily = input.fontFamilyOverride ?? cachedFamily ?? DEFAULT_FONT_FAMILY;
   const fontScaleX =
     input.scaleXOverride ?? (fontWidth > 0 ? fontWidth / fontHeight : 1);
   const measureSizeDots =
     input.fontSizeDots ?? fontHeight / ZPL_FONT_HEIGHT_TO_CSS_RATIO;
+  // Style follows the RESOLVED face, so a referenced-but-unloaded TTF that
+  // falls back to the substitute keeps its calibrated bold (metrics feed the
+  // anchor math); a real face renders and measures at its own weight. Read
+  // off the resolution branch, never by comparing family strings.
+  const fontStyle: "normal" | "bold" =
+    input.fontFamilyOverride || cachedFamily ? "normal" : "bold";
   const glyphWidthDots = measureInkWidthPx(
     content,
     measureSizeDots,
     fontFamily,
-    input.measureFontStyle,
+    fontStyle,
   );
   const spacingDots =
     (input.letterSpacingDots ?? 0) * Math.max(0, content.length - 1);
   const inkWidthDots = (glyphWidthDots + spacingDots) * fontScaleX;
-  return { content, fontFamily, fontScaleX, inkWidthDots, fontSizeDots: input.fontSizeDots };
+  return {
+    content,
+    fontFamily,
+    fontScaleX,
+    inkWidthDots,
+    fontSizeDots: input.fontSizeDots,
+    fontStyle,
+  };
 }
 
 /** Ink extent feeding the FO/I and FO/B anchor shift: cell grid for bitmap
  *  device fonts, measured PrintLab width otherwise. The single derivation
  *  shared by emit and parse; one-sided drift breaks byte-exact round-trips
- *  for rotated fields. */
+ *  for rotated fields. Depends on live font-cache state, which is safe:
+ *  untouched imports replay verbatim from the overlay, and dirty fields
+ *  regenerate with parse and emit reading the same cache. */
 export function anchorInkWidthDots(input: {
   fontId: string | undefined;
   content: string;
@@ -136,7 +150,6 @@ export function getTextRenderMetrics(
       fontFamilyOverride,
       fontSizeDots: device?.fontSizeDots,
       scaleXOverride: device?.scaleX,
-      measureFontStyle: device ? "normal" : undefined,
       letterSpacingDots: device?.letterSpacingDots,
     }),
     yOffsetDots: device?.yOffsetDots,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -528,9 +528,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
-      "devCsp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:5173 ws://localhost:5173; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:*; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+      "devCsp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* http://localhost:5173 ws://localhost:5173; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
     }
   },
   "plugins": {

--- a/src/components/Canvas/KonvaObject.tsx
+++ b/src/components/Canvas/KonvaObject.tsx
@@ -613,10 +613,7 @@ function KonvaObjectInner({
   if (obj.type === "text" && textMetrics) {
     const p = obj.props;
     const { content, fontFamily, fontScaleX, fontSizePx } = textMetrics;
-    // Bitmap device fonts (A-H) carry their own weight via the substitute
-    // family (Vera Mono / Bold, OCR); forcing bold there faux-bolds them
-    // thicker than Labelary. Font 0 / custom uploads stay bold.
-    const fontStyle = textMetrics.fontSizeDots != null ? "normal" : "bold";
+    const fontStyle = textMetrics.fontStyle;
     // Device-font position trims (cap-top / left-bearing) vs Labelary.
     const deviceXOffPx = dotsToPx(textMetrics.xOffsetDots ?? 0, scale, dpmm);
     const deviceYOffPx = dotsToPx(textMetrics.yOffsetDots ?? 0, scale, dpmm);
@@ -679,8 +676,12 @@ function KonvaObjectInner({
             rotation: zplRotationDeg[p.rotation],
             fill: reverseText ? "#ffffff" : "#000000",
             globalCompositeOperation: reverseText ? "difference" : "source-over",
-            stroke: isSelected ? colors.selection : undefined,
-            strokeWidth: isSelected ? 1 : 0,
+            // No glyph stroke under 'difference': the stroke pass inverts
+            // against the fill (halo/hollow edges, #399); the transformer
+            // frame still marks the selection, like reverseShapeStyle does
+            // for filled shapes.
+            stroke: isSelected && !reverseText ? colors.selection : undefined,
+            strokeWidth: isSelected && !reverseText ? 1 : 0,
             letterSpacing: fpLetterSpacingPx + deviceLetterSpacingPx,
             offsetXPx: fpShiftXPx + deviceXOffPx,
             offsetYPx: deviceYOffPx,

--- a/src/lib/fontCache.test.ts
+++ b/src/lib/fontCache.test.ts
@@ -4,6 +4,7 @@ import {
   getFontFamily,
   getAllFonts,
   loadFontFile,
+  loadFontBytes,
   removeFont,
   subscribe,
   fontByteLength,
@@ -41,8 +42,7 @@ describe('fontCache', () => {
   // ── loadFontFile ─────────────────────────────────────────────────────────────
 
   it('registers the FontFace from bytes, never a url() source', async () => {
-    // Regression (#356 comment): a url(data:...) source is a font-src fetch,
-    // which the desktop CSP blocks; every upload failed there.
+    // Regression #356; the why lives at registerFontFace's doc header.
     const sources: unknown[] = [];
     const Original = globalThis.FontFace;
     class CapturingFontFace {
@@ -140,6 +140,23 @@ describe('fontCache', () => {
 
   it('getAllFonts returns empty array when nothing is loaded', () => {
     expect(getAllFonts()).toHaveLength(0);
+  });
+
+  it('drops the cache entry when the engine rejects the bytes', async () => {
+    // The why lives at settleRegistration's doc header.
+    class RejectingFontFace {
+      load() { return Promise.reject(new Error('bad font')); }
+    }
+    const Original = globalThis.FontFace;
+    vi.stubGlobal('FontFace', RejectingFontFace);
+    try {
+      const entry = await loadFontBytes(new Uint8Array([1, 2, 3]), 'BROKEN.TTF');
+      expect(entry.name).toBe('BROKEN.TTF');
+      expect(getFontFamily('BROKEN.TTF')).toBeUndefined();
+      expect(localStorage.getItem('zplab.font.BROKEN.TTF')).toBeNull();
+    } finally {
+      vi.stubGlobal('FontFace', Original);
+    }
   });
 
   // ── removeFont ────────────────────────────────────────────────────────────────

--- a/src/lib/labelGeometry/textRenderMetrics.test.ts
+++ b/src/lib/labelGeometry/textRenderMetrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getTextRenderMetrics } from "@zplab/core/lib/labelGeometry/textRenderMetrics";
+import { computeTextRenderMetrics, getTextRenderMetrics } from "@zplab/core/lib/labelGeometry/textRenderMetrics";
 import type { LabelObject } from "@zplab/core/types/Group";
 import type { LabelConfig } from "@zplab/core/types/LabelConfig";
 
@@ -72,5 +72,36 @@ describe("getTextRenderMetrics — device font resolution", () => {
     const m = getTextRenderMetrics(obj, undefined, label({ defaultFontId: "B" }));
     expect(m!.fontSizeDots).toBeUndefined();
     expect(m!.content).toBe("Abc");
+  });
+});
+
+describe("computeTextRenderMetrics fontStyle", () => {
+  it("derives the style from the RESOLVED face", async () => {
+    // Only the PrintLab substitute is bold (calibrated so); see #356.
+    expect(computeTextRenderMetrics({ content: "X", fontHeight: 30, fontWidth: 0 }).fontStyle)
+      .toBe("bold");
+    // Referenced but NOT loaded: falls back to the substitute, which must
+    // keep its calibrated bold or the anchor metrics measure the wrong face.
+    expect(
+      computeTextRenderMetrics({
+        content: "X", fontHeight: 30, fontWidth: 0, printerFontName: "MISSING.TTF",
+      }).fontStyle,
+    ).toBe("bold");
+    const { loadFontBytes, removeFont } = await import("@zplab/core/lib/fontCache");
+    await loadFontBytes(new Uint8Array([1, 2, 3]), "DINALTERNATE.TTF");
+    try {
+      expect(
+        computeTextRenderMetrics({
+          content: "X", fontHeight: 30, fontWidth: 0, printerFontName: "DINALTERNATE.TTF",
+        }).fontStyle,
+      ).toBe("normal");
+    } finally {
+      removeFont("DINALTERNATE.TTF");
+    }
+    expect(
+      computeTextRenderMetrics({
+        content: "X", fontHeight: 30, fontWidth: 0, fontFamilyOverride: "'Vera Mono'",
+      }).fontStyle,
+    ).toBe("normal");
   });
 });

--- a/src/test/desktopCsp.test.ts
+++ b/src/test/desktopCsp.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+/** Regression #399: a feature commit reverted the #396 CSP token and v0.4.0
+ *  shipped without it. Pins the invariant from outside the fix's file set. */
+describe("desktop CSP", () => {
+  it("allows data: fonts (WKWebView enforces font-src on FontFace loads)", () => {
+    const conf = JSON.parse(readFileSync("src-tauri/tauri.conf.json", "utf8"));
+    for (const key of ["csp", "devCsp"]) {
+      const csp: string = conf.app.security[key];
+      const fontSrc = csp.split(";").map((d) => d.trim()).find((d) => d.startsWith("font-src"));
+      expect(fontSrc, `${key} font-src`).toContain("data:");
+    }
+  });
+});


### PR DESCRIPTION
f6bf8a61 reverted all #396 files, so v0.4.0 shipped pre-fix (#399). Restores the merged state, drops the selection stroke under 'difference', rolls back rejected font bytes, and pins the CSP token with a config test.