### PR TITLE
feat(parser): expose object and finding source spans

### DIFF
--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -12,7 +12,7 @@ import { parseLabelMetaComment, type LabelMeta } from "./zplLabelMeta";
 import { stripLineWrap, stripTrailingSpaces, tokenize } from "./zplParser/helpers";
 import { lookaheadJmDensity, scanBareStream } from "./zplHeadScan";
 import { qrPrintsAsGraphic } from "./objectBounds";
-import { createParserState, deriveUnitScale, REGEN_LOSSY_REASONS, resetFormatScopedState, type FnDefaultCandidate, type RegenLossyReason } from "./zplParser/context";
+import { createParserState, deriveUnitScale, REGEN_LOSSY_REASONS, resetFormatScopedState, type FnDefaultCandidate, type RegenLossyReason, type SpannedToken } from "./zplParser/context";
 import { createFlushField } from "./zplParser/flushField";
 import { createBarcodeHandlers } from "./zplParser/handlers/barcodes";
 import { createDynamicFontAWildcard, createFieldHandlers } from "./zplParser/handlers/fields";
@@ -27,6 +27,7 @@ import type {
   ImportFinding,
   ParsedPage,
   ParsedZPL,
+  SourceSpan,
   UnbalancedFormat,
   Wildcard,
 } from "./zplParser/types";
@@ -355,16 +356,16 @@ export function parseZPL(
   const bucketFindings = (
     pageIndex: number,
     partial: readonly string[],
-    browser: readonly string[],
-    unk: readonly string[],
-    replay: readonly string[],
-    device: readonly string[],
+    browser: readonly SpannedToken[],
+    unk: readonly SpannedToken[],
+    replay: readonly SpannedToken[],
+    device: readonly SpannedToken[],
   ): ImportFinding[] => [
-    ...partial.map((command): ImportFinding => ({ kind: "partial", command, pageIndex })),
-    ...browser.map((command): ImportFinding => ({ kind: "browserLimit", command, pageIndex })),
-    ...unk.map((command): ImportFinding => ({ kind: "unknown", command, pageIndex })),
-    ...replay.map((command): ImportFinding => ({ kind: "replayRisk", command, pageIndex })),
-    ...device.map((command): ImportFinding => ({ kind: "deviceAction", command, pageIndex })),
+    ...partial.map((command): ImportFinding => ({ kind: "partial", command, pageIndex, span: s.result.partialSpans.get(command) })),
+    ...browser.map((t): ImportFinding => ({ kind: "browserLimit", command: t.command, pageIndex, span: t.span })),
+    ...unk.map((t): ImportFinding => ({ kind: "unknown", command: t.command, pageIndex, span: t.span })),
+    ...replay.map((t): ImportFinding => ({ kind: "replayRisk", command: t.command, pageIndex, span: t.span })),
+    ...device.map((t): ImportFinding => ({ kind: "deviceAction", command: t.command, pageIndex, span: t.span })),
   ];
 
   /** Close the current page at source offset `end`: per-format serial-orphan
@@ -441,6 +442,17 @@ export function parseZPL(
     };
     if (pageOverlay) page.overlay = pageOverlay;
     if (!s.sawXa) page.bare = true;
+    if (opts.captureOverlay) {
+      const spanEntries = overlaySpans.slice(pg.span).flatMap(
+        (sp): [string, SourceSpan][] =>
+          sp.link.kind === "object"
+            ? [[sp.link.objectId, { start: sp.start, end: sp.end }]]
+            : [],
+      );
+      if (spanEntries.length > 0) {
+        page.objectSpans = new Map(spanEntries);
+      }
+    }
     pages.push(page);
     // ^PW/^LL persist across ^XA, so only a value CHANGE between page closes is
     // a real divergence the single-label model cannot represent.
@@ -458,7 +470,11 @@ export function parseZPL(
     resetFormatScopedState(s);
   };
 
-  for (const { cmd, rest, start } of tokens) {
+  for (const { cmd, rest, start, end } of tokens) {
+    // Read by the finding push sites (notePartial, pushBrowserLimit). End is
+    // trimmed: the tokenizer's end runs to the next command's prefix, and a
+    // span must not swallow the line break plus following indent.
+    s.result.tokenSpan = { start, end: Math.min(end, start + 3 + rest.trimEnd().length) };
     // Strips trailing break plus indent from the last literal param; LITERAL_TAIL_CMDS keep real trailing spaces.
     const p = stripLineWrap(rest).split(s.format.delimiterChar);
     const last = p[p.length - 1];
@@ -470,12 +486,12 @@ export function parseZPL(
     // ~PH/~PP: flagged as device actions AND skipped entirely, or they would
     // fall through to the unknown bucket and surface twice in the summary.
     if (tildeDeviceCodes.has(cmd) && zpl[start] === s.format.tildeChar) {
-      deviceAction.push(`${zpl[start]}${cmd}`);
+      deviceAction.push({ command: `${zpl[start]}${cmd}`, span: s.result.tokenSpan });
       continue;
     }
     // These findings name bytes that replay verbatim, so report the source prefix.
-    if (replayRiskCodes.has(cmd)) replayRisk.push(`${zpl[start]}${cmd}`);
-    else if (deviceActionCodes.has(cmd)) deviceAction.push(`${zpl[start]}${cmd}`);
+    if (replayRiskCodes.has(cmd)) replayRisk.push({ command: `${zpl[start]}${cmd}`, span: s.result.tokenSpan });
+    else if (deviceActionCodes.has(cmd)) deviceAction.push({ command: `${zpl[start]}${cmd}`, span: s.result.tokenSpan });
     // Balance bookkeeping needs the token offset and the state the handler is
     // about to flip, so it sits here rather than in the two handlers.
     if (cmd === "XA" || cmd === "XZ") {
@@ -679,7 +695,7 @@ export function parseZPL(
       // trimEnd: `rest` runs to the next command, dragging the line break in
       // multi-line ZPL into the surfaced token.
       const token = `${zpl[start] ?? "^"}${cmd}${rest}`.trimEnd();
-      unknown.push(token);
+      unknown.push({ command: token, span: s.result.tokenSpan });
     }
   }
 

--- a/packages/core/src/lib/zplParser/context.ts
+++ b/packages/core/src/lib/zplParser/context.ts
@@ -1,4 +1,5 @@
 import type { LabelObject } from "../../types/Group";
+import type { SourceSpan } from "./types";
 import type { LabelConfig } from "../../types/LabelConfig";
 import type { PrinterProfile } from "../../types/PrinterProfile";
 import type { Variable } from "../../types/Variable";
@@ -47,6 +48,13 @@ export const REGEN_LOSSY_REASONS = {
 
 export type RegenLossyReason = (typeof REGEN_LOSSY_REASONS)[keyof typeof REGEN_LOSSY_REASONS];
 
+/** A bucketed command plus the span of the token whose processing recorded
+ *  it, stamped at the push site from `ParserResult.tokenSpan`. */
+export interface SpannedToken {
+  command: string;
+  span?: SourceSpan;
+}
+
 /** Shared parse accumulators; pages slice the arrays via offset marks, the
  *  document-wide fields hand back via `ParsedZPL`. */
 export interface ParserResult {
@@ -55,12 +63,16 @@ export interface ParserResult {
   printerProfile: Partial<PrinterProfile>;
   variables: Variable[];
   partialCmds: Set<string>;
-  browserLimit: string[];
-  unknown: string[];
+  /** First-seen span per partial code; swapped with `partialCmds` per page. */
+  partialSpans: Map<string, SourceSpan>;
+  /** Span of the token currently being processed; the loop updates it. */
+  tokenSpan?: SourceSpan;
+  browserLimit: SpannedToken[];
+  unknown: SpannedToken[];
   /** Setup-Script commands seen (profile-backed, routable on import). */
-  replayRisk: string[];
+  replayRisk: SpannedToken[];
   /** Device-action commands seen (no profile field, not routable). */
-  deviceAction: string[];
+  deviceAction: SpannedToken[];
   /** Every in-range ^FN slot the tokenizer saw, including on fields that end
    *  up passthrough-only (no Variable). Import renumbering must avoid these:
    *  overlays replay the original bytes. */
@@ -292,7 +304,17 @@ export interface ParserState {
 /** trimEnd: `token` carries `rest` up to the next command, which in multi-line
  *  ZPL includes the trailing newline (noise in this diagnostic surface). */
 export function pushBrowserLimit(result: ParserResult, token: string): void {
-  result.browserLimit.push(token.trimEnd());
+  result.browserLimit.push({ command: token.trimEnd(), span: result.tokenSpan });
+}
+
+/** Partial-command funnel: dedup set plus first-seen span, recorded at the
+ *  source instead of a loop-side growth watch (which fails wrong on paths
+ *  that skip it). */
+export function notePartial(result: ParserResult, code: string): void {
+  result.partialCmds.add(code);
+  if (result.tokenSpan && !result.partialSpans.has(code)) {
+    result.partialSpans.set(code, result.tokenSpan);
+  }
 }
 
 /** Default text height: ^CF override, else ZPL baseline 30. */
@@ -338,6 +360,7 @@ export function resetFieldBlockDefaults(defaults: DefaultsState): void {
  *  resets too: a page closing mid-field must not leak a dangling ^FH/^FB. */
 export function resetFormatScopedState(s: ParserState): void {
   s.result.partialCmds = new Set();
+  s.result.partialSpans = new Map();
   s.varScopeStart = s.result.variables.length;
   s.serialStrippedFns.clear();
   s.bareDeclaredFns.clear();
@@ -362,6 +385,7 @@ export function createParserState(): ParserState {
       printerProfile: {},
       variables: [],
       partialCmds: new Set<string>(),
+      partialSpans: new Map<string, SourceSpan>(),
       browserLimit: [],
       unknown: [],
       replayRisk: [],

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -47,7 +47,7 @@ import type { CodablockProps } from "../../registry/codablock";
 import type { Tlc39Props } from "../../registry/tlc39";
 import { upceData6FromFd } from "../../registry/hriFormatters";
 import { decodeFH, makeObj, variableNameFromComment } from "./helpers";
-import {
+import { notePartial,
   getPosType,
   REGEN_LOSSY_REASONS,
   resetFieldBlockDefaults,
@@ -65,7 +65,7 @@ function code49HeightDots(s: ParserState): number {
   const mult = s.field.bcCode49Mult;
   const raw = mult === null ? ((s.defaults.byHeight || 20) - 3 * mw) / 2 : mult * mw;
   const height = code49SnapHeight(raw, mw);
-  if (mult === null || height !== raw) s.result.partialCmds.add("^B4");
+  if (mult === null || height !== raw) notePartial(s.result, "^B4");
   return height;
 }
 /** Cross-family deps flushField borrows from graphics (^GB+^FR) and parseZPL (^FX). */
@@ -179,7 +179,7 @@ export function createFlushField(
       // A range insert takes PART of the slot; the model has no range
       // vocabulary, so the collapse loses information. Bytes compare against
       // the canonical emit form, so any variance counts (#02# included).
-      if (m[2]) s.result.partialCmds.add("^FE");
+      if (m[2]) notePartial(s.result, "^FE");
       if (m[0] !== `${s.format.embedChar}${n}${s.format.embedChar}`) {
         s.fdRegenLossy ??= REGEN_LOSSY_REASONS.fnEmbed;
       }
@@ -426,7 +426,7 @@ export function createFlushField(
           s.fdRegenLossy ??= REGEN_LOSSY_REASONS.qr;
         }
         if (s.field.qrHeaderPartial || (fd.lossy && rawDecoded !== "")) {
-          s.result.partialCmds.add("^BQ");
+          notePartial(s.result, "^BQ");
         }
         pushLeaf(
           makeObj(
@@ -722,7 +722,7 @@ export function createFlushField(
       && isGs1Active(getEntry(justPushed.type), justPushed.props);
     const lastSerialisable = !!justPushed && !lastGs1
       && !!getEntry(justPushed.type)?.serialisable;
-    if (s.field.snPending && lastGs1) s.result.partialCmds.add(`^${s.field.snMode}`);
+    if (s.field.snPending && lastGs1) notePartial(s.result, `^${s.field.snMode}`);
 
     // Bind pending ^FN slot; existing Variable for same fnNumber is reused.
     if (s.comment.fnNumber !== null) {

--- a/packages/core/src/lib/zplParser/handlers/barcodes.ts
+++ b/packages/core/src/lib/zplParser/handlers/barcodes.ts
@@ -5,6 +5,7 @@ import type { Gs1DatabarProps } from "../../../registry/gs1databar";
 import { qrBqHeader, qrMagnificationFromZpl, qrModelFromZpl } from "../../../registry/qrcode";
 import { clampMaxicodeAppend, type MaxicodeProps } from "../../../registry/maxicode";
 import { GS1_DATABAR_DEFAULT_SEGMENTS } from "../../gs1";
+import { notePartial } from "../context";
 import type { ParserState } from "../context";
 import { dotsFor, int, readRotation, strParam } from "../helpers";
 import type { Handler } from "../types";
@@ -88,7 +89,7 @@ export function createBarcodeHandlers(s: ParserState): Record<string, Handler> {
       const f = strParam(p[2]) || "N";
       s.field.bcInterp = f === "A" || f === "B";
       s.field.bcInterpAbove = f === "A";
-      if (!["N", "A", "B"].includes(f)) s.result.partialCmds.add("^B4");
+      if (!["N", "A", "B"].includes(f)) notePartial(s.result, "^B4");
       const m = (p[3] ?? "A").toUpperCase();
       s.field.bcCode49Mode = /^[A0-5]$/.test(m)
         ? (m as Code49Props["mode"])

--- a/packages/core/src/lib/zplParser/handlers/fields.ts
+++ b/packages/core/src/lib/zplParser/handlers/fields.ts
@@ -5,7 +5,7 @@ import { getEntry, isGs1Active } from "../../../registry";
 import { classifyField } from "../../variableField";
 import { isGroup } from "../../../types/Group";
 import { ZPL_BUILTIN_FONT_LETTERS } from "../../customFonts";
-import {
+import { notePartial,
   getDefaultTextH,
   getDefaultTextW,
   resetFieldBlockDefaults,
@@ -45,7 +45,7 @@ export function createDynamicFontAWildcard(s: ParserState): Wildcard {
         !s.fonts.aliases.has(fontChar) &&
         !ZPL_BUILTIN_FONT_LETTERS.includes(fontChar)
       ) {
-        s.result.partialCmds.add(`^${cmd}`);
+        notePartial(s.result, `^${cmd}`);
       }
     },
   };
@@ -227,7 +227,7 @@ export function createFieldHandlers(
       // 2D/stacked field would import a state the emitter drops on export.
       // GS1 fields drop it with a loss note, like the in-field placement.
       if (lastObj && !isGroup(lastObj) && isGs1Active(getEntry(lastObj.type), lastObj.props)) {
-        s.result.partialCmds.add("^SN");
+        notePartial(s.result, "^SN");
         return;
       }
       if (lastObj && getEntry(lastObj.type)?.serialisable) {
@@ -328,7 +328,7 @@ export function createFieldHandlers(
       // record it so the import won't mistake it for a Setup-Script font.
       const fontRefTrimmed = fontRef.trim();
       if (fontRefTrimmed) s.fonts.referencedFontPaths.add(fontRefTrimmed);
-      s.result.partialCmds.add("^A@");
+      notePartial(s.result, "^A@");
     },
     // ^TB{rotation},{width},{height}: text block. Stored natively (width +
     // clip height) so it round-trips as ^TB, unlike the prior lossy collapse
@@ -363,14 +363,14 @@ export function createFieldHandlers(
     CI(p) {
       const enc = ciToEncoding(int(p[0]));
       s.format.ciDecoder = getDecoder(enc.label);
-      if (!enc.supported) s.result.partialCmds.add(`^CI${int(p[0])}`);
+      if (!enc.supported) notePartial(s.result, `^CI${int(p[0])}`);
     },
 
     // ^FN{n}: template slot for the next field's ^FD default. Out-of-range ignored.
     FN(p) {
       const n = int(p[0]);
       if (n < FN_NUMBER_MIN || n > FN_NUMBER_MAX) {
-        s.result.partialCmds.add("^FN");
+        notePartial(s.result, "^FN");
         return;
       }
       s.result.sourceFnNumbers.add(n);
@@ -444,7 +444,7 @@ export function createFieldHandlers(
     CC(_, rest) {
       const c = rest[0];
       if (!acceptsPrefixRemap(c, s.format.tildeChar, s.format.delimiterChar)) {
-        s.result.partialCmds.add("^CC");
+        notePartial(s.result, "^CC");
         return;
       }
       s.format.caretChar = c;
@@ -453,7 +453,7 @@ export function createFieldHandlers(
     CT(_, rest) {
       const c = rest[0];
       if (!acceptsPrefixRemap(c, s.format.caretChar, s.format.delimiterChar)) {
-        s.result.partialCmds.add("^CT");
+        notePartial(s.result, "^CT");
         return;
       }
       s.format.tildeChar = c;
@@ -462,7 +462,7 @@ export function createFieldHandlers(
     CD(_, rest) {
       const c = rest[0];
       if (!acceptsPrefixRemap(c, s.format.caretChar, s.format.tildeChar)) {
-        s.result.partialCmds.add("^CD");
+        notePartial(s.result, "^CD");
         return;
       }
       s.format.delimiterChar = c;

--- a/packages/core/src/lib/zplParser/handlers/graphics.ts
+++ b/packages/core/src/lib/zplParser/handlers/graphics.ts
@@ -4,7 +4,7 @@ import type { ImageProps } from "../../../registry/image";
 import type { LineProps } from "../../../registry/line";
 import { loadFontBytesSync } from "../../fontCache";
 import { formatStoragePath, parseStoragePath } from "../../storagePath";
-import { getPosType, pushBrowserLimit, type ParserState } from "../context";
+import { notePartial, getPosType, pushBrowserLimit, type ParserState } from "../context";
 import { decodeGraphicToImage } from "../decoders/graphic";
 import { preserveGfData } from "../decoders/gfa";
 import { extractQrSidecar } from "../../qrGraphic";
@@ -236,7 +236,7 @@ export function createGraphicsHandlers(
         // falls back to a square so the placeholder stays grabbable.
         const opaqueHeight = gfFieldCount > 0 ? Math.floor(gfFieldCount / gfBytesPerRow) : 0;
         const opaqueH = opaqueHeight > 0 ? opaqueHeight : opaqueWidth;
-        s.result.partialCmds.add("^GF");
+        notePartial(s.result, "^GF");
         pushGraphic(
           "image",
           opaqueWidth,
@@ -252,7 +252,7 @@ export function createGraphicsHandlers(
         );
         return;
       }
-      if (!gfImage.crcOk) s.result.partialCmds.add("^GF");
+      if (!gfImage.crcOk) notePartial(s.result, "^GF");
       const gfComment = takeComment();
       // Rotated-QR sidecar: rebuild the QR object, not an image. The emit anchors
       // via fieldPos, so keep the raw field coords, not pushGraphic's ftTopLeft.
@@ -379,7 +379,7 @@ export function createGraphicsHandlers(
       // printer side is assumed to resolve. Surface as partial so the
       // import report flags the degraded preview. No real dims; the square
       // placeholder doubles as the ^FT footprint.
-      s.result.partialCmds.add("^XG");
+      notePartial(s.result, "^XG");
       pushGraphic(
         "image",
         200,
@@ -467,7 +467,7 @@ export function createGraphicsHandlers(
           pushBrowserLimit(s.result, dySummary);
           return;
         }
-        if (!dyImage.crcOk) s.result.partialCmds.add("~DY");
+        if (!dyImage.crcOk) notePartial(s.result, "~DY");
         // Path normalisation: ~DY uses `device:stem` without extension; the
         // ^XG side resolves `device:stem.GRF`. Store the `.GRF` form so the
         // XG lookup is direct.

--- a/packages/core/src/lib/zplParser/handlers/labelConfig.ts
+++ b/packages/core/src/lib/zplParser/handlers/labelConfig.ts
@@ -3,7 +3,7 @@ import { parseIntOrUndef } from "../../inputParse";
 import { isYesNo } from "../../../types/typeHelpers";
 import { dotsToMm } from "../../coordinates";
 import { isPlausibleLabelMm } from "../../zplLabelMeta";
-import { deriveUnitScale, type ParserState } from "../context";
+import { notePartial, deriveUnitScale, type ParserState } from "../context";
 import { dotsFor, firstChar, inRange, int, intDotsOrUndef, strParam } from "../helpers";
 import type { Handler } from "../types";
 
@@ -29,14 +29,14 @@ export function createLabelConfigHandlers(
       if (w === undefined || w <= 0) return;
       const mm = dotsToMm(w, dpmm);
       if (isPlausibleLabelMm(mm)) labelConfig.widthMm = mm;
-      else s.result.partialCmds.add("^PW");
+      else notePartial(s.result, "^PW");
     },
     LL(_, rest) {
       const h = physDots(rest);
       if (h === undefined || h <= 0) return;
       const mm = dotsToMm(h, dpmm);
       if (isPlausibleLabelMm(mm)) labelConfig.heightMm = mm;
-      else s.result.partialCmds.add("^LL");
+      else notePartial(s.result, "^LL");
     },
     PQ(p) {
       const qty = int(p[0], 0);
@@ -61,7 +61,7 @@ export function createLabelConfigHandlers(
     RS(p) {
       const adopt = (slot: number, take: (raw: string | undefined) => boolean) => {
         if (take(p[slot])) return;
-        if (strParam(p[slot]) !== "") s.result.partialCmds.add("^RS");
+        if (strParam(p[slot]) !== "") notePartial(s.result, "^RS");
       };
       adopt(0, (raw) => {
         if (int(raw, 0) !== 8) return false;
@@ -106,7 +106,7 @@ export function createLabelConfigHandlers(
     RB(p) {
       const bits = inRange(parseIntOrUndef(p[0]), RFID_EPC_BITS_RANGE);
       if (bits === undefined) {
-        s.result.partialCmds.add("^RB");
+        notePartial(s.result, "^RB");
         return;
       }
       // Only a trailing delimiter is noise; an empty slot inside the list is
@@ -125,7 +125,7 @@ export function createLabelConfigHandlers(
         parts.some((x) => x === undefined) ||
         parts.reduce((a, b) => (a ?? 0) + (b ?? 0), 0) !== bits
       ) {
-        s.result.partialCmds.add("^RB");
+        notePartial(s.result, "^RB");
         return;
       }
       labelConfig.rfidEpcBits = bits;
@@ -136,12 +136,12 @@ export function createLabelConfigHandlers(
       const take = (slot: number, set: (v: RfidPower) => void) => {
         const value = parseRfidPower(p[slot]);
         if (value !== undefined) set(value);
-        else if (strParam(p[slot]) !== "") s.result.partialCmds.add("^RW");
+        else if (strParam(p[slot]) !== "") notePartial(s.result, "^RW");
       };
       take(0, (v) => (labelConfig.rfidReadPower = v));
       take(1, (v) => (labelConfig.rfidWritePower = v));
       // The antenna slot is unmodelled, so any value in it is a loss.
-      if (strParam(p[2]) !== "") s.result.partialCmds.add("^RW");
+      if (strParam(p[2]) !== "") notePartial(s.result, "^RW");
     },
     MM(_, rest) {
       const mode = firstChar(rest);

--- a/packages/core/src/lib/zplParser/handlers/units.ts
+++ b/packages/core/src/lib/zplParser/handlers/units.ts
@@ -1,5 +1,5 @@
 import { isMuDpi, jmDensityOf } from "../../../types/LabelConfig";
-import { deriveUnitScale, type ParserState } from "../context";
+import { notePartial, deriveUnitScale, type ParserState } from "../context";
 import type { Handler } from "../types";
 
 /** ^MU / ^JM handlers. ^MU owns the dot-scale of body values; the ^JM density
@@ -7,7 +7,7 @@ import type { Handler } from "../types";
  *  only validates and surfaces the values the lookahead ignores. */
 export function createUnitsHandler(s: ParserState, dpmm: number): Record<string, Handler> {
   const labelConfig = s.result.labelConfig;
-  const markPartial = () => s.result.partialCmds.add("^MU");
+  const markPartial = () => notePartial(s.result, "^MU");
 
   return {
     // a-slot scales dot-quantities on read so the model stays
@@ -38,7 +38,7 @@ export function createUnitsHandler(s: ParserState, dpmm: number): Record<string,
     // an invalid value, or a ^JM outside any head (post-^FS, preamble, between formats).
     JM(_p, rest) {
       const v = jmDensityOf(rest, s.format.delimiterChar);
-      if (v === undefined || !s.format.inFormatHead) s.result.partialCmds.add("^JM");
+      if (v === undefined || !s.format.inFormatHead) notePartial(s.result, "^JM");
     },
   };
 }

--- a/packages/core/src/lib/zplParser/helpers.ts
+++ b/packages/core/src/lib/zplParser/helpers.ts
@@ -209,7 +209,9 @@ export function* tokenize(
     // mutates it). Generic commands consume rest until the next delimiter.
     if (cmd === "CC" || cmd === "CT" || cmd === "CD") {
       const argChar = zpl[cmdStart + 3] ?? "";
-      pos = cmdStart + 4;
+      // Clamp: the arg slot may be missing at EOF, and `end` must stay a
+      // valid slice index.
+      pos = Math.min(cmdStart + 4, zpl.length);
       yield { cmd, rest: argChar, start: cmdStart, end: pos };
       continue;
     }

--- a/packages/core/src/lib/zplParser/types.ts
+++ b/packages/core/src/lib/zplParser/types.ts
@@ -15,6 +15,13 @@ export type ImportFindingKind =
   | "fnDefaultDropped"
   | "mixedPageGeometry";
 
+/** Absolute offsets into the parsed source string. Readonly: one span object
+ *  may back several findings of the same token, so no consumer may rebase it. */
+export interface SourceSpan {
+  readonly start: number;
+  readonly end: number;
+}
+
 /**
  * One import finding. Created per-occurrence so each entry can be navigated
  * to its source page in the UI; cross-page dedup happens (if at all) in the
@@ -32,6 +39,10 @@ export interface ImportFinding {
   /** Which divergence a 'mixedPageGeometry' finding reports, so consumers
    *  pick their message without sniffing `command`. */
   cause?: 'size' | 'jm';
+  /** Span of the token whose processing recorded the finding (always
+   *  stamped). A flush-raised finding carries the token that closed the
+   *  field: its ^FS or the next field's opener. Absent for post-parse kinds. */
+  span?: SourceSpan;
 }
 
 export interface ImportReport {
@@ -73,6 +84,10 @@ export interface ParsedPage {
   /** Page 0 only: stream had no ^XA wrapper (bare field paste). Re-export
    *  regenerates the wrapper, so the overlay is suppressed by the caller. */
   bare?: boolean;
+  /** Absolute source span per cleanly linked object; unlinked objects absent.
+   *  Requires `captureOverlay` (reuses the overlay's link pass) but survives
+   *  pages whose overlay the all-linked gate refuses. */
+  objectSpans?: ReadonlyMap<string, SourceSpan>;
 }
 
 /** First ^XA/^XZ imbalance. `at` is the command's offset in the source

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -3339,3 +3339,89 @@ describe('parseZPL — unbalanced command text', () => {
     });
   });
 });
+
+describe('parseZPL — source spans (objectSpans + finding.span)', () => {
+  it('stamps each cleanly linked object with its absolute source span', () => {
+    const f1 = '^FO10,10^A0N,20,0^FDhi^FS';
+    const f2 = '^FO20,40^GB50,50,2^FS';
+    const zpl = `^XA${f1}${f2}^XZ`;
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    expect(r.objects).toHaveLength(2);
+    const [a, b] = r.objects;
+    const spanA = defined(r.objectSpans?.get(defined(a).id));
+    const spanB = defined(r.objectSpans?.get(defined(b).id));
+    expect(zpl.slice(spanA.start, spanA.end)).toBe(f1);
+    expect(zpl.slice(spanB.start, spanB.end)).toBe(f2);
+  });
+
+  it('keeps object spans when the all-linked gate refuses the overlay', () => {
+    // Two objects in one field: neither links, the overlay is refused, but
+    // the clean text field keeps its span for editor/linter navigation.
+    const clean = '^FO10,10^A0N,20,0^FDhi^FS';
+    const zpl = `^XA${clean}^FO20,40^GB50,50,2^GB60,60,2^FS^XZ`;
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    expect(r.objects.length).toBeGreaterThan(1);
+    expect(r.overlay).toBeUndefined();
+    const textObj = r.objects.find((o) => o.type === 'text');
+    const span = defined(r.objectSpans?.get(defined(textObj).id));
+    expect(zpl.slice(span.start, span.end)).toBe(clean);
+  });
+
+  it('stamps bucketed findings with the span of the recording token', () => {
+    const zpl = '^XA^ZZ9,1^FO10,10^A0N,20,0^FDhi^FS^XZ';
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    const unknown = defined(r.findings.find((f) => f.kind === 'unknown'));
+    const span = defined(unknown.span);
+    expect(zpl.slice(span.start, span.end)).toBe('^ZZ9,1');
+  });
+
+  it('spans exclude the line-wrap tail up to the next command', () => {
+    const zpl = '^XA^QQdata ^FO10,10^A0N,20,0^FDhi^FS^XZ';
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    const unknown = defined(r.findings.find((f) => f.kind === 'unknown'));
+    expect(unknown.command).toBe('^QQdata');
+    const span = defined(unknown.span);
+    expect(zpl.slice(span.start, span.end)).toBe('^QQdata');
+  });
+
+  it('pretty-printed ZPL: a span covers one command, not the next line indent', () => {
+    const zpl = '^XA\n  ^ZZ1,1\n  ^FO10,10^A0N,20,0^FDhi^FS\n^XZ';
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    const unknown = defined(r.findings.find((f) => f.kind === 'unknown'));
+    const span = defined(unknown.span);
+    expect(zpl.slice(span.start, span.end)).toBe('^ZZ1,1');
+  });
+
+  it('a truncated ^CC at EOF keeps the span inside the source', () => {
+    // The prefix-remap tokenizer path consumed its arg slot unconditionally,
+    // pushing end one past EOF; editor ranges past doc length throw.
+    const zpl = '^XA^CC';
+    const r = parseZPL(zpl, 8);
+    const partial = defined(r.pages.flatMap((p) => p.findings).find((f) => f.kind === 'partial'));
+    const span = defined(partial.span);
+    expect(span.end).toBeLessThanOrEqual(zpl.length);
+    expect(zpl.slice(span.start, span.end)).toBe('^CC');
+  });
+
+  it('spans stay document-absolute on pages after the first', () => {
+    const f1 = '^FO10,10^A0N,20,0^FDp1^FS';
+    const f2 = '^FO20,20^A0N,20,0^FDp2^FS';
+    const zpl = `^XA${f1}^XZ^XA^ZZ9,1${f2}^XZ`;
+    const r = parseZPL(zpl, 8, { captureOverlay: true });
+    const page1 = defined(r.pages[1]);
+    const obj = defined(page1.objects[0]);
+    const span = defined(page1.objectSpans?.get(obj.id));
+    expect(zpl.slice(span.start, span.end)).toBe(f2);
+    const unknown = defined(page1.findings.find((f) => f.kind === 'unknown'));
+    const fSpan = defined(unknown.span);
+    expect(zpl.slice(fSpan.start, fSpan.end)).toBe('^ZZ9,1');
+  });
+
+  it('stamps a pre-handler device action with its token span', () => {
+    const zpl = '^XA^FO10,10^A0N,20,0^FDhi^FS^XZ~PH';
+    const r = parseZPL(zpl, 8, { captureOverlay: true });
+    const dev = defined(r.pages.flatMap((p) => p.findings).find((f) => f.kind === 'deviceAction'));
+    const span = defined(dev.span);
+    expect(zpl.slice(span.start, span.end)).toBe('~PH');
+  });
+});


### PR DESCRIPTION
objectSpans per page and ImportFinding.span, independent of the overlay's all-linked gate (which keeps guarding byte-exact replay only).