### PR TITLE
feat(editor): mark spanned import findings as warnings in the source …

### DIFF
--- a/e2e/sourceEdit.spec.ts
+++ b/e2e/sourceEdit.spec.ts
@@ -76,6 +76,13 @@ test('an unbalanced draft shows a positioned lint error while typing', async ({ 
   await expect(page.locator('.cm-lintRange-error')).toHaveText('^XZ');
 });
 
+test('a device action gets a positioned warning mark while typing', async ({ page }) => {
+  await page.goto('/');
+  const output = await importSample(page);
+  await retype(page, output, '^XA^FO10,10^A0N,30,30^FDX^FS^XZ~PH');
+  await expect(page.locator('.cm-lintRange-warning')).toHaveText('~PH');
+});
+
 test('Escape asks to discard and restores the export', async ({ page }) => {
   await page.goto('/');
   const output = await importSample(page);

--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -475,6 +475,7 @@ export function parseZPL(
     // trimmed: the tokenizer's end runs to the next command's prefix, and a
     // span must not swallow the line break plus following indent.
     s.result.tokenSpan = { start, end: Math.min(end, start + 3 + rest.trimEnd().length) };
+    s.result.lastSpanByCmd.set(cmd, s.result.tokenSpan);
     // Strips trailing break plus indent from the last literal param; LITERAL_TAIL_CMDS keep real trailing spaces.
     const p = stripLineWrap(rest).split(s.format.delimiterChar);
     const last = p[p.length - 1];

--- a/packages/core/src/lib/zplParser/context.ts
+++ b/packages/core/src/lib/zplParser/context.ts
@@ -67,6 +67,8 @@ export interface ParserResult {
   partialSpans: Map<string, SourceSpan>;
   /** Span of the token currently being processed; the loop updates it. */
   tokenSpan?: SourceSpan;
+  /** Last span per bare command code; notePartial anchors partials here. */
+  lastSpanByCmd: Map<string, SourceSpan>;
   browserLimit: SpannedToken[];
   unknown: SpannedToken[];
   /** Setup-Script commands seen (profile-backed, routable on import). */
@@ -309,12 +311,13 @@ export function pushBrowserLimit(result: ParserResult, token: string): void {
 
 /** Partial-command funnel: dedup set plus first-seen span, recorded at the
  *  source instead of a loop-side growth watch (which fails wrong on paths
- *  that skip it). */
+ *  that skip it). A partial names a command code, so it anchors at that
+ *  command's own bytes, not the token that happened to raise it. */
 export function notePartial(result: ParserResult, code: string): void {
   result.partialCmds.add(code);
-  if (result.tokenSpan && !result.partialSpans.has(code)) {
-    result.partialSpans.set(code, result.tokenSpan);
-  }
+  if (result.partialSpans.has(code)) return;
+  const span = result.lastSpanByCmd.get(code.slice(1)) ?? result.tokenSpan;
+  if (span) result.partialSpans.set(code, span);
 }
 
 /** Default text height: ^CF override, else ZPL baseline 30. */
@@ -361,6 +364,7 @@ export function resetFieldBlockDefaults(defaults: DefaultsState): void {
 export function resetFormatScopedState(s: ParserState): void {
   s.result.partialCmds = new Set();
   s.result.partialSpans = new Map();
+  s.result.lastSpanByCmd = new Map();
   s.varScopeStart = s.result.variables.length;
   s.serialStrippedFns.clear();
   s.bareDeclaredFns.clear();
@@ -386,6 +390,7 @@ export function createParserState(): ParserState {
       variables: [],
       partialCmds: new Set<string>(),
       partialSpans: new Map<string, SourceSpan>(),
+      lastSpanByCmd: new Map<string, SourceSpan>(),
       browserLimit: [],
       unknown: [],
       replayRisk: [],

--- a/packages/core/src/lib/zplParser/types.ts
+++ b/packages/core/src/lib/zplParser/types.ts
@@ -39,9 +39,9 @@ export interface ImportFinding {
   /** Which divergence a 'mixedPageGeometry' finding reports, so consumers
    *  pick their message without sniffing `command`. */
   cause?: 'size' | 'jm';
-  /** Span of the token whose processing recorded the finding (always
-   *  stamped). A flush-raised finding carries the token that closed the
-   *  field: its ^FS or the next field's opener. Absent for post-parse kinds. */
+  /** Source anchor, always stamped: a partial points at the command it
+   *  names (even when raised later, at field flush); every other bucketed
+   *  kind at the token being processed. Absent for post-parse kinds. */
   span?: SourceSpan;
 }
 

--- a/src/components/Output/ZplCodeMirror.test.tsx
+++ b/src/components/Output/ZplCodeMirror.test.tsx
@@ -162,6 +162,24 @@ describe("ZplCodeMirror diagnostics", () => {
     expect(container.querySelector(".cm-lintRange-error")?.textContent).toBe("^XA");
   });
 
+  it("renders a finding warning as CM warning, not error or hint", async () => {
+    const { forEachDiagnostic } = await import("@codemirror/lint");
+    const value = "^XA^FDa^FS^XZ~PH";
+    const { container } = render(
+      <ZplCodeMirror
+        value={value}
+        onChange={vi.fn()}
+        ariaLabel="zpl" placeholderText="ph"
+        diagnostics={[{ from: 13, to: 16, severity: "warning", message: "device action" }]}
+      />,
+    );
+    const view = EditorView.findFromDOM(container as HTMLElement)!;
+    const seen: string[] = [];
+    forEachDiagnostic(view.state, (d) => seen.push(d.severity));
+    expect(seen).toEqual(["warning"]);
+    expect(container.querySelector(".cm-lintRange-warning")?.textContent).toBe("~PH");
+  });
+
   it("does not re-dispatch an identical set (an open tooltip would close)", () => {
     const value = "^XA^FDx^FSstray^XZ";
     const lint = () => [{ from: 10, to: 15, severity: "error" as const, message: "boom" }];

--- a/src/components/Output/ZplCodeMirror.tsx
+++ b/src/components/Output/ZplCodeMirror.tsx
@@ -156,9 +156,10 @@ function highlightDecorations(state: EditorState, lines: ReadonlySet<number>): D
 const NO_LINES: ReadonlySet<number> = new Set();
 
 /** Total map, so a new semantic severity cannot silently render as a hint. */
-const CM_SEVERITY: Record<SourceLint['severity'], 'error' | 'hint'> = {
+const CM_SEVERITY: Record<SourceLint['severity'], 'error' | 'hint' | 'warning'> = {
   error: 'error',
   related: 'hint',
+  warning: 'warning',
 };
 
 // Compartment payloads built in ONE place each, so mount and reconfigure

--- a/src/components/Output/ZplSourceEditor.tsx
+++ b/src/components/Output/ZplSourceEditor.tsx
@@ -8,6 +8,7 @@ import {
   selectPreviewLocksEditor,
   selectShadowDraft,
   selectShadowRefusal,
+  selectShadowFindings,
   selectSourceDocumentState,
 } from '../../store/labelStore';
 import type { SourceEditMode } from '../../store/slices/sourceEditSlice';
@@ -50,6 +51,7 @@ export function ZplSourceEditor({
   const gateMsg = gateRefusal !== null ? sourceRefusalText(gateRefusal, t) : null;
 
   const shadowRefusal = useLabelStore(selectShadowRefusal);
+  const shadowFindings = useLabelStore(selectShadowFindings);
   const shadowDraft = useLabelStore(selectShadowDraft);
   // Offsets only describe the text they were parsed from, so a lagging shadow
   // hands null and the editor keeps mapping its previous set; outside a
@@ -58,7 +60,7 @@ export function ZplSourceEditor({
     session === null
       ? NO_DIAGNOSTICS
       : shadowDraft === value
-        ? buildSourceDiagnostics(shadowRefusal, t)
+        ? buildSourceDiagnostics(shadowRefusal, shadowFindings, t)
         : null;
 
   // The text history belongs to the session: clear it when one ENDS, or an
@@ -148,7 +150,8 @@ function SessionChrome({
       : liveRefusal.reason !== 'unbalanced'
         ? sourceRefusalText(liveRefusal.reason, t)
         : liveDraft === session.draft
-          ? (buildSourceDiagnostics(liveRefusal, t)[0]?.message ?? null)
+          ? (buildSourceDiagnostics(liveRefusal, [], t)
+              .find((l) => l.severity === 'error')?.message ?? null)
           : null;
 
   // Whitespace over an empty baseline authored nothing: exits treat it as

--- a/src/hooks/useSourceEditShadow.test.tsx
+++ b/src/hooks/useSourceEditShadow.test.tsx
@@ -44,6 +44,31 @@ afterEach(() => {
 });
 
 describe("useSourceShadowSync", () => {
+  it("carries spanned import findings for the parsed draft", async () => {
+    const { rerender } = renderHook(() => useSourceShadowSync());
+    const draft = "^XA^FO10,10^A0N,30,30^FDHi^FS^XZ~PH";
+    act(() => {
+      useLabelStore.setState({ sourceEdit: session(draft) });
+    });
+    rerender();
+    await flushParse();
+    const shadow = useLabelStore.getState().sourceShadow;
+    const dev = shadow?.findings.find((f) => f.kind === "deviceAction");
+    expect(dev?.span && draft.slice(dev.span.start, dev.span.end)).toBe("~PH");
+  });
+
+  it("clears findings on the refusal path (offsets would be stale)", async () => {
+    const { rerender } = renderHook(() => useSourceShadowSync());
+    act(() => {
+      useLabelStore.setState({ sourceEdit: session("^XA~PH^FDx^FS") });
+    });
+    rerender();
+    await flushParse();
+    const shadow = useLabelStore.getState().sourceShadow;
+    expect(shadow?.refusal?.reason).toBe("unbalanced");
+    expect(shadow?.findings).toEqual([]);
+  });
+
   it("parses an edited draft into the shadow; an untouched buffer stays live", async () => {
     const { rerender } = renderHook(() => useSourceShadowSync());
     act(() => {

--- a/src/hooks/useSourceEditShadow.ts
+++ b/src/hooks/useSourceEditShadow.ts
@@ -30,7 +30,7 @@ export function useSourceShadowSync(): void {
     if (draft === null || baseline === null) return;
     const shadow = useLabelStore.getState().setSourceShadow;
     if (draft === baseline) {
-      const id = setTimeout(() => shadow({ doc: null, refusal: null, draft }), 0);
+      const id = setTimeout(() => shadow({ doc: null, refusal: null, findings: [], draft }), 0);
       return () => clearTimeout(id);
     }
     if (draft.length > MAX_SOURCE_CHARS) {
@@ -56,6 +56,7 @@ export function useSourceShadowSync(): void {
             columnMapping: plan.next.columnMapping,
           },
           refusal: null,
+          findings: plan.report.findings,
           draft,
         });
       } else if (

--- a/src/lib/sourceDiagnostics.test.ts
+++ b/src/lib/sourceDiagnostics.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { buildSourceDiagnostics } from "./sourceDiagnostics";
+import { describeFinding } from "./importReport";
 import { formatTemplate } from "./formatTemplate";
 import { fallbackTranslations as en } from "../locales";
+import type { ImportFinding } from "@zplab/core/lib/importReport";
 
 describe("buildSourceDiagnostics", () => {
   it("names each imbalance kind with the bytes it found", () => {
     const of = (ub: { kind: "strayXz" | "unclosedXa"; at: number; cmd: string }) =>
-      buildSourceDiagnostics({ reason: "unbalanced", unbalanced: ub }, en);
+      buildSourceDiagnostics({ reason: "unbalanced", unbalanced: ub }, [], en);
     // The generic banner told the user to ADD what the diagnostic points at.
     expect(of({ kind: "strayXz", at: 0, cmd: "#XZ" })).toEqual([{
       from: 0, to: 3, severity: "error",
@@ -20,13 +22,57 @@ describe("buildSourceDiagnostics", () => {
     const lints = buildSourceDiagnostics({
       reason: "unbalanced",
       unbalanced: { kind: "unclosedXa", at: 0, cmd: "^XA", related: { at: 40, cmd: "^XA" } },
-    }, en);
+    }, [], en);
     expect(lints.map((l) => [l.from, l.severity])).toEqual([[0, "error"], [40, "related"]]);
     expect(lints[1]?.message).toBe(formatTemplate(en.output.lintStillOpenHereFmt, { cmd: "^XA" }));
   });
 
   it("stays silent for a refusal without a located command", () => {
-    expect(buildSourceDiagnostics({ reason: "tooLarge" }, en)).toEqual([]);
-    expect(buildSourceDiagnostics(null, en)).toEqual([]);
+    expect(buildSourceDiagnostics({ reason: "tooLarge" }, [], en)).toEqual([]);
+    expect(buildSourceDiagnostics(null, [], en)).toEqual([]);
+  });
+
+  it("maps a spanned finding to a warning with its report wording", () => {
+    const f: ImportFinding = { kind: "deviceAction", command: "~PH", pageIndex: 0, span: { start: 12, end: 15 } };
+    const { title, detail } = describeFinding(f, en.importReport);
+    expect(buildSourceDiagnostics(null, [f], en)).toEqual([
+      { from: 12, to: 15, severity: "warning", message: `${title}: ${detail}` },
+    ]);
+  });
+
+  it("drops findings without a span instead of guessing a position", () => {
+    const f: ImportFinding = { kind: "lossyEdit", command: "some reason", pageIndex: 0 };
+    expect(buildSourceDiagnostics(null, [f], en)).toEqual([]);
+  });
+
+  it("returns every lint in document order", () => {
+    const late: ImportFinding = { kind: "unknown", command: "^QQ1", pageIndex: 0, span: { start: 30, end: 34 } };
+    const early: ImportFinding = { kind: "deviceAction", command: "~PH", pageIndex: 0, span: { start: 3, end: 6 } };
+    const lints = buildSourceDiagnostics(
+      { reason: "unbalanced", unbalanced: { kind: "strayXz", at: 0, cmd: "^XZ" } }, [late, early], en);
+    expect(lints.map((l) => l.from)).toEqual([0, 3, 30]);
+    expect(lints[0]?.severity).toBe("error");
+  });
+
+  it("caps by position, so a late kind is not starved by an early flood", () => {
+    const flood: ImportFinding[] = Array.from({ length: 600 }, (_, i) =>
+      ({ kind: "unknown", command: `^Q${i}`, pageIndex: 0, span: { start: 100 + i, end: 101 + i } }));
+    const early: ImportFinding = { kind: "deviceAction", command: "~PH", pageIndex: 0, span: { start: 3, end: 6 } };
+    const lints = buildSourceDiagnostics(null, [...flood, early], en);
+    expect(lints[0]?.from).toBe(3);
+  });
+
+  it("the cap budgets findings only: the imbalance error always survives", () => {
+    const flood: ImportFinding[] = Array.from({ length: 600 }, (_, i) =>
+      ({ kind: "unknown", command: `^Q${i}`, pageIndex: 0, span: { start: i, end: i + 1 } }));
+    const lints = buildSourceDiagnostics(
+      { reason: "unbalanced", unbalanced: { kind: "strayXz", at: 900, cmd: "^XZ" } }, flood, en);
+    expect(lints.some((l) => l.severity === "error")).toBe(true);
+  });
+
+  it("caps a degenerate flood of warnings", () => {
+    const flood: ImportFinding[] = Array.from({ length: 600 }, (_, i) =>
+      ({ kind: "unknown", command: `^Q${i}`, pageIndex: 0, span: { start: i, end: i + 1 } }));
+    expect(buildSourceDiagnostics(null, flood, en).length).toBeLessThanOrEqual(500);
   });
 });

--- a/src/lib/sourceDiagnostics.ts
+++ b/src/lib/sourceDiagnostics.ts
@@ -1,5 +1,7 @@
 import type { UnbalancedFormat } from '@zplab/core/lib/zplParser';
+import type { ImportFinding } from '@zplab/core/lib/importReport';
 import type { SourceRefusalInfo } from '@zplab/core/lib/zplSourceEdit';
+import { describeFinding } from './importReport';
 import { formatTemplate } from './formatTemplate';
 import type { Translations } from '../locales';
 
@@ -11,9 +13,13 @@ export interface SourceLint {
   to: number;
   /** `related` marks context, not a second defect: the editor renders it
    *  weaker so one problem still reads as one problem. */
-  severity: 'error' | 'related';
+  severity: 'error' | 'related' | 'warning';
   message: string;
 }
+
+/** A pasted garbage stream can raise a finding per token; past this the
+ *  squiggles stop adding information. */
+const MAX_FINDING_LINTS = 500;
 
 const KIND_MSG = {
   strayXz: 'lintStrayXzFmt',
@@ -21,30 +27,50 @@ const KIND_MSG = {
 } as const;
 
 /** The one diagnostics derivation: the imbalance a refused apply reports,
- *  pointed at the command that caused it. */
+ *  pointed at the command that caused it, then the spanned import findings
+ *  as warnings in the report's own wording. Span-less findings stay in the
+ *  report surfaces; a guessed position would mislead. */
 export function buildSourceDiagnostics(
   refusal: SourceRefusalInfo | null,
+  findings: readonly ImportFinding[],
   t: Translations,
 ): SourceLint[] {
-  if (refusal?.reason !== 'unbalanced') return [];
-  const ub: UnbalancedFormat = refusal.unbalanced;
-  const lints: SourceLint[] = [
-    {
+  const lints: SourceLint[] = [];
+  if (refusal?.reason === 'unbalanced') {
+    const ub: UnbalancedFormat = refusal.unbalanced;
+    lints.push({
       from: ub.at,
       to: ub.at + ub.cmd.length,
       severity: 'error',
       message: formatTemplate(t.output[KIND_MSG[ub.kind]], { cmd: ub.cmd }),
-    },
-  ];
-  // The defect is the unterminated format, but the repair goes here, which in
-  // a multi-label document is a whole label away from the opener.
-  if (ub.related) {
-    lints.push({
-      from: ub.related.at,
-      to: ub.related.at + ub.related.cmd.length,
-      severity: 'related',
-      message: formatTemplate(t.output.lintStillOpenHereFmt, { cmd: ub.cmd }),
+    });
+    // The defect is the unterminated format, but the repair goes here, which in
+    // a multi-label document is a whole label away from the opener.
+    if (ub.related) {
+      lints.push({
+        from: ub.related.at,
+        to: ub.related.at + ub.related.cmd.length,
+        severity: 'related',
+        message: formatTemplate(t.output.lintStillOpenHereFmt, { cmd: ub.cmd }),
+      });
+    }
+  }
+  const warnings: SourceLint[] = [];
+  for (const f of findings) {
+    if (!f.span) continue;
+    const { title, detail } = describeFinding(f, t.importReport);
+    warnings.push({
+      from: f.span.start,
+      to: f.span.end,
+      severity: 'warning',
+      message: `${title}: ${detail}`,
     });
   }
+  // Document order, then cap: kind-grouped input never matches what the
+  // editor holds (it iterates by position), and capping in arrival order
+  // starves whole kinds. Warnings only, so a flood cannot push out the error.
+  warnings.sort((a, b) => a.from - b.from);
+  lints.push(...warnings.slice(0, MAX_FINDING_LINTS));
+  lints.sort((a, b) => a.from - b.from);
   return lints;
 }

--- a/src/lib/zplParser.test.ts
+++ b/src/lib/zplParser.test.ts
@@ -3425,3 +3425,21 @@ describe('parseZPL — source spans (objectSpans + finding.span)', () => {
     expect(zpl.slice(span.start, span.end)).toBe('~PH');
   });
 });
+
+describe('parseZPL — a partial names its own command', () => {
+  it('spans the command the finding names, not the token that flushed it', () => {
+    const zpl = '^XA^FO10,10^BQN,2,10,Q,7^FDMM,AHello^FS^XZ';
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    const partial = defined(r.findings.find((f) => f.kind === 'partial' && f.command === '^BQ'));
+    const span = defined(partial.span);
+    expect(zpl.slice(span.start, span.end)).toBe('^BQN,2,10,Q,7');
+  });
+
+  it('points a remapped-prefix partial at its own source bytes', () => {
+    const zpl = '^XA^CC##FO10,10#BQN,2,10,Q,7#FDMM,AHello#FS#XZ';
+    const r = parseSingle(zpl, 8, { captureOverlay: true });
+    const partial = defined(r.findings.find((f) => f.kind === 'partial' && f.command.endsWith('BQ')));
+    const span = defined(partial.span);
+    expect(zpl.slice(span.start, span.end)).toBe('#BQN,2,10,Q,7');
+  });
+});

--- a/src/store/labelStore.selectors.ts
+++ b/src/store/labelStore.selectors.ts
@@ -1,3 +1,4 @@
+import type { ImportFinding } from '@zplab/core/lib/importReport';
 import { pageLabelConfig, type LabelObject } from '@zplab/core/types/Group';
 import { isDefaultHost, resolveHost, resolveApiKey } from '../lib/labelary';
 import { isDesktopShell } from '../lib/platform';
@@ -46,6 +47,8 @@ export const currentPageLabel = (state: LabelState): PageLabel =>
  *  Session-end writers null the whole shadow, so no status guard is needed. */
 export const selectShadowRefusal = (s: LabelState) => s.sourceShadow?.refusal ?? null;
 export const selectShadowDraft = (s: LabelState) => s.sourceShadow?.draft ?? null;
+const NO_FINDINGS: readonly ImportFinding[] = [];
+export const selectShadowFindings = (s: LabelState) => s.sourceShadow?.findings ?? NO_FINDINGS;
 
 export const selectRenderPages = (s: LabelState) => s.sourceShadow?.doc?.pages ?? s.pages;
 

--- a/src/store/labelStore.ts
+++ b/src/store/labelStore.ts
@@ -61,6 +61,7 @@ export {
   selectSourceEditDirty,
   selectDocumentEmits,
   selectShadowRefusal,
+  selectShadowFindings,
   selectShadowDraft,
   selectRenderPages,
   selectRenderVariables,

--- a/src/store/slices/sourceEditSlice.test.ts
+++ b/src/store/slices/sourceEditSlice.test.ts
@@ -95,6 +95,7 @@ describe("applyZplSource", () => {
       sourceShadow: {
         doc: { label: { widthMm: 70, heightMm: 40, dpmm: 8 }, pages: [basePages[0]!, { objects: [] }], variables: [], columnMapping: null },
         refusal: null,
+        findings: [],
         draft: "^XA^FDone^FS^XZ",
       },
       currentPageIndex: 1,

--- a/src/store/slices/sourceEditSlice.ts
+++ b/src/store/slices/sourceEditSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { SourceApplyOk, SourceRefusalInfo } from '@zplab/core/lib/zplSourceEdit';
+import type { ImportFinding } from '@zplab/core/lib/importReport';
 import type { LabelConfig } from '@zplab/core/types/LabelConfig';
 import type { Page } from '@zplab/core/types/Group';
 import type { ColumnMapping, Variable } from '@zplab/core/types/Variable';
@@ -21,6 +22,9 @@ export interface SourceShadow {
     columnMapping: ColumnMapping | null;
   } | null;
   refusal: SourceRefusalInfo | null;
+  /** Spanned import findings of the parse that produced `draft`; empty under
+   *  a refusal (their offsets would describe a text the doc rejected). */
+  findings: readonly ImportFinding[];
   /** The text `refusal` was parsed from; `doc` can be older (it keeps the
    *  last good parse). The debounced parse lags the live draft, so position
    *  consumers must check identity first. */
@@ -103,6 +107,7 @@ export const createSourceEditSlice: StateCreator<LabelState, [], [], SourceEditS
             sourceShadow: {
               doc: state.sourceShadow?.doc ?? null,
               refusal: refusal && refusalInfo(refusal),
+              findings: [],
               draft,
             },
           }


### PR DESCRIPTION
…pane

Findings ride the shadow parse; messages reuse the import report wording, so no new locale keys.