### PR TITLE
feat(preflight): warn when a slot's consumers encode it differently

### DIFF
--- a/packages/core/src/lib/preflight.ts
+++ b/packages/core/src/lib/preflight.ts
@@ -19,6 +19,7 @@ import { classifyField, isLoneMarker } from "./variableField";
 import { parseContent, typedContentIncompleteRows, typedContentMarkerFindings } from "./typedContent";
 import { getObjectStringContent, resolveForRow, variableSubstitutions } from "./variableBinding";
 import { fnConsumerBuckets, isModeDLeaf } from "./gs1ModeDFns";
+import { slotEncodingConflicts } from "./slotConflicts";
 import { isPrintedBlank } from "./zebraTextLayout";
 import { resolveTextMode } from "../registry/text";
 import type { ColumnMapping, Variable } from "../types/Variable";
@@ -204,18 +205,20 @@ export function markerValueFindings(
   // shared slots emit raw; exclusive plain-^BC slots still leak `>` before an
   // invocation char, which the escape leaves verbatim by design.
   const byName = new Map(deps.variables.map((v) => [v.name, v]));
-  // One CSV row-walk per variable per run, not per warning channel. Values
-  // are chip-resolved: the emit resolves them too, so the dirty predicates
-  // must see the byte, not the marker text.
-  const subsCache = new Map<string, string[]>();
-  const substitutionsOf = (v: Variable): string[] => {
+  // One CSV row-walk per variable per run, not per warning channel. The dirty
+  // predicates get chip-RESOLVED values (their plans see bytes); the encoding
+  // comparison gets RAW values (the emit transforms unresolved defaults).
+  const subsCache = new Map<string, { raw: string[]; resolved: string[] }>();
+  const subsOf = (v: Variable) => {
     let subs = subsCache.get(v.id);
     if (!subs) {
-      subs = variableSubstitutions(v, deps.dataset, deps.columnMapping).map(resolveControlMarkers);
+      const raw = variableSubstitutions(v, deps.dataset, deps.columnMapping);
+      subs = { raw, resolved: raw.map(resolveControlMarkers) };
       subsCache.set(v.id, subs);
     }
     return subs;
   };
+  const substitutionsOf = (v: Variable): string[] => subsOf(v).resolved;
   const slotValueWarnings = (
     slots: Set<number>,
     leafPred: (leaf: LeafObject) => boolean,
@@ -265,6 +268,14 @@ export function markerValueFindings(
     plainLeaf,
     (val) => planHasLoss(planCode128Fd(val, "sharedRaw"), "controlBytesDropped"),
     c0Message,
+  );
+  // No value predicate: divergence is already decided per value in slotEncodingConflicts.
+  const conflicts = slotEncodingConflicts(leaves, deps.variables, (v) => subsOf(v).raw, buckets);
+  slotValueWarnings(
+    conflicts.fns,
+    (leaf) => conflicts.consumerIds.has(leaf.id),
+    () => true,
+    (names) => `${names} is bound by fields that encode it differently: every consumer prints the encoding of the field that emits the slot`,
   );
   // Exclusive slots: a lone bind is a whole ^FD (invocation form covers
   // control bytes AND protects `>`+invocation sequences by encoding them);

--- a/packages/core/src/lib/slotConflicts.ts
+++ b/packages/core/src/lib/slotConflicts.ts
@@ -1,0 +1,95 @@
+import { exportableLeaves, type LabelObject } from "../types/Group";
+import { classifyField } from "./variableField";
+import { qrPrintsAsGraphic } from "./objectBounds";
+import { resolveContentPreview } from "./markerResolve";
+import { planCode128Fd } from "./code128Plan";
+import { getEntry, isGs1Active, usesPlainCode128Escape } from "../registry";
+import { extractTemplateRefs } from "./fnTemplate";
+import { getObjectStringContent } from "./variableBinding";
+import { fnConsumerBuckets, type FnConsumerBuckets } from "./gs1ModeDFns";
+import type { Variable } from "../types/Variable";
+
+type SlotEncoder = ((s: string) => string) | undefined;
+
+export interface SlotConflicts {
+  fns: Set<number>;
+  /** Leaves that consume a conflicted slot; findings must not blame others. */
+  consumerIds: Set<string>;
+}
+
+/** Slots whose consumers would put DIFFERENT bytes in the one substituted
+ *  value: the emitting field wins, every consumer prints its encoding.
+ *  Values must be RAW (chips unresolved): fdFieldFor transforms the
+ *  unresolved default; the code128 plans resolve chips internally. */
+export function slotEncodingConflicts(
+  objects: readonly LabelObject[],
+  variables: readonly Variable[],
+  substitutionsOf: (v: Variable) => readonly string[] = (v) => [v.defaultValue],
+  buckets: FnConsumerBuckets = fnConsumerBuckets(objects, variables),
+): SlotConflicts {
+  const byName = new Map(variables.map((v) => [v.name, v]));
+  const perSlot = new Map<
+    number,
+    { encoders: SlotEncoder[]; vars: Set<Variable>; leafIds: string[] }
+  >();
+  const note = (v: Variable, encode: SlotEncoder, leafId: string) => {
+    const slot =
+      perSlot.get(v.fnNumber) ??
+      { encoders: [], vars: new Set<Variable>(), leafIds: [] };
+    slot.encoders.push(encode);
+    slot.vars.add(v);
+    slot.leafIds.push(leafId);
+    perSlot.set(v.fnNumber, slot);
+  };
+  for (const leaf of exportableLeaves(objects)) {
+    const c = getObjectStringContent(leaf);
+    if (c === undefined) continue;
+    const entry = getEntry(leaf.type);
+    // An unregistered type emits nothing, so it consumes no slot.
+    if (!entry) continue;
+    const props = (leaf as { props?: { serial?: object } }).props;
+    // ^SN serial replaces the whole ^FD (no ^FN); GS1-mode serial keeps fdFieldFor.
+    if (props?.serial && !isGs1Active(entry, props)) continue;
+    // A rotated QR ships as ^GFA (no ^FN) only when its content resolves
+    // non-empty; empty falls back to a real ^BQ+^FN emit (registry/qrcode).
+    if (qrPrintsAsGraphic(leaf) && resolveContentPreview(c, variables)) continue;
+    const cls = classifyField(c, variables);
+    if (cls.kind === "single") {
+      // fdFieldFor encodes the single-bind value; a plain-^BC lone bind on a
+      // shared slot is degraded to sharedRaw by the emit (barcode1d, rawFdFns).
+      note(
+        cls.variable,
+        usesPlainCode128Escape(entry, props) && buckets.plainShared.has(cls.variable.fnNumber)
+          ? (s: string) => planCode128Fd(s, "sharedRaw").fd
+          : entry.fdTransform?.(leaf),
+        leaf.id,
+      );
+      continue;
+    }
+    // Every other shape embeds the slot inside its own payload and reads it raw.
+    for (const name of extractTemplateRefs(c)) {
+      const v = byName.get(name);
+      if (v) note(v, undefined, leaf.id);
+    }
+  }
+  const fns = new Set<number>();
+  const consumerIds = new Set<string>();
+  for (const [fn, { encoders, vars, leafIds }] of perSlot) {
+    if (encoders.length < 2) continue;
+    // Exclusive code128-family slots are emit-coordinated: all consumers
+    // share the ^BC grammar, so byte differences (>0) decode identically.
+    if (buckets.modeDExclusive.has(fn) || buckets.plainExclusive.has(fn)) continue;
+    // All-raw readers cannot diverge; skip the row walk.
+    if (encoders.every((e) => e === undefined)) continue;
+    const diverges = [...vars].some((v) =>
+      substitutionsOf(v).some(
+        (val) => new Set(encoders.map((e) => (e ? e(val) : val))).size > 1,
+      ),
+    );
+    if (diverges) {
+      fns.add(fn);
+      for (const id of leafIds) consumerIds.add(id);
+    }
+  }
+  return { fns, consumerIds };
+}

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -22,7 +22,7 @@ import { designAsPageLabel, jmDensityOf } from '../types/LabelConfig';
 import type { ClockOffset, CustomFontMapping, JmDensity, LabelConfig, PageLabel } from '../types/LabelConfig';
 import type { ZplEmitContext } from '../types/ZplEmit';
 import type { Variable } from '../types/Variable';
-import { exportableLeaves, isGroup, pageLabelConfig, walkObjects, type LabelObject, type LeafObject, type Page } from '../types/Group';
+import { exportableLeaves, isGroup, pageLabelConfig, type LabelObject, type LeafObject, type Page } from '../types/Group';
 import { isOverlayConsistent, MIN_JM_SPAN, type FormatHead, type JmSpan } from './zplOverlay/overlay';
 import { reconstructBlockHead } from './zplHeadScan';
 import { objectBoundsDots, type ObjectBoundsCtx } from './objectBounds';
@@ -78,8 +78,9 @@ export function planTemplateHeader(
   // page's templates use.
   const templateVarsByFn = new Map<number, Variable>();
   const singleBindFns = new Set<number>();
-  for (const leaf of flattenObjects(shifted)) {
-    if (leaf.includeInExport === false) continue;
+  // Group exclusion cascades: a hidden single-bind must not suppress the
+  // header default its visible template co-consumer depends on.
+  for (const leaf of exportableLeaves(shifted)) {
     const c = getObjectStringContent(leaf);
     if (c === undefined) continue;
     // Content == exactly one known marker is single-bind: emitted inline as
@@ -629,7 +630,7 @@ export function generateBatchZpl(
   const identity = (s: string) => s;
   // Excluded leaves aren't in the stored template, so don't source a transform
   // from one (it could shadow an exported field sharing the same variable).
-  const leaves = [...walkObjects(objects)].filter((o) => o.includeInExport !== false);
+  const leaves = exportableLeaves(objects);
   const batchBuckets = fnConsumerBuckets(objects, variables);
   const modeDFns = batchBuckets.modeDExclusive;
   const plain128Fns = batchBuckets.plainExclusive;

--- a/src/lib/preflight.test.ts
+++ b/src/lib/preflight.test.ts
@@ -535,8 +535,19 @@ describe("markerValueFindings (typed-content marker values)", () => {
   const qr = (id: string, content: string, extra: object = {}): LeafObject =>
     ({ id, type: "qrcode", x: 0, y: 0, rotation: 0,
        props: { content, magnification: 3, errorCorrection: "M", model: 2, rotation: "N", ...extra } } as LabelObject as LeafObject);
+  const plainText = (id: string, extra: object = {}): LeafObject =>
+    ({ id, type: "text", x: 0, y: 100, rotation: 0,
+       props: { content: "«ssid»", fontHeight: 30, fontWidth: 0, rotation: "N", reverse: false, ...extra } } as LabelObject as LeafObject);
+  const bcPlain = (id: string, extra: object = {}): LeafObject =>
+    ({ id, type: "code128", x: 0, y: 200, rotation: 0,
+       props: { content: "«ssid»", height: 80, moduleWidth: 2, rotation: "N",
+         printInterpretation: false, checkDigit: false, ...extra } } as LabelObject as LeafObject);
   const vars = [{ id: "s", name: "ssid", fnNumber: 1, defaultValue: "A;B" }];
   const deps = { variables: vars, dataset: null, columnMapping: null };
+  const withDefault = (dv: string) =>
+    ({ ...deps, variables: [{ id: "s", name: "ssid", fnNumber: 1, defaultValue: dv }] });
+  const conflictOn = (fs: ReturnType<typeof markerValueFindings>) =>
+    fs.filter((f) => f.detail?.includes("encode it differently")).map((f) => f.objectId);
 
   it("flags a WiFi payload whose marker default carries a structural char", () => {
     const out = markerValueFindings([qr("a", "WIFI:T:WPA;S:«ssid»;;")], deps);
@@ -551,6 +562,89 @@ describe("markerValueFindings (typed-content marker values)", () => {
     const columnMapping = { bindings: { s: "net" }, headerSnapshot: ["net"] };
     const out = markerValueFindings([qr("a", "WIFI:T:WPA;S:«ssid»;;")], { variables: clean, dataset, columnMapping });
     expect(out).toHaveLength(1);
+  });
+
+  it("warns when a single-bind QR and a text field share a slot", () => {
+    const shared = markerValueFindings([qr("a", "«ssid»"), plainText("t")], deps);
+    expect(shared.some((f) => f.objectId === "a" && f.kind === "markerValueUnsafe")).toBe(true);
+    expect(conflictOn(markerValueFindings([qr("a", "«ssid»")], deps))).toEqual([]);
+  });
+
+  it("warns when two QRs disagree on the slot encoding (different EC)", () => {
+    const out = markerValueFindings([qr("a", "«ssid»"), qr("b", "«ssid»", { errorCorrection: "L" })], deps);
+    expect(out.some((f) => f.kind === "markerValueUnsafe")).toBe(true);
+  });
+
+  it("stays quiet for a rotated QR: it emits ^GFA and claims no slot", () => {
+    const out = markerValueFindings([qr("a", "«ssid»", { rotation: "R" }), plainText("t")], deps);
+    expect(out.some((f) => f.kind === "markerValueUnsafe")).toBe(false);
+  });
+
+  it("warns for a rotated QR whose empty default falls back to ^BQ+^FN", () => {
+    const out = markerValueFindings([qr("rot", "«ssid»", { rotation: "R" }), plainText("t")], withDefault(""));
+    expect(conflictOn(out)).toContain("rot");
+  });
+
+  it("stays quiet for a template QR sharing its slot (the slot stays raw)", () => {
+    const out = markerValueFindings([qr("a", "WIFI:T:WPA;S:«ssid»;;"), plainText("t")], deps);
+    expect(conflictOn(out)).toEqual([]);
+  });
+
+  it("warns when a single-bind QR and a plain ^BC share a slot", () => {
+    const out = markerValueFindings([qr("a", "«ssid»"), bcPlain("c")], deps);
+    expect(out.some((f) => f.objectId === "a" && f.kind === "markerValueUnsafe")).toBe(true);
+  });
+
+  it("blames only leaves that consume the conflicted slot", () => {
+    // 'rot' ships as ^GFA; the real conflict is between 'n' and 't'.
+    const out = markerValueFindings(
+      [qr("rot", "«ssid»", { rotation: "R" }), qr("n", "«ssid»", { errorCorrection: "L" }), plainText("t")],
+      withDefault("W"));
+    expect(conflictOn(out).sort()).toEqual(["n", "t"]);
+  });
+
+  it("catches a row-dependent conflict the defaults hide (^FB escape on a CSV row)", () => {
+    const fb = plainText("f", { blockWidth: 200 });
+    const columnMapping = { bindings: { s: "net" }, headerSnapshot: ["net"] };
+    const row = (cell: string) => ({
+      variables: [{ id: "s", name: "ssid", fnNumber: 1, defaultValue: "safe" }], columnMapping,
+      dataset: { headers: ["net"], rows: [[cell]] } });
+    expect(conflictOn(markerValueFindings([fb, plainText("t")], row("a\nb")))).not.toEqual([]);
+    // A clean row encodes to itself on both sides.
+    expect(conflictOn(markerValueFindings([fb, plainText("t")], row("also safe")))).toEqual([]);
+  });
+
+  it("no encoding conflict for a shared plain ^BC: the emit degrades it to raw", () => {
+    const out = markerValueFindings([bcPlain("c"), plainText("t")], withDefault("a\x1db"));
+    expect(conflictOn(out)).toEqual([]);
+  });
+
+  it("warns when the degraded ^BC resolves a chip the text ships literally", () => {
+    const out = markerValueFindings([bcPlain("c"), plainText("t")], withDefault("a«ctrl:GS»b"));
+    expect(conflictOn(out).sort()).toEqual(["c", "t"]);
+  });
+
+  it("stays quiet on a chip-only difference both consumers ship literally", () => {
+    const out = markerValueFindings([plainText("f", { blockWidth: 200 }), plainText("t")], withDefault("a«ctrl:LF»b"));
+    expect(conflictOn(out)).toEqual([]);
+  });
+
+  it("same-carrier lone bind and template are emit-coordinated: quiet", () => {
+    const out = markerValueFindings([bcPlain("c"), bcPlain("c2", { content: "PRE«ssid»" })], withDefault("A>B"));
+    expect(conflictOn(out)).toEqual([]);
+  });
+
+  it("a serial field emits ^SN, not ^FN: no phantom conflict", () => {
+    const serial = bcPlain("s", { serial: { start: 1, increment: 1, leadingZeros: true } });
+    const out = markerValueFindings([serial, qr("q", "«ssid»")], deps);
+    expect(conflictOn(out)).toEqual([]);
+  });
+
+  it("an unregistered type consumes no slot", () => {
+    const ghost = { id: "z", type: "doesnotexist", x: 0, y: 0, rotation: 0,
+      props: { content: "«ssid»" } } as unknown as LeafObject;
+    const out = markerValueFindings([qr("a", "«ssid»"), ghost], deps);
+    expect(conflictOn(out)).toEqual([]);
   });
 
   it("stays quiet for text payloads and marker-free content", () => {

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -1689,6 +1689,17 @@ describe('generateZPL — variable bindings', () => {
     expect(zpl).not.toContain('^FN');
   });
 
+  it('declares the header default although a hidden single-bind claims the slot', () => {
+    const hidden = { id: 'g', type: 'group', includeInExport: false,
+      children: [textObj] } as unknown as LabelObject;
+    const template = { id: 'obj-2', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: 'PRE«sku»POST', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const zpl = generateZPL(BASE_LABEL, [hidden, template], [variable]);
+    expect(zpl).toContain('^FN7^FDABC-123^FS');
+    expect(zpl).toContain('^FDPRE#7#POST');
+  });
+
   it('emits the marker literally when no variable matches the name (orphan)', () => {
     const zpl = generateZPL(BASE_LABEL, [textObj], [
       { ...variable, name: 'other' },
@@ -1753,6 +1764,19 @@ describe('generateBatchZpl', () => {
     expect(result).toContain('^FN1^FDA1^FS');
     expect(result).toContain('^FN1^FDB2^FS');
     expect(result).toContain('^FN1^FDC3^FS');
+  });
+
+  it('does not source a row transform from a leaf inside an excluded group', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const hiddenQr = {
+      id: 'g', type: 'group', includeInExport: false,
+      children: [{ id: 'q', type: 'qrcode', x: 0, y: 0, rotation: 0,
+        props: { content: '«sku»', magnification: 3, errorCorrection: 'M', model: 2, rotation: 'N' } }],
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [hiddenQr, textObj('sku')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    // The hidden QR's EC prefix must not stamp the recall value.
+    expect(result).toContain('^FN1^FDA1^FS');
   });
 
   it('skips variables that are not in the mapping', () => {


### PR DESCRIPTION
Derived by comparing the encodings the emitters produce, so per-object options and binding shapes are covered without a rule per type.