### PR TITLE
fix(batch): leave mapped ^FN slots bare in the stored format (#407)

### DIFF
--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -17,6 +17,7 @@ import { escapeGs1FdValue } from './gs1';
 import { fnConsumerBuckets } from './gs1ModeDFns';
 import { planCode128Fd } from './code128Plan';
 import { resolveControlMarkers } from '../types/controlKey';
+import { resolveContentPreview } from './markerResolve';
 import { formatLabelMetaComment } from './zplLabelMeta';
 import { designAsPageLabel, jmDensityOf } from '../types/LabelConfig';
 import type { ClockOffset, CustomFontMapping, JmDensity, LabelConfig, PageLabel } from '../types/LabelConfig';
@@ -25,7 +26,7 @@ import type { Variable } from '../types/Variable';
 import { exportableLeaves, isGroup, pageLabelConfig, type LabelObject, type LeafObject, type Page } from '../types/Group';
 import { isOverlayConsistent, MIN_JM_SPAN, type FormatHead, type JmSpan } from './zplOverlay/overlay';
 import { reconstructBlockHead } from './zplHeadScan';
-import { objectBoundsDots, type ObjectBoundsCtx } from './objectBounds';
+import { objectBoundsDots, qrPrintsAsGraphic, type ObjectBoundsCtx } from './objectBounds';
 import { formatFontDownloadFromPath } from './customFonts';
 import { imageEmitDims, imageEmitRotation, parseGfHeader, shippableGfa, type ImageProps } from '../registry/image';
 import { formatStoragePath } from './storagePath';
@@ -64,6 +65,7 @@ export function planTemplateHeader(
   shifted: LabelObject[],
   label: LabelConfig,
   variables: readonly Variable[],
+  bareFnSlots?: ReadonlySet<number>,
 ): { headerLines: string[]; emitCtx: ZplEmitContext } {
   // O(N+V) vs O(N*V) per-marker re-scan.
   const varsByName = new Map(variables.map((v) => [v.name, v]));
@@ -115,10 +117,13 @@ export function planTemplateHeader(
   const headerLines: string[] = [];
   const emitCtx: ZplEmitContext = { label, variables };
   if (plainSharedFns.size > 0) emitCtx.rawFdFns = plainSharedFns;
+  if (bareFnSlots && bareFnSlots.size > 0) emitCtx.bareFnSlots = bareFnSlots;
 
   if (pickedEmbedChar !== null) {
     for (const [fn, v] of [...templateVarsByFn].sort(([a], [b]) => a - b)) {
       if (singleBindFns.has(fn)) continue;
+      // Recall-supplied slots get no declaration (see bareFnSlots).
+      if (emitCtx.bareFnSlots?.has(fn)) continue;
       // Mode-D-exclusive slot: > needs its >0 invocation (parser reverses).
       // Plain-^BC-exclusive slot likewise: >/^/~ need their invocation
       // literals; the ^FH hex fdField would otherwise use is dropped from
@@ -619,19 +624,19 @@ export function generateBatchZpl(
   },
   columnMapping: { bindings: Record<string, string> },
 ): string {
-  const baseZpl = generateZPL(label, objects, variables);
-  // Inject after first ^XA (not at start) because ~DY/~SD preambles
-  // emit before ^XA and would skip a start-anchored match.
-  const templateStored = baseZpl.replace(
-    /\^XA\r?\n/,
-    `^XA\n^DF${BATCH_TEMPLATE_PATH}\n`,
-  );
-
   const identity = (s: string) => s;
-  // Excluded leaves aren't in the stored template, so don't source a transform
-  // from one (it could shadow an exported field sharing the same variable).
-  const leaves = exportableLeaves(objects);
-  const batchBuckets = fnConsumerBuckets(objects, variables);
+  // Only leaves that emit an ^FN in the stored template may donate their
+  // transform: an excluded or home-dropped leaf or a rotated QR shipped as
+  // ^GFA would stamp a foreign encoding onto the surviving co-consumer.
+  const shifted = shiftObjectsByHome(
+    objects, label.labelHomeX ?? 0, label.labelHomeY ?? 0, label.labelTop ?? 0, label,
+  );
+  const leaves = exportableLeaves(shifted).filter(
+    (o) => !(qrPrintsAsGraphic(o) && resolveContentPreview(getObjectStringContent(o) ?? '', variables)),
+  );
+  // Same shifted tree the template's own header pass classifies; the donor
+  // filter above is the narrower "emits an ^FN" question.
+  const batchBuckets = fnConsumerBuckets(shifted, variables);
   const modeDFns = batchBuckets.modeDExclusive;
   const plain128Fns = batchBuckets.plainExclusive;
   const plainSharedFns = batchBuckets.plainShared;
@@ -667,6 +672,17 @@ export function generateBatchZpl(
             : identity);
     overrides.push({ fn: v.fnNumber, colIdx, transform });
   }
+
+  // Mapped slots stay bare in the stored format; the recall supplies them.
+  const mappedFns = new Set(overrides.map((o) => o.fn));
+  const baseZpl = generateZplBlock(label, objects, variables, mappedFns).block;
+  // Inject after first ^XA (not at start) because ~DY/~SD preambles
+  // emit before ^XA and would skip a start-anchored match. No ^FS after the
+  // name: it would precede ^JM and disable the density (p.269).
+  const templateStored = baseZpl.replace(
+    /\^XA\r?\n/,
+    `^XA\n^DF${BATCH_TEMPLATE_PATH}\n`,
+  );
 
   const recallBlocks = dataset.rows.map((row) => {
     const lines: string[] = ['^XA', `^XF${BATCH_TEMPLATE_PATH}`];
@@ -742,13 +758,14 @@ export function planFieldEmission(
   label: PageLabel,
   objects: LabelObject[],
   variables: readonly Variable[] = [],
+  bareFnSlots?: ReadonlySet<number>,
 ): { headerLines: string[]; bodies: EmittedBody[] } {
   const homeX = label.labelHomeX ?? 0;
   const homeY = label.labelHomeY ?? 0;
   const top = label.labelTop ?? 0;
   const shifted = shiftObjectsByHome(objects, homeX, homeY, top, label);
 
-  const { headerLines, emitCtx } = planTemplateHeader(shifted, label, variables);
+  const { headerLines, emitCtx } = planTemplateHeader(shifted, label, variables, bareFnSlots);
 
   // Groups are structural; includeInExport=false cascades to the subtree.
   // Byte-identical round-trip lives in the overlay path (emitOverlayPage); this
@@ -792,6 +809,7 @@ function generateZplBlock(
   label: PageLabel,
   objects: LabelObject[],
   variables: readonly Variable[] = [],
+  bareFnSlots?: ReadonlySet<number>,
 ): PageBlock {
   // ^PW/^LL are consumed in physical head dots (ZD230-verified), even under
   // ^JMB: the body's object dots emit in the effective (halved) scale, but the
@@ -949,7 +967,7 @@ function generateZplBlock(
     lines.push(`^CF${slots.join(",")}`);
   }
 
-  const { headerLines, bodies } = planFieldEmission(label, objects, variables);
+  const { headerLines, bodies } = planFieldEmission(label, objects, variables, bareFnSlots);
   lines.push(...headerLines);
   const bodyIdByLine = new Map<number, string>();
   for (const b of bodies) {

--- a/packages/core/src/lib/zplParser/flushField.ts
+++ b/packages/core/src/lib/zplParser/flushField.ts
@@ -203,6 +203,12 @@ export function createFlushField(
   };
 
   const flushField = () => {
+    // A positioned `^FN<n>^FS` without ^FD is a stored-format placeholder
+    // (the batch template shape); adopt an empty ^FD so the bound field
+    // imports instead of dropping.
+    if (s.field.fieldType && s.field.pendingFD === null && s.comment.fnNumber !== null) {
+      s.field.pendingFD = "";
+    }
     if (!s.field.fieldType || s.field.pendingFD === null) {
       // Bare `^FN<n>^FD<default>^FS`: Variable declaration, not a field.
       if (s.comment.fnNumber !== null && s.field.pendingFD !== null) {

--- a/packages/core/src/registry/zplHelpers.ts
+++ b/packages/core/src/registry/zplHelpers.ts
@@ -292,6 +292,7 @@ export function fdFieldFor(
     const cls = classifyField(content, ctx.variables);
     if (cls.kind === "single") {
       const v = cls.variable;
+      if (ctx.bareFnSlots?.has(v.fnNumber)) return `^FN${v.fnNumber}^FS`;
       return `^FN${v.fnNumber}${fdField(transform(encodeDefault(v.defaultValue)))}`;
     }
   }

--- a/packages/core/src/types/ZplEmit.ts
+++ b/packages/core/src/types/ZplEmit.ts
@@ -34,6 +34,10 @@ export interface ZplEmitContext {
   /** ^FN slots a plain ^BC single-bind must emit RAW (chip-resolved only):
    *  the slot is shared, so the Code 128 escape would corrupt co-consumers. */
   rawFdFns?: ReadonlySet<number>;
+  /** ^FN slots a ^XF recall supplies: the stored format must carry no ^FD
+   *  for them or the template data wins, for placed fields and ^FE embeds
+   *  alike (ZD230-measured, #407; Labelary cannot referee the embed case). */
+  bareFnSlots?: ReadonlySet<number>;
 }
 
 /** The prop slice HRI formatters may read; every leaf props bag satisfies it. */

--- a/scratch-labelary/compare2.mjs
+++ b/scratch-labelary/compare2.mjs
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import zlib from 'node:zlib';
+
+const dir = import.meta.dirname;
+const png = (n) => decodePng(join(dir, n));
+
+function decodePng(path) {
+  const buf = readFileSync(path);
+  let off = 8;
+  const chunks = [];
+  while (off < buf.length) {
+    const len = buf.readUInt32BE(off);
+    const type = buf.toString('ascii', off + 4, off + 8);
+    chunks.push({ type, data: buf.subarray(off + 8, off + 8 + len) });
+    off += 12 + len;
+  }
+  const ihdr = chunks.find((c) => c.type === 'IHDR').data;
+  const width = ihdr.readUInt32BE(0);
+  const height = ihdr.readUInt32BE(4);
+  const colorType = ihdr[9];
+  const idat = Buffer.concat(chunks.filter((c) => c.type === 'IDAT').map((c) => c.data));
+  const raw = zlib.inflateSync(idat);
+  const bpp = colorType === 6 ? 4 : colorType === 2 ? 3 : 1;
+  const stride = width * bpp;
+  const out = Buffer.alloc(stride * height);
+  let prev = Buffer.alloc(stride);
+  for (let y = 0; y < height; y++) {
+    const filter = raw[y * (stride + 1)];
+    const line = raw.subarray(y * (stride + 1) + 1, (y + 1) * (stride + 1));
+    const cur = out.subarray(y * stride, (y + 1) * stride);
+    for (let x = 0; x < stride; x++) {
+      const a = x >= bpp ? cur[x - bpp] : 0;
+      const b = prev[x];
+      const c = x >= bpp ? prev[x - bpp] : 0;
+      let v = line[x];
+      if (filter === 1) v = (v + a) & 0xff;
+      else if (filter === 2) v = (v + b) & 0xff;
+      else if (filter === 3) v = (v + ((a + b) >> 1)) & 0xff;
+      else if (filter === 4) {
+        const p = a + b - c;
+        const pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c);
+        const pr = pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+        v = (v + pr) & 0xff;
+      }
+      cur[x] = v;
+    }
+    prev = cur;
+  }
+  return { width, height, bpp, pixels: out };
+}
+
+function diffPng(a, b, labelA, labelB) {
+  if (a.width !== b.width || a.height !== b.height) {
+    console.log(`${labelA} vs ${labelB}: DIFFERENT DIMENSIONS ${a.width}x${a.height} vs ${b.width}x${b.height}`);
+    return null;
+  }
+  let diff = 0;
+  let minX = a.width, maxX = 0, minY = a.height, maxY = 0;
+  for (let y = 0; y < a.height; y++) {
+    for (let x = 0; x < a.width; x++) {
+      const i = (y * a.width + x) * (a.bpp || 1);
+      if (a.pixels[i] !== b.pixels[i]) {
+        diff++;
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+    }
+  }
+  const total = a.pixels.length;
+  const pct = (100 * diff / total).toFixed(3);
+  console.log(`${labelA} vs ${labelB}: ${diff} px of ${total} (${pct}%) bbox x[${minX}..${maxX}] y[${minY}..${maxY}]`);
+  return diff;
+}
+
+const t1 = png('t1_bare.png');
+const t2 = png('t2_sealed.png');
+const t6 = png('t6_embed.png');
+const t7 = png('t7_qr.png');
+const ctrl_sku = png('ctrl_sku.png');
+const ctrl_def = png('ctrl_default.png');
+const ctrl_embed = png('ctrl_embed.png');
+const ctrl_qr = png('ctrl_qr.png');
+
+console.log('--- bare slot + recall vs flat render (the fix) ---');
+diffPng(t1, ctrl_sku, 't1 bare+recall', 'ctrl SKU-42');
+console.log('--- sealed default + recall: which text prints? ---');
+const d1 = diffPng(t2, ctrl_def, 't2 sealed+recall', 'ctrl DEFAULT');
+const d2 = diffPng(t2, ctrl_sku, 't2 sealed+recall', 'ctrl SKU-42');
+console.log('   => recall overrides sealed default on Labelary:', d2 === 0, '| keeps default:', d1 === 0);
+console.log('--- embed case ---');
+diffPng(t6, ctrl_embed, 't6 embed+recall', 'ctrl PRESKU-42POST');
+console.log('--- QR case ---');
+diffPng(t7, ctrl_qr, 't7 qr+recall', 'ctrl QR MA,A1');
+console.log('--- baseline: DEFAULT vs SKU-42 flat renders ---');
+diffPng(ctrl_def, ctrl_sku, 'ctrl DEFAULT', 'ctrl SKU-42');

--- a/scratch-labelary/compare3.mjs
+++ b/scratch-labelary/compare3.mjs
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import zlib from 'node:zlib';
+
+const dir = import.meta.dirname;
+function decodePng(name) {
+  const buf = readFileSync(join(dir, name));
+  let off = 8;
+  const chunks = [];
+  while (off < buf.length) {
+    const len = buf.readUInt32BE(off);
+    const type = buf.toString('ascii', off + 4, off + 8);
+    chunks.push({ type, data: buf.subarray(off + 8, off + 8 + len) });
+    off += 12 + len;
+  }
+  const ihdr = chunks.find((c) => c.type === 'IHDR').data;
+  const width = ihdr.readUInt32BE(0);
+  const height = ihdr.readUInt32BE(4);
+  const colorType = ihdr[9];
+  const idat = Buffer.concat(chunks.filter((c) => c.type === 'IDAT').map((c) => c.data));
+  const raw = zlib.inflateSync(idat);
+  const bpp = colorType === 6 ? 4 : colorType === 2 ? 3 : 1;
+  const stride = width * bpp;
+  const out = Buffer.alloc(stride * height);
+  let prev = Buffer.alloc(stride);
+  for (let y = 0; y < height; y++) {
+    const filter = raw[y * (stride + 1)];
+    const line = raw.subarray(y * (stride + 1) + 1, (y + 1) * (stride + 1));
+    const cur = out.subarray(y * stride, (y + 1) * stride);
+    for (let x = 0; x < stride; x++) {
+      const a = x >= bpp ? cur[x - bpp] : 0;
+      const b = prev[x];
+      const c = x >= bpp ? prev[x - bpp] : 0;
+      let v = line[x];
+      if (filter === 1) v = (v + a) & 0xff;
+      else if (filter === 2) v = (v + b) & 0xff;
+      else if (filter === 3) v = (v + ((a + b) >> 1)) & 0xff;
+      else if (filter === 4) {
+        const p = a + b - c;
+        const pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - c);
+        const pr = pa <= pb && pa <= pc ? a : pb <= pc ? b : c;
+        v = (v + pr) & 0xff;
+      }
+      cur[x] = v;
+    }
+    prev = cur;
+  }
+  return { width, height, bpp, pixels: out };
+}
+
+function diffPng(a, b, labelA, labelB) {
+  if (a.width !== b.width || a.height !== b.height) {
+    console.log(`${labelA} vs ${labelB}: DIFFERENT DIMENSIONS`);
+    return;
+  }
+  let diff = 0;
+  let minX = a.width, maxX = 0, minY = a.height, maxY = 0;
+  for (let y = 0; y < a.height; y++) {
+    for (let x = 0; x < a.width; x++) {
+      const i = (y * a.width + x) * (a.bpp || 1);
+      if (a.pixels[i] !== b.pixels[i]) {
+        diff++;
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+    }
+  }
+  console.log(`${labelA} vs ${labelB}: ${diff} px bbox x[${minX}..${maxX}] y[${minY}..${maxY}]`);
+}
+
+const p = (n) => decodePng(n);
+const t6 = p('t6_embed.png');
+const e1 = p('e1_flat_embed_default.png');
+const e2 = p('e2_stored_embed_recall.png');
+const e4 = p('e4_flat_unresolved.png');
+const e5 = p('e5_ctrl_predefaultpost.png');
+const ctrl_sku_embed = p('ctrl_embed.png');
+
+console.log('--- flat ^FE embed + header default vs flat PREDEFAULTPOST ---');
+diffPng(e1, e5, 'e1 flat embed+default', 'ctrl PREDEFAULTPOST');
+console.log('--- stored embed (header default) + recall SKU-42 vs flat PREDEFAULTPOST ---');
+diffPng(e2, e5, 'e2 stored+recall', 'ctrl PREDEFAULTPOST');
+console.log('--- stored embed (header default) + recall SKU-42 vs flat PRESKU-42POST ---');
+diffPng(e2, ctrl_sku_embed, 'e2 stored+recall', 'ctrl PRESKU-42POST');
+console.log('--- stored embed (header default) + recall vs flat embed + default ---');
+diffPng(e2, e1, 'e2 stored+recall', 'e1 flat embed+default');
+console.log('--- t6 (bare embed) + recall vs unresolved flat embed ---');
+diffPng(t6, e4, 't6 bare+recall', 'e4 unresolved');
+console.log('--- t6 (bare embed) + recall vs PRESKU-42POST ---');
+diffPng(t6, ctrl_sku_embed, 't6 bare+recall', 'ctrl PRESKU-42POST');

--- a/scratch-labelary/t4_template_only.png
+++ b/scratch-labelary/t4_template_only.png
@@ -1,0 +1,1 @@
+ERROR: Requested 1st label but ZPL generated no labels

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -1732,6 +1732,9 @@ describe('generateZPL — variable bindings', () => {
 
 describe('generateBatchZpl', () => {
   const baseLabel = { widthMm: 50, heightMm: 30, dpmm: 8 } as PageLabel;
+  // Path-anchored: a bare '^XF' prefix match could truncate the template
+  // slice and let the negative ^FD assertions pass vacuously.
+  const batchTemplateOf = (result: string) => result.split('^XFR:LBL.ZPL')[0] ?? '';
   // Single-bind field: content is the variable's lone marker.
   const textObj = (markerName: string): LabelObject =>
     ({
@@ -1764,6 +1767,111 @@ describe('generateBatchZpl', () => {
     expect(result).toContain('^FN1^FDA1^FS');
     expect(result).toContain('^FN1^FDB2^FS');
     expect(result).toContain('^FN1^FDC3^FS');
+  });
+
+  it('leaves a mapped slot bare in the stored format (a template ^FD seals it)', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const result = generateBatchZpl(baseLabel, [textObj('sku')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(template).toContain('^FN1^FS');
+    expect(template).not.toContain('^FN1^FD');
+    expect(result).toContain('^FN1^FDA1^FS');
+  });
+
+  it('keeps the ^FD default for unmapped variables in both binding shapes', () => {
+    const variables = [
+      { id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' },
+      { id: 'v2', name: 'lot', fnNumber: 2, defaultValue: 'FALLBACK' },
+      { id: 'v3', name: 'bin', fnNumber: 3, defaultValue: 'LONE' },
+    ];
+    // 'lot' is template-embedded (header-declaration branch), 'bin' is a
+    // single-bind (inline fdFieldFor branch); the bare-slot skip must take
+    // neither, and must key on the slot, not on the set existing.
+    const embed = {
+      id: 'e', type: 'text', x: 10, y: 30, rotation: 0,
+      props: { content: 'LOT:«lot»', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [textObj('sku'), embed, textObj('bin')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(template).toContain('^FN2^FDFALLBACK^FS');
+    expect(template).toContain('^FN3^FDLONE^FS');
+  });
+
+  it('keeps ^JM alive: no ^FS may precede it in the stored template', () => {
+    // ^JM only counts before the first ^FS (spec p.269); a terminator on the
+    // ^DF line would disable the density for every batch export.
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const result = generateBatchZpl({ ...baseLabel, jmDensity: 'B' } as PageLabel,
+      [textObj('sku')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(parseZPL(template, 8).labelConfig.jmDensity).toBe('B');
+  });
+
+  it('imports its own batch template without dropping the bare bound fields', () => {
+    // Roundtrip guarantee: the template is a .zpl the user can re-open.
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const result = generateBatchZpl(baseLabel, [textObj('sku')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    const page = parseZPL(template, 8).pages[0];
+    expect(page?.objects).toHaveLength(1);
+    expect(page?.variables.map((v) => v.fnNumber)).toEqual([1]);
+  });
+
+  it('does not source a recall transform from a home-dropped leaf', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const qr = { id: 'q', type: 'qrcode', x: 5, y: 10, rotation: 0,
+      props: { content: '«sku»', magnification: 3, errorCorrection: 'M', model: 2, rotation: 'N' },
+    } as unknown as LabelObject;
+    const survivor = { ...(textObj('sku') as object), x: 40 } as LabelObject;
+    const result = generateBatchZpl({ ...baseLabel, labelHomeX: 20 } as PageLabel,
+      [qr, survivor], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const recall = result.split('^XFR:LBL.ZPL').slice(1).join('');
+    expect(recall).toContain('^FN1^FDA1^FS');
+    expect(recall).not.toContain('MA,');
+  });
+
+  it('does not source a recall transform from a QR that ships as ^GFA', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const rotQr = { id: 'q', type: 'qrcode', x: 10, y: 10, rotation: 0,
+      props: { content: '«sku»', magnification: 3, errorCorrection: 'M', model: 2, rotation: 'R' },
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [rotQr, textObj('sku')], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const recall = result.split('^XFR:LBL.ZPL').slice(1).join('');
+    expect(recall).toContain('^FN1^FDA1^FS');
+    expect(recall).not.toContain('MA,');
+  });
+
+  it('omits the header declaration of a mapped template-embedded slot', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const embed = {
+      id: 'e', type: 'text', x: 10, y: 10, rotation: 0,
+      props: { content: 'PRE«sku»POST', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [embed], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(template).toContain('^FDPRE#1#POST');
+    expect(template).not.toContain('^FN1^FD');
+    expect(result).toContain('^FN1^FDA1^FS');
+  });
+
+  it('keeps a mapped QR bare in the template while its recall carries the switches', () => {
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'DEF' }];
+    const qr = { id: 'q', type: 'qrcode', x: 0, y: 0, rotation: 0,
+      props: { content: '«sku»', magnification: 3, errorCorrection: 'M', model: 2, rotation: 'N' },
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [qr], variables,
+      { headers: ['sku'], rows: [['A1']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(template).toContain('^FN1^FS');
+    expect(template).not.toContain('^FN1^FD');
+    expect(result).toContain('^FN1^FDMA,A1^FS');
   });
 
   it('does not source a row transform from a leaf inside an excluded group', () => {
@@ -2085,6 +2193,23 @@ describe('generateBatchZpl', () => {
     const recall = result.split('^XFR:LBL.ZPL').slice(1).join('');
     expect(recall).toContain('^FN1^FD>9337334^FS');
     expect(recall).not.toContain('^FH_');
+  });
+
+  it('keeps a mapped shared slot bare in the template and raw in the recall', () => {
+    // rawFdFns and bareFnSlots meet here: bare template, sharedRaw recall.
+    const variables = [{ id: 'v1', name: 'sku', fnNumber: 1, defaultValue: 'X' }];
+    const textLeaf = {
+      id: 't1', type: 'text', x: 0, y: 0, rotation: 0,
+      props: { content: 'A«sku»B', fontHeight: 30, fontWidth: 0, rotation: 'N' },
+    } as unknown as LabelObject;
+    const result = generateBatchZpl(baseLabel, [...code128Chip('«sku»'), textLeaf], variables,
+      { headers: ['sku'], rows: [['X>Y']] }, { bindings: { v1: 'sku' } });
+    const template = batchTemplateOf(result);
+    expect(template).toContain('^FN1^FS');
+    expect(template).not.toContain('^FN1^FD');
+    const recall = result.split('^XFR:LBL.ZPL').slice(1).join('');
+    expect(recall).toContain('^FN1^FDX>Y^FS');
+    expect(recall).not.toContain('>0Y');
   });
 
   it('emits a GS1 field as mode-D data even when a legacy model carries serial', () => {

--- a/src/store/labelStore.selectors.ts
+++ b/src/store/labelStore.selectors.ts
@@ -1,5 +1,6 @@
 import type { ImportFinding } from '@zplab/core/lib/importReport';
 import { pageLabelConfig, type LabelObject } from '@zplab/core/types/Group';
+import { boundColumnIndex } from '@zplab/core/lib/variableBinding';
 import { isDefaultHost, resolveHost, resolveApiKey } from '../lib/labelary';
 import { isDesktopShell } from '../lib/platform';
 import type { Dataset } from './slices/dataSlice';
@@ -164,11 +165,9 @@ export const selectBatchInputs = (
   const { dataset, columnMapping } = s;
   if (!dataset || dataset.rows.length === 0) return null;
   if (!columnMapping) return null;
-  const headers = new Set(dataset.headers);
-  const hasLiveBinding = s.variables.some((v) => {
-    const header = columnMapping.bindings[v.id];
-    return header !== undefined && headers.has(header);
-  });
+  const hasLiveBinding = s.variables.some(
+    (v) => boundColumnIndex(v, dataset, columnMapping) !== -1,
+  );
   if (!hasLiveBinding) return null;
   return { dataset: dataset, mapping: columnMapping };
 };


### PR DESCRIPTION
A template ^FD seals the slot: the firmware prints the template data and ignores the recall value (ZD230-measured, both binding shapes). The parser now imports the bare template shape instead of dropping it.