### PR TITLE
fix(qr): pin the ^BY height an ^FO QR sinks by

### DIFF
--- a/packages/core/src/lib/bwipConstants.ts
+++ b/packages/core/src/lib/bwipConstants.ts
@@ -1,6 +1,5 @@
 import type { ZplRotation } from "../registry/rotation";
 
-export const QR_FO_Y_OFFSET_DOTS = 10;
 export const QR_FT_MODULE_OFFSET = 3;
 
 // Zebra always reserves text zone below EAN/UPC (8 and 12 dpmm: 13 dots).

--- a/packages/core/src/lib/objectBounds.ts
+++ b/packages/core/src/lib/objectBounds.ts
@@ -26,7 +26,8 @@ import { blockBoundsDots, blockLineWidthDots, EMPTY_TEXT_PLACEHOLDER_GLYPHS, isB
 import { effectiveFontHeightDots } from "./labelGeometry/deviceFonts";
 import { resolveDefaultSizeDots } from "./resolveDefaultSize";
 import { mmToDots } from "./coordinates";
-import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "./bwipConstants";
+import { QR_FT_MODULE_OFFSET } from "./bwipConstants";
+import { qrByHeight } from "./qrBy";
 
 export interface BoundingBoxDots {
   x: number;
@@ -178,7 +179,7 @@ function barcodeTopLeft(
     return { x: obj.x + off.x - barLeft, y: obj.y + off.y - qrShift - barTop };
   }
   if (obj.type === "qrcode" && !qrPrintsAsGraphic(obj)) {
-    return { x: obj.x - barLeft, y: obj.y + QR_FO_Y_OFFSET_DOTS - barTop };
+    return { x: obj.x - barLeft, y: obj.y + qrByHeight(obj.props) - barTop };
   }
   return { x: obj.x - barLeft, y: obj.y - barTop };
 }

--- a/packages/core/src/lib/qrBy.ts
+++ b/packages/core/src/lib/qrBy.ts
@@ -1,0 +1,19 @@
+// Lives in lib so both registry/qrcode and lib/qrGraphic may import it
+// without a registry<->lib cycle.
+
+/** ZPL power-up value of ^BY h (spec p.148); also what Labelary simulates. */
+export const QR_BY_DEFAULT_HEIGHT = 10;
+
+/** The one answer to "does this pin a ^BY height": positive integer. The spec
+ *  states no upper bound for ^BY h, and imports must round-trip whatever the
+ *  source printed with, so none is invented here. */
+export function isQrByHeight(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 1;
+}
+
+/** Effective ^BY height: the pinned prop or the power-up default. Also the
+ *  ^FO sink distance (see QrCodeProps.byHeight); render, bounds, drag inverse,
+ *  rescale and the emit all read this one function. */
+export function qrByHeight(props: { byHeight?: number }): number {
+  return props.byHeight ?? QR_BY_DEFAULT_HEIGHT;
+}

--- a/packages/core/src/lib/qrGraphic.ts
+++ b/packages/core/src/lib/qrGraphic.ts
@@ -2,6 +2,7 @@ import bwipjs from "bwip-js/browser";
 import { gfaFromRaster, type MonoRaster } from "./imageToZpl";
 import { formatSidecarComment, sidecarBody } from "./zplLabelMeta";
 import { isZplRotation, type ZplRotation } from "../registry/rotation";
+import { isQrByHeight } from "./qrBy";
 
 // ^BQ cannot rotate (firmware no-op, ZD230-verified), so a rotated QR emits as a
 // ^GFA of the exact module matrix plus a ZPLLAB sidecar for lossless reimport.
@@ -12,6 +13,8 @@ export interface QrGraphicInput {
   errorCorrection: "H" | "Q" | "M" | "L";
   model: 1 | 2;
   rotation: ZplRotation;
+  /** Pinned ^BY height, kept so a rotate-back re-emits the imported value. */
+  byHeight?: number;
 }
 
 /** Single source for the QR encode settings so canvas, preflight and graphic
@@ -120,6 +123,7 @@ export function formatQrSidecarComment(p: QrGraphicInput): string {
       ec: p.errorCorrection,
       model: p.model,
       rot: p.rotation,
+      ...(p.byHeight !== undefined ? { byh: p.byHeight } : {}),
     },
   });
   return formatSidecarComment(body);
@@ -144,6 +148,7 @@ export function parseQrSidecarComment(commentBody: string): QrGraphicInput | nul
   if (typeof q.content !== "string" || typeof q.mag !== "number") return null;
   if (!isEc(q.ec) || typeof q.rot !== "string" || !isZplRotation(q.rot)) return null;
   return {
+    ...(isQrByHeight(q.byh) ? { byHeight: q.byh } : {}),
     content: q.content,
     magnification: q.mag,
     errorCorrection: q.ec,

--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -11,6 +11,7 @@ import { getObjectStringContent } from "./variableBinding";
 import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
 import { stripLineWrap, stripTrailingSpaces, tokenize } from "./zplParser/helpers";
 import { lookaheadJmDensity, scanBareStream } from "./zplHeadScan";
+import { qrPrintsAsGraphic } from "./objectBounds";
 import { createParserState, deriveUnitScale, resetFormatScopedState, type FnDefaultCandidate } from "./zplParser/context";
 import { createFlushField } from "./zplParser/flushField";
 import { createBarcodeHandlers } from "./zplParser/handlers/barcodes";
@@ -299,6 +300,10 @@ export function parseZPL(
     // Start of a contiguous ^FX run immediately before a field, so the
     // field's span owns its comment bytes.
     commentStart: null as number | null,
+    // In-span ^BY sightings, from the tokenizer (so ^CC/^CD remaps count):
+    // any form, and one that fills the h slot the ^FO QR position depends on.
+    spanHasBy: false,
+    spanByHasH: false,
     // Format state that would re-interpret a regenerated object's bytes on
     // replay; drives the overlay's regenSafe flag (verbatim replay unaffected).
     regenHostileFormat: false,
@@ -581,23 +586,35 @@ export function parseZPL(
           if (box) linkObject(reverseBefore.span.start, reverseBefore.span.end, box.id);
           if (pg.ovStart !== null) pg.ovBase++;
         }
+        if (cmd === "BY" && pg.ovStart !== null) {
+          pg.spanHasBy = true;
+          // Mirrors the handler's capture: zero is no height (the session
+          // value stays in charge), so it must not count as a pin.
+          pg.spanByHasH ||= s.defaults.byHeight >= 1;
+        }
         if (cmd === "FO" || cmd === "FT") {
           pg.ovStart = pg.commentStart ?? start;
           pg.ovBase = objects.length;
           pg.commentStart = null;
+          pg.spanHasBy = false;
+          pg.spanByHasH = false;
         } else if (cmd === "FS" && pg.ovStart !== null) {
           const fieldEnd = start + 3;
           // A ^BY-consuming barcode whose ^BY sits outside its own field would
           // inherit a regenerated neighbour's inline ^BY on replay; mark the
-          // block unsafe. Classify by the parsed object type (not a regex) so
-          // 2D codes that ignore ^BY (QR/DataMatrix/Aztec/MaxiCode) stay
-          // regenSafe. The field's own object is the last one pushed.
+          // block unsafe. Classify by the parsed object type (not a regex).
+          // Of the 2D codes only ^FO QR consumes ^BY (its print sinks by the
+          // height, ZD230-measured); DataMatrix/Aztec/MaxiCode and ^FT QR are
+          // immune. The field's own object is the last one pushed.
           const own = objects.length > pg.ovBase ? objects[objects.length - 1] : undefined;
-          if (
-            own &&
-            BY_CONSUMING_BARCODE_TYPES.has(own.type) &&
-            !/\^BY/i.test(zpl.slice(pg.ovStart, fieldEnd))
-          ) {
+          // QR consumes only the h slot (position), so its ^BY must fill one;
+          // the 1D families consume w, which every ^BY form sets.
+          const hasNeededBy = own?.type === "qrcode" ? pg.spanByHasH : pg.spanHasBy;
+          const consumesBy = !!own && (
+            BY_CONSUMING_BARCODE_TYPES.has(own.type) ||
+            (own.type === "qrcode" && own.positionType !== "FT" && !qrPrintsAsGraphic(own))
+          );
+          if (consumesBy && !hasNeededBy) {
             pg.sawBareBarcode = true;
           }
           if (s.reverseBg && s.reverseBg.span === undefined && objects.length === pg.ovBase) {

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -420,6 +420,8 @@ export function createFlushField(
               model: s.field.qrModel === 1 ? 1 : 2,
               // ^BQ orientation slot is a no-op; rotated QRs arrive as ^GFA + sidecar.
               rotation: "N",
+              // Position, not size: the print sinks by this (see QrCodeProps).
+              ...(s.defaults.byHeight >= 1 ? { byHeight: s.defaults.byHeight } : {}),
             } satisfies QrCodeProps,
             posType,
             comment,

--- a/packages/core/src/lib/zplParser/handlers/barcodes.ts
+++ b/packages/core/src/lib/zplParser/handlers/barcodes.ts
@@ -46,7 +46,10 @@ export function createBarcodeHandlers(s: ParserState): Record<string, Handler> {
     // ^BY{moduleWidth},{ratio},{height}
     BY(p) {
       defaults.byModuleWidth = dots(p[0], 2);
-      defaults.byHeight = dots(p[2], 0);
+      // h is session-inherited: an h-less ^BY (or h=0, which firmware refuses)
+      // leaves the previous height in charge instead of resetting it.
+      const h = dots(p[2], 0);
+      if (h >= 1) defaults.byHeight = h;
     },
 
     // ── 1D barcodes via mkBarcode(type, hIdx, iIdx, iDefault?, cIdx?) ─────

--- a/packages/core/src/lib/zplParser/handlers/graphics.ts
+++ b/packages/core/src/lib/zplParser/handlers/graphics.ts
@@ -269,6 +269,7 @@ export function createGraphicsHandlers(
             errorCorrection: qr.errorCorrection,
             model: qr.model,
             rotation: qr.rotation,
+            ...(qr.byHeight !== undefined ? { byHeight: qr.byHeight } : {}),
           } satisfies QrCodeProps,
           getPosType(s.field),
           rest,

--- a/packages/core/src/registry/qrcode.ts
+++ b/packages/core/src/registry/qrcode.ts
@@ -6,6 +6,7 @@ import { hasTemplateMarkers } from '../lib/fnTemplate';
 import { formatQrSidecarComment, qrRotatedGfaCached } from '../lib/qrGraphic';
 import { clockCtxFromLabel, resolveContentPreview } from '../lib/markerResolve';
 import { type ZplRotation } from './rotation';
+import { qrByHeight } from '../lib/qrBy';
 
 /** ZPL prefixes the QR payload with `{ec}A,` inside ^FD. Shared by toZPL and
  *  the CSV batch override so a per-row value also gets the prefix. */
@@ -16,6 +17,8 @@ const qrFdTransform =
 
 export const MAGNIFICATION_MIN = 1;
 export const MAGNIFICATION_MAX = 10;
+// Re-exported from lib/qrBy (the cycle-free spot) because this is the prop's home.
+export { QR_BY_DEFAULT_HEIGHT, isQrByHeight, qrByHeight } from '../lib/qrBy';
 
 export interface QrCodeProps {
   content: string;
@@ -26,6 +29,10 @@ export interface QrCodeProps {
   /** ^BQ can't rotate (firmware no-op), so a non-N rotation emits a pre-rotated
    *  ^GFA graphic + sidecar. */
   rotation: ZplRotation;
+  /** ^BY height in effect at the source field. The firmware sinks an ^FO QR by
+   *  the session's ^BY height (ZD230: h-1, Labelary: h), so an unpinned field
+   *  prints wherever the printer's last ^BY put it; absent = power-up default. */
+  byHeight?: number;
 }
 
 // One switch for the capability flag and the emitter's chip resolution.
@@ -87,8 +94,12 @@ export const qrcode: ObjectTypeCore<QrCodeProps> = {
     // Prefix passed as the fdFieldFor transform (not baked into content) so it
     // composes with the binding: single-bind default / template / CSV override
     // all get the prefix instead of the payload being emitted raw.
+    // ^BY pins the height the ^FO sink depends on (w/r left empty: 1D fields
+    // carry their own ^BY). In-span, i.e. AFTER ^FO, so the overlay's bare-^BY
+    // check sees it and a regen replays it byte-exactly. ^FT anchors are immune.
     return [
       fieldPosZ(obj),
+      obj.positionType !== 'FT' ? `^BY,,${qrByHeight(p)}` : '',
       `^BQN,${p.model},${p.magnification}`,
       fdFieldFor(p.content, ctx, qrFdTransform(obj), undefined, CONTROL_CHARS),
     ].join('');

--- a/packages/mcp-server/src/boundary.ts
+++ b/packages/mcp-server/src/boundary.ts
@@ -11,6 +11,7 @@ import {
 import { getEntry, ObjectRegistry } from "@zplab/core/registry";
 import { gfShipsSafely, parseGfHeader } from "@zplab/core/registry/image";
 import { isZplRotation } from "@zplab/core/registry/rotation";
+import { isQrByHeight } from "@zplab/core/lib/qrBy";
 import { ZPL_PARAM_CHARS } from "@zplab/core/lib/zplParams";
 import { MAX_SOURCE_PAGES } from "@zplab/core/lib/zplSourceEdit";
 import {
@@ -307,6 +308,7 @@ const OPTIONAL_PROP_TYPES: Record<string, string> = {
   blockJustify: "string",
   blockHangingIndent: "number",
   blockHeight: "number",
+  byHeight: "number",
   textMode: "string",
   fpDirection: "string",
   fpCharGap: "number",
@@ -380,6 +382,13 @@ export function propIssues(
       issues.push(`${type}.${key} must not contain ^ ~ or , (they end the ZPL parameter)`);
       continue;
     }
+    // byHeight is a qrcode prop; on any other type it would silently never
+    // print, and the global OPTIONAL/knownPropNames maps would swallow the
+    // unknown-prop note, so it rejects here explicitly.
+    if (key === "byHeight" && type !== "qrcode") {
+      issues.push(`${type}.byHeight is a qrcode prop`);
+      continue;
+    }
     // hasOwn, not a bracket read: a prop named toString would otherwise resolve
     // Object.prototype's and be rejected for not being a function.
     const fallback = defaults && Object.hasOwn(defaults, key) ? defaults[key] : undefined;
@@ -390,6 +399,9 @@ export function propIssues(
     if (fallback === undefined && optional !== undefined && value !== undefined && value !== null) {
       const got = Array.isArray(value) ? "array" : typeof value;
       if (got !== optional) issues.push(`${type}.${key} must be ${optional} (got ${got})`);
+      else if (key === "byHeight" && !isQrByHeight(value)) {
+        issues.push(`${type}.byHeight must be a positive integer (got ${value})`);
+      }
       continue;
     }
     if (fallback === undefined || fallback === null || value === undefined || value === null) {
@@ -493,6 +505,7 @@ export const PROP_SUMMARIES: Record<string, Record<string, string>> = {
     errorCorrection: "L | M | Q | H",
     model: "1 | 2",
     rotation: "N | R | I | B",
+    byHeight: "optional ^BY height the print position sinks by; omit for the default (10)",
   },
   box: {
     width: "dots",

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -90,6 +90,7 @@ describe("mcp-server tools", () => {
       // fields raster_image fills that carry no registry default.
       if (t.type === "text") for (const k of ["reverse", "blockWidth", "blockLines", "blockLineSpacing", "blockJustify"]) allowed.add(k);
       if (t.type === "image") for (const k of ["heightDots", "_gfaCache"]) allowed.add(k);
+      if (t.type === "qrcode") allowed.add("byHeight");
       for (const key of Object.keys(t.props)) {
         expect(allowed.has(key), `${t.type}.${key} is not a known prop`).toBe(true);
       }
@@ -791,6 +792,34 @@ describe("agent-facing reporting", () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.errors[0]).toContain("must be N, R, I or B");
+  });
+
+  it("rejects byHeight on a non-qrcode type instead of swallowing it", () => {
+    // The global optional/known maps would accept it silently on any type.
+    const r = label([
+      { type: "code128", x: 1, y: 1, props: { content: "123", height: 80, moduleWidth: 2, byHeight: 12 } },
+    ]);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.errors[0]).toContain("byHeight is a qrcode prop");
+  });
+
+  it("rejects a byHeight no ^BY could pin, keeps any positive integer", () => {
+    for (const byHeight of [1.5, 0, -3]) {
+      const r = label([
+        { type: "qrcode", x: 1, y: 1, props: { content: "x", byHeight } },
+      ]);
+      expect(r.ok, String(byHeight)).toBe(false);
+      if (r.ok) continue;
+      expect(r.errors[0]).toContain("byHeight must be a positive integer");
+    }
+    // Imported designs may carry any source value; the boundary must not
+    // reject on validate/export what the parser faithfully captured.
+    for (const byHeight of [50, 50000]) {
+      expect(label([
+        { type: "qrcode", x: 1, y: 1, props: { content: "x", byHeight } },
+      ]).ok, String(byHeight)).toBe(true);
+    }
   });
 
   it("remarks on a prop that will never print", () => {

--- a/src/components/Canvas/BarcodeObject.tsx
+++ b/src/components/Canvas/BarcodeObject.tsx
@@ -5,6 +5,7 @@ import type Konva from "konva";
 import { BARCODE_1D_TYPES, ObjectRegistry, objectResolvesCtrl } from "@zplab/core/registry";
 import { dotsToPx, mmToDots, pxToDots } from "@zplab/core/lib/coordinates";
 import { barcodeFtAnchorOffset, qrPrintsAsGraphic, rightAnchorShiftDots } from "@zplab/core/lib/objectBounds";
+import { qrByHeight } from "@zplab/core/registry/qrcode";
 import { useColorScheme, CANVAS_WARNING } from "../../hooks/useColorScheme";
 import { useFontCacheVersion } from "../../hooks/useFontCacheVersion";
 import { selectionHandlers, useBlankFieldWarns, PLACEHOLDER_DASH, PLACEHOLDER_STROKE_PX, type KonvaObjectProps } from "./konvaObjectProps";
@@ -42,7 +43,6 @@ import {
   ocrbEanHriGapDots,
   EAN_TEXT_ZONE_DOTS,
   EAN_UPC_TYPES,
-  QR_FO_Y_OFFSET_DOTS,
   QR_FT_MODULE_OFFSET,
 } from "@zplab/core/lib/bwipConstants";
 
@@ -244,14 +244,13 @@ export function BarcodeObject({
   // A rotated QR prints as a shift-free ^GFA, so the ^BQ artifacts below are N-only.
   const graphicQr = qrPrintsAsGraphic(obj);
   const ftOffset = barcodeFtAnchorOffset(graphicQr ? "N" : rotation, uprightBarWDots, ftBarHDots);
-  // Zebra firmware artifact: ^FT for QR shifts the symbol up by exactly 3 modules
-  // (= 3 * magnification dots), independent of dpmm or content; ^FO QR is +10 dots.
-  // Verified against Labelary across magnifications 4-10 at 8 and 12 dpmm.
+  // ^FT QR rises exactly 3 modules above the anchor (^BY-independent, both
+  // renderers agree); ^FO QR sinks by the pinned ^BY height instead.
   const qrFtShiftDots =
     obj.type === "qrcode" && !graphicQr
       ? QR_FT_MODULE_OFFSET * (obj.props as { magnification: number }).magnification
       : 0;
-  const foYShiftDots = obj.type === "qrcode" && !graphicQr ? QR_FO_Y_OFFSET_DOTS : 0;
+  const foYShiftDots = obj.type === "qrcode" && !graphicQr ? qrByHeight(obj.props) : 0;
 
   const displayX = obj.positionType === "FT" ? obj.x + ftOffset.x : obj.x;
   const displayY =

--- a/src/components/Canvas/hooks/useKonvaTransformer.ts
+++ b/src/components/Canvas/hooks/useKonvaTransformer.ts
@@ -1508,7 +1508,7 @@ export function useKonvaTransformer({
         committedH = sp.height * sy;
       }
     }
-    // Invert per-type render offsets (QR's +10 Y, the rotation-aware FT bar
+    // Invert per-type render offsets (QR's ^BY-height Y, the rotation-aware FT bar
     // anchor) so the stored model matches the render path. Text renders at
     // obj.x/y directly.
     const modelPos = modelPositionFromRenderedTopLeft(

--- a/src/components/Canvas/transformPosition.test.ts
+++ b/src/components/Canvas/transformPosition.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { committedUprightBarDots, modelPositionFromRenderedTopLeft, renderedTopLeftFromModel } from "./transformPosition";
 import { setMeasuredBounds, clearMeasuredBounds } from "../../lib/measuredBoundsCache";
-import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
+import { QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
+import { QR_BY_DEFAULT_HEIGHT } from "@zplab/core/registry/qrcode";
 import type { LabelObject } from "@zplab/core/types/Group";
 import type { LeafObject } from "@zplab/core/registry";
 import type { ZplRotation } from "@zplab/core/registry/rotation";
@@ -29,7 +30,7 @@ describe("modelPositionFromRenderedTopLeft", () => {
   it("subtracts QR FO Y offset for QR codes with positionType=FO", () => {
     expect(modelPositionFromRenderedTopLeft(qrFo, 100, 200)).toEqual({
       x: 100,
-      y: 200 - QR_FO_Y_OFFSET_DOTS,
+      y: 200 - QR_BY_DEFAULT_HEIGHT,
     });
   });
 
@@ -37,7 +38,7 @@ describe("modelPositionFromRenderedTopLeft", () => {
     const obj = { ...qrFo, positionType: undefined };
     expect(modelPositionFromRenderedTopLeft(obj, 100, 200)).toEqual({
       x: 100,
-      y: 200 - QR_FO_Y_OFFSET_DOTS,
+      y: 200 - QR_BY_DEFAULT_HEIGHT,
     });
   });
 

--- a/src/components/Canvas/transformPosition.ts
+++ b/src/components/Canvas/transformPosition.ts
@@ -1,5 +1,5 @@
 import type { LeafObject } from "@zplab/core/registry";
-import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
+import { QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
 import {
   barcodeFtAnchorOffset,
   isBarcode,
@@ -8,6 +8,7 @@ import {
   rightAnchorShiftDots,
   rotatedFootprint,
 } from "@zplab/core/lib/objectBounds";
+import { qrByHeight } from "@zplab/core/registry/qrcode";
 import { isAxisSwapped, objectRotation, type ZplRotation } from "@zplab/core/registry/rotation";
 import { getMeasuredSnapshot } from "../../lib/measuredBoundsCache";
 
@@ -65,7 +66,7 @@ export function committedUprightBarDots(
   return { w: uprightW * (swap ? sy : sx), h: uprightH * (swap ? sx : sy) };
 }
 
-/** Rendered top-left -> stored model position. QR FO subtracts the +10 Y
+/** Rendered top-left -> stored model position. QR FO subtracts the pinned ^BY Y
  *  artifact; FT barcodes invert the rotation-aware bar anchor. On a resize pass
  *  the committed upright bar size (`committedUprightW/H`, in dots) so the inverse
  *  uses the same dimensions the commit stores; omit it elsewhere to use the
@@ -86,7 +87,7 @@ export function modelPositionFromRenderedTopLeft(
       : committedUprightW;
   const anchor = rightAnchorShift(obj, committedBoxW);
   if (obj.type === "qrcode" && obj.positionType !== "FT" && !qrPrintsAsGraphic(obj)) {
-    return { x: renderedXDots + anchor, y: renderedYDots - QR_FO_Y_OFFSET_DOTS };
+    return { x: renderedXDots + anchor, y: renderedYDots - qrByHeight(obj.props) };
   }
   if (isFtBarcode(obj)) {
     const c = cacheBar(obj);
@@ -112,7 +113,7 @@ export function renderedTopLeftFromModel(obj: LeafObject): {
   y: number;
 } {
   if (obj.type === "qrcode" && obj.positionType !== "FT" && !qrPrintsAsGraphic(obj)) {
-    return renderedWithAnchor(obj, obj.x, obj.y + QR_FO_Y_OFFSET_DOTS);
+    return renderedWithAnchor(obj, obj.x, obj.y + qrByHeight(obj.props));
   }
   if (isFtBarcode(obj)) {
     const c = cacheBar(obj);

--- a/src/lib/densityRescale.test.ts
+++ b/src/lib/densityRescale.test.ts
@@ -67,6 +67,45 @@ describe("rescaleDesign", () => {
     expect(r.warnings).toEqual([]);
   });
 
+  it("scales the pinned QR ^BY height like any dot value", () => {
+    const qr = leaf("q", "qrcode", 10, 10, { content: "QA,hi", magnification: 4, errorCorrection: "Q", model: 2, rotation: "N", byHeight: 50 } as never);
+    const r = rescaleDesign(page(qr), label, 8, 12, { dpmm: 12 });
+    const out = r.pages[0]!.objects[0] as typeof qr;
+    expect((out.props as { byHeight?: number }).byHeight).toBe(75);
+  });
+
+  it("materialises and scales the default byHeight for an ^FO QR", () => {
+    const qr = leaf("q", "qrcode", 10, 10, { content: "QA,hi", magnification: 4, errorCorrection: "Q", model: 2, rotation: "N" } as never);
+    const r = rescaleDesign(page(qr), label, 8, 12, { dpmm: 12 });
+    const out = r.pages[0]!.objects[0] as typeof qr;
+    expect((out.props as { byHeight?: number }).byHeight).toBe(15);
+  });
+
+  // Dormant states (rotated, ^FT) scale too: a later toggle back must land
+  // at the new density (see rescaleLeaf).
+  it("materialises the default byHeight for a rotated ^FO QR", () => {
+    const qr = leaf("q", "qrcode", 10, 10, { content: "QA,hi", magnification: 4, errorCorrection: "Q", model: 2, rotation: "R" } as never);
+    const r = rescaleDesign(page(qr), label, 8, 12, { dpmm: 12 });
+    const out = r.pages[0]!.objects[0] as typeof qr;
+    expect((out.props as { byHeight?: number }).byHeight).toBe(15);
+  });
+
+  it("scales a large byHeight proportionally (spec states no ^BY h ceiling)", () => {
+    const qr = leaf("q", "qrcode", 10, 10, { content: "QA,hi", magnification: 4, errorCorrection: "Q", model: 2, rotation: "N", byHeight: 32000 } as never);
+    const r = rescaleDesign(page(qr), label, 8, 12, { dpmm: 12 });
+    const out = r.pages[0]!.objects[0] as typeof qr;
+    expect((out.props as { byHeight?: number }).byHeight).toBe(48000);
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("materialises the default byHeight for an ^FT QR (dormant until a toggle)", () => {
+    const qr = leaf("q", "qrcode", 10, 10, { content: "QA,hi", magnification: 4, errorCorrection: "Q", model: 2, rotation: "N" } as never);
+    qr.positionType = "FT";
+    const r = rescaleDesign(page(qr), label, 8, 12, { dpmm: 12 });
+    const out = r.pages[0]!.objects[0] as typeof qr;
+    expect((out.props as { byHeight?: number }).byHeight).toBe(15);
+  });
+
   it("clamps QR magnification to 10 and warns", () => {
     const qr = leaf("q", "qrcode", 0, 0, { content: "QA,hi", magnification: 5, errorCorrection: "Q", model: 2, rotation: "N" } as never);
     const r = rescaleDesign(page(qr), label, 8, 24, { dpmm: 24 }); // factor 3 -> 15 clamps to 10

--- a/src/lib/densityRescale.ts
+++ b/src/lib/densityRescale.ts
@@ -2,6 +2,7 @@ import { isGroup, type LabelObject, type LeafObject, type Page } from "@zplab/co
 import { getEntry } from "@zplab/core/registry";
 import { gfaCacheIsOnlyCopy, type ImageProps } from "@zplab/core/registry/image";
 import { effectiveDpmm, labelConfigSpec, scaledLabelConfigFields, type JmDensity, type LabelConfig } from "@zplab/core/types/LabelConfig";
+import { qrByHeight } from "@zplab/core/registry/qrcode";
 
 /** Pending density change: a new head dpmm or a new ^JM mode, both reinterpreting
  *  stored dots under one rescale prompt. `configPatch` carries extra fields (e.g. a
@@ -103,6 +104,13 @@ function rescaleLeaf(leaf: LeafObject, factor: number, warnings: RescaleWarning[
   const warn = (prop: string, reason: RescaleWarning["reason"]) =>
     warnings.push({ id: leaf.id, name: labelOf(leaf), type: leaf.type, prop, reason });
 
+  // Every QR materialises its ^BY height here, dormant states included (^FT,
+  // rotated): the emit pins the power-up default whenever the prop is absent,
+  // and a later rotate-back/anchor-toggle must land at the NEW density, not at
+  // the old default. Floor only (no ceiling exists, see isQrByHeight).
+  if (leaf.type === "qrcode") {
+    next.byHeight = Math.max(1, Math.round(qrByHeight(props as { byHeight?: number }) * factor));
+  }
   for (const k of SCALE_MIN1) {
     const v = props[k];
     if (typeof v === "number" && v > 0) next[k] = Math.max(1, Math.round(v * factor));

--- a/src/lib/positionConvert.test.ts
+++ b/src/lib/positionConvert.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { convertPositionType, supportsPositionToggle } from "./positionConvert";
 import { objectBoundsDots, type ObjectBoundsCtx } from "@zplab/core/lib/objectBounds";
-import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
+import { QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
+import { QR_BY_DEFAULT_HEIGHT } from "@zplab/core/registry/qrcode";
 import type { PageLabel } from "@zplab/core/types/LabelConfig";
 import type { LabelObject } from "@zplab/core/types/Group";
 import type { LeafObject } from "@zplab/core/registry";
@@ -84,8 +85,8 @@ describe("convertPositionType", () => {
     const before = objectBoundsDots(qr, ctx(measured));
     const ft = flipped(qr, "FT", ctx(measured));
     expect(objectBoundsDots(ft, ctx(measured))).toEqual(before);
-    // FO renders y + QR_FO_Y_OFFSET; FT renders y - uprightH - QR_FT_MODULE_OFFSET*mag.
-    expect(ft.y).toBe(70 + QR_FO_Y_OFFSET_DOTS + 100 + QR_FT_MODULE_OFFSET * 4);
+    // FO renders y + effective ^BY height; FT renders y - uprightH - QR_FT_MODULE_OFFSET*mag.
+    expect(ft.y).toBe(70 + QR_BY_DEFAULT_HEIGHT + 100 + QR_FT_MODULE_OFFSET * 4);
     const back = flipped(ft, "FO", ctx(measured));
     expect({ x: back.x, y: back.y }).toEqual({ x: qr.x, y: qr.y });
   });
@@ -100,6 +101,16 @@ describe("convertPositionType", () => {
     expect(objectBoundsDots(ft, ctx(measured))).toEqual(before);
     const back = flipped(ft, "FO", ctx(measured));
     expect({ x: back.x, y: back.y }).toEqual({ x: bc.x, y: bc.y });
+  });
+
+  it("flips FO<->FT bounds-preserving with a pinned non-default byHeight", () => {
+    const qr = leaf("qrcode", 100, 200, { content: "x", magnification: 5, errorCorrection: "M", model: 2, rotation: "N", byHeight: 50 } as never);
+    const measured = new Map([[qr.id, { width: 120, height: 120 }]]);
+    const before = objectBoundsDots(qr, ctx(measured));
+    const ft = flipped(qr, "FT", ctx(measured));
+    expect(objectBoundsDots(ft, ctx(measured))).toEqual(before);
+    const back = flipped(ft, "FO", ctx(measured));
+    expect({ x: back.x, y: back.y }).toEqual({ x: qr.x, y: qr.y });
   });
 
   it("unmeasured barcode falls back to prop height, matching the bounds fallback", () => {

--- a/src/lib/qrGraphic.test.ts
+++ b/src/lib/qrGraphic.test.ts
@@ -99,6 +99,23 @@ describe("qr sidecar comment", () => {
     expect(parseQrSidecarComment(body)).toEqual(props);
   });
 
+  it("round-trips the pinned byHeight, and omits it when absent", () => {
+    const withBy = { ...props, byHeight: 50 };
+    expect(parseQrSidecarComment(formatQrSidecarComment(withBy).slice(3, -3))).toEqual(withBy);
+    // Absent stays absent: materialising 10 here would turn every legacy
+    // sidecar lossy on the emit comparison.
+    expect(parseQrSidecarComment(formatQrSidecarComment(props).slice(3, -3))).toEqual(props);
+  });
+
+  it("drops a byh no ^BY could have pinned, keeps any positive integer", () => {
+    for (const byh of [1.5, 0, -3]) {
+      const body = `ZPLLAB:{"qr":{"content":"X","mag":4,"ec":"Q","model":2,"rot":"R","byh":${byh}}}`;
+      expect(parseQrSidecarComment(body)?.byHeight).toBeUndefined();
+    }
+    const big = 'ZPLLAB:{"qr":{"content":"X","mag":4,"ec":"Q","model":2,"rot":"R","byh":50000}}';
+    expect(parseQrSidecarComment(big)?.byHeight).toBe(50000);
+  });
+
   it("rejects foreign and label-meta comments", () => {
     expect(parseQrSidecarComment("just a note")).toBeNull();
     expect(parseQrSidecarComment('ZPLLAB:{"dpmm":8,"wMm":100,"hMm":50}')).toBeNull();

--- a/src/lib/zplOverlay/overlayCapture.test.ts
+++ b/src/lib/zplOverlay/overlayCapture.test.ts
@@ -154,8 +154,47 @@ describe("parseZPL overlay capture", () => {
     expect(o.regenSafe).toBe(true);
   });
 
-  it("keeps a 2D code (QR) regenSafe even without ^BY (it ignores ^BY)", () => {
-    expect(captured("^XA^FO10,10^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(true);
+  // An unpinned ^FO QR inherits printer state on replay (see QrCodeProps.byHeight).
+  it("flags an ^FO QR without in-span ^BY as not regenSafe", () => {
+    expect(captured("^XA^FO10,10^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(false);
+  });
+
+  it("keeps an ^FO QR with in-span ^BY regenSafe (the emit form)", () => {
+    expect(captured("^XA^FO10,10^BY,,10^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(true);
+  });
+
+  it("flags an ^FO QR whose in-span ^BY sets no height", () => {
+    // ^BY2 pins only the width; the height the position depends on stays
+    // session-inherited, so the regen would move the print.
+    expect(captured("^XA^FO10,10^BY2^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(false);
+  });
+
+  it("keeps a rotated QR (^GFA + sidecar) regenSafe without ^BY", () => {
+    // The graphic path ignores ^BY; only a live ^BQ consumes it.
+    const zpl = '^XA^FXZPLLAB:{"qr":{"content":"X","mag":4,"ec":"Q","model":2,"rot":"R"}}^FS^FO10,10^GFA,3,3,1,00,00,00^FS^XZ';
+    expect(captured(zpl).regenSafe).toBe(true);
+  });
+
+  it("recognises an in-span ^BY under a remapped ^CD delimiter", () => {
+    // The check reads tokenizer state, not raw bytes, so ^BY;;50 counts. The
+    // page still loses regen safety, but to ^CD's own format-state reason,
+    // not to a phantom missing ^BY.
+    const r = parseSingle("^XA^CD;^FO10,10^BY;;50^BQN,2,5^FDQA,hello^FS^XZ", 8, {
+      captureOverlay: true,
+    });
+    expect(r.overlay?.regenSafe).toBe(false);
+    const reason = r.findings.find((f) => f.kind === "lossyEdit")?.command ?? "";
+    expect(reason).toContain("format state");
+    expect(reason).not.toContain("in-field ^BY");
+  });
+
+  it("treats an in-span ^BY,,0 as not pinning (zero is no height)", () => {
+    // h=0 is no pin: the session height stays in charge.
+    expect(captured("^XA^FO10,10^BY,,0^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(false);
+  });
+
+  it("keeps an ^FT QR regenSafe without ^BY (anchor is ^BY-independent)", () => {
+    expect(captured("^XA^FT10,200^BQN,2,5^FDQA,hello^FS^XZ").regenSafe).toBe(true);
   });
 
   it("keeps a DataMatrix regenSafe without ^BY", () => {

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -3,6 +3,7 @@ import { zlibSync } from 'fflate';
 import { parseZPL, BY_CONSUMING_BARCODE_TYPES } from '@zplab/core/lib/zplParser';
 import { generateZPL } from '@zplab/core/lib/zplGenerator';
 import { formatLabelMetaComment } from '@zplab/core/lib/zplLabelMeta';
+import { objectBoundsDots } from '@zplab/core/lib/objectBounds';
 import { ObjectRegistry } from '@zplab/core/registry';
 import { defined, props, serialOf, parseSingle, commandsOf } from '../test/helpers';
 import { parseGfWrapper } from '@zplab/core/lib/zplParser/decoders/crc';
@@ -895,6 +896,56 @@ describe('parseZPL — ^BQ QR Code', () => {
   it('falls back to Model 2 for a missing/invalid ^BQ b', () => {
     const { objects } = parseSingle('^XA^FO0,0^BQN,,4^FDQA,X^FS^XZ', 8);
     expect(props(objects[0]).model).toBe(2);
+  });
+});
+
+describe('parseZPL — ^BQ ^BY height pinning', () => {
+  // Unpinned, the print moves per printer session (see QrCodeProps.byHeight).
+  it('captures the effective ^BY height on an imported ^FO QR', () => {
+    const { objects } = parseSingle('^XA^BY2,3,50^FO10,10^BQN,2,4^FDQA,X^FS^XZ', 8);
+    expect(props(objects[0]).byHeight).toBe(50);
+  });
+
+  it('keeps byHeight through the rotated ^GFA sidecar', () => {
+    const src = '^XA^FO10,10^BY2,3,50^BQN,2,4^FDQA,X^FS^XZ';
+    const first = defined(parseSingle(src, 8).objects[0]);
+    props(first).rotation = 'R';
+    const out = generateZPL(
+      { widthDots: 800, heightDots: 1200, dpmm: 8 } as never,
+      [first] as never,
+      [],
+    );
+    const back = defined(parseSingle(out.includes('^XA') ? out : `^XA${out}^XZ`, 8).objects[0]);
+    expect(back.type).toBe('qrcode');
+    expect(props(back).byHeight).toBe(50);
+  });
+
+  it('keeps an out-of-convention ^BY height verbatim (import is fidelity, not authoring)', () => {
+    const { objects } = parseSingle('^XA^FO10,10^BY,,50000^BQN,2,4^FDQA,X^FS^XZ', 8);
+    expect(props(objects[0]).byHeight).toBe(50000);
+  });
+
+  it('carries a non-default ^BY height from import through to the canvas bounds', () => {
+    // Cross-subsystem pin: parse -> model -> objectBoundsDots, so the render
+    // path is covered beyond the default ^BY,,10 the fixtures use.
+    const { objects } = parseSingle('^XA^FO10,100^BY,,50^BQN,2,4^FDQA,X^FS^XZ', 8);
+    const qr = defined(objects[0]);
+    const measured = new Map([[qr.id, { width: 120, height: 120 }]]);
+    const b = objectBoundsDots(qr, {
+      label: { widthDots: 800, heightDots: 1200, dpmm: 8 } as never,
+      measured,
+    });
+    expect(b.y).toBe(100 + 50);
+  });
+
+  it('inherits the session height past an h-less ^BY, like the firmware', () => {
+    const { objects } = parseSingle('^XA^BY,,50^FO10,10^BY2^BQN,2,4^FDQA,X^FS^XZ', 8);
+    expect(props(objects[0]).byHeight).toBe(50);
+  });
+
+  it('leaves byHeight absent when the source never set ^BY', () => {
+    const { objects } = parseSingle('^XA^FO10,10^BQN,2,4^FDQA,X^FS^XZ', 8);
+    expect(props(objects[0]).byHeight).toBeUndefined();
   });
 });
 

--- a/src/test/labelarySync.test.ts
+++ b/src/test/labelarySync.test.ts
@@ -18,7 +18,8 @@ import {
 import { dotsToPx } from "@zplab/core/lib/coordinates";
 import { getObjectStringContent } from "@zplab/core/lib/variableBinding";
 import { upcSuppTextZoneDots, QR_FT_MODULE_OFFSET } from "@zplab/core/lib/bwipConstants";
-import { barcodeFtAnchorOffset } from "@zplab/core/lib/objectBounds";
+import { qrPrintsAsGraphic, barcodeFtAnchorOffset } from "@zplab/core/lib/objectBounds";
+import { qrByHeight } from "@zplab/core/registry/qrcode";
 import { ObjectRegistry } from "@zplab/core/registry";
 import { objectRotation } from "@zplab/core/registry/rotation";
 import { defined } from "./helpers";
@@ -125,21 +126,23 @@ describe("Labelary Sync - Canvas Dimension Logic", () => {
       if (obj.positionType === "FT") {
         // Mirror the real render/bounds anchor (objectBounds.barcodeTopLeft):
         // rotation-aware bar-base offset + HRI text-zone shift (px*8 -> dots).
+        // Mirrors BarcodeObject: a rotated QR prints as a shift-free ^GFA.
+        const gQr = qrPrintsAsGraphic(obj);
         const off = barcodeFtAnchorOffset(
-          rotation,
+          gQr ? "N" : rotation,
           displaySize.upright.barW * 8,
           displaySize.upright.barH * 8,
         );
         visualX += off.x - displaySize.barLeftPx * 8;
         visualY += off.y - displaySize.barTopPx * 8;
-        if (obj.type === "qrcode") {
+        if (obj.type === "qrcode" && !gQr) {
           const mag = (obj.props as { magnification?: number }).magnification ?? 1;
           visualY -= QR_FT_MODULE_OFFSET * mag;
         }
       } else {
         // FO positions relative to top-left, with specific quirks.
-        if (obj.type === "qrcode") {
-          visualY += 10;
+        if (obj.type === "qrcode" && !qrPrintsAsGraphic(obj)) {
+          visualY += qrByHeight(obj.props);
         }
         if (obj.type === "upcEanExtension" && obj.props.printInterpretation) {
           // ^BS bbox top sits above the FO anchor by the supplement

--- a/src/test/visualRegression.test.ts
+++ b/src/test/visualRegression.test.ts
@@ -30,7 +30,9 @@ import {
   type ZebraWidthBarType,
 } from "@zplab/core/lib/barcodeRawGeometry";
 import { dotsToPx } from "@zplab/core/lib/coordinates";
-import { QR_FO_Y_OFFSET_DOTS, QR_FT_MODULE_OFFSET, upcSuppTextZoneDots } from "@zplab/core/lib/bwipConstants";
+import { QR_FT_MODULE_OFFSET, upcSuppTextZoneDots } from "@zplab/core/lib/bwipConstants";
+import { qrPrintsAsGraphic } from "@zplab/core/lib/objectBounds";
+import { qrByHeight } from "@zplab/core/registry/qrcode";
 import { barcodeFtAnchorOffset, isBarcode } from "@zplab/core/lib/objectBounds";
 
 const FIXTURES_DIR = path.resolve(
@@ -108,13 +110,13 @@ describe("Visual Regression - bwip-js vs Labelary", () => {
         8,
       );
 
-      // Zebra firmware renders ^FO-positioned QR codes with a +10 dot Y offset.
-      // Match production BarcodeObject.tsx behaviour. UPC/EAN supplements
+      // An ^FO QR draws sunk by its effective ^BY height (default 10),
+      // mirroring production BarcodeObject.tsx. UPC/EAN supplements
       // render the human-readable digits ABOVE the bars, so the bitmap's
       // top edge sits text-zone above the FO anchor.
       const drawY =
-        obj.type === "qrcode"
-          ? obj.y + QR_FO_Y_OFFSET_DOTS
+        obj.type === "qrcode" && obj.positionType !== "FT" && !qrPrintsAsGraphic(obj)
+          ? obj.y + qrByHeight(obj.props)
           : obj.type === "upcEanExtension" && obj.props.printInterpretation
             ? obj.y - upcSuppTextZoneDots(obj.props.moduleWidth)
             : obj.y;
@@ -135,12 +137,14 @@ describe("Visual Regression - bwip-js vs Labelary", () => {
       // then apply rotatedGroupTransform-equivalent rotation around that.
       // FT barcodes anchor at the rotation-aware bar base (mirrors the render);
       // FO uses drawY above. px == dots here (getDisplaySize scale 8, dpmm 8).
+      // Mirrors BarcodeObject: a rotated QR prints as a shift-free ^GFA.
+      const gQr = qrPrintsAsGraphic(obj);
       const ftOff =
         obj.positionType === "FT" && isBarcode(obj)
-          ? barcodeFtAnchorOffset(rot, ub.barW, ub.barH)
+          ? barcodeFtAnchorOffset(gQr ? "N" : rot, ub.barW, ub.barH)
           : { x: 0, y: 0 };
       const ftQrShift =
-        obj.positionType === "FT" && obj.type === "qrcode"
+        obj.positionType === "FT" && obj.type === "qrcode" && !gQr
           ? QR_FT_MODULE_OFFSET * (obj.props as { magnification: number }).magnification
           : 0;
       const bboxTopLeftX = obj.x + ftOff.x - displaySize.barLeftPx;

--- a/tests/fixtures/labelary_images/fixtures.json
+++ b/tests/fixtures/labelary_images/fixtures.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "barcode_qr_standard",
-      "zpl_input": "^XA^FO50,50^BQN,2,4^FDQA,Hello World^FS^XZ",
+      "zpl_input": "^XA^FO50,50^BY,,10^BQN,2,4^FDQA,Hello World^FS^XZ",
       "expected_bounds": {
         "x": 50,
         "y": 60,
@@ -46,7 +46,7 @@
     },
     {
       "id": "barcode_qr_large_high_ec",
-      "zpl_input": "^XA^FO150,150^BQN,2,8^FDHA,Zebra Print Lab QR Code Testing^FS^XZ",
+      "zpl_input": "^XA^FO150,150^BY,,10^BQN,2,8^FDHA,Zebra Print Lab QR Code Testing^FS^XZ",
       "expected_bounds": {
         "x": 150,
         "y": 160,

--- a/tests/fixtures/testCases.ts
+++ b/tests/fixtures/testCases.ts
@@ -55,14 +55,14 @@ export const testCases: TestCase[] = [
   },
   {
     id: "barcode_qr_standard",
-    zpl_input: "^XA^FO50,50^BQN,2,4^FDQA,Hello World^FS^XZ",
+    zpl_input: "^XA^FO50,50^BY,,10^BQN,2,4^FDQA,Hello World^FS^XZ",
     expected_bounds: { x: 50, y: 50, width: 100, height: 100 },
     image_ref: "barcode_qr_standard.png",
   },
   {
     id: "barcode_qr_large_high_ec",
     zpl_input:
-      "^XA^FO150,150^BQN,2,8^FDHA,Zebra Print Lab QR Code Testing^FS^XZ",
+      "^XA^FO150,150^BY,,10^BQN,2,8^FDHA,Zebra Print Lab QR Code Testing^FS^XZ",
     expected_bounds: { x: 150, y: 150, width: 250, height: 250 },
     image_ref: "barcode_qr_large_high_ec.png",
   },


### PR DESCRIPTION
The firmware offsets ^FO ^BQ by the printer-persistent ^BY height, so an unpinned QR prints at a different y per printer session.