### PR TITLE
fix(source-edit): carry editor state across an apply by line diff

### DIFF
--- a/packages/core/src/lib/blockDiff.test.ts
+++ b/packages/core/src/lib/blockDiff.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { diffBlocks } from "./blockDiff";
+import type { SourceSpan } from "./zplParser/types";
+
+const NL = String.fromCharCode(10);
+const doc = (...blocks: string[][]): { text: string; blocks: SourceSpan[] } => {
+  let text = "";
+  const spans: SourceSpan[] = [];
+  for (const lines of blocks) {
+    const start = text.length;
+    text += ["^XA", ...lines, "^XZ"].join(NL) + NL;
+    spans.push({ start, end: text.length });
+  }
+  return { text, blocks: spans };
+};
+const f = (...lines: string[]) => lines.map((l) => `^FO1^FD${l}^FS`);
+const pairsOf = (x: { text: string; blocks: SourceSpan[] }, y: { text: string; blocks: SourceSpan[] }) => [...diffBlocks(x.text, x.blocks, y.text, y.blocks).pairs];
+
+describe("diffBlocks", () => {
+  it("keeps equal pages in place when one of them is edited", () => {
+    expect(pairsOf(doc(f("A", "B"), f("A", "B")), doc(f("A", "Z"), f("A", "B")))).toEqual([[0, 0], [1, 1]]);
+    expect(pairsOf(doc(f("A", "B"), f("A", "B"), f("A", "B")), doc(f("A", "B"), f("A", "Z"), f("A", "B")))).toEqual([[0, 0], [1, 1], [2, 2]]);
+    // Ambiguous by content (page 2 equals the new page 1, page 1 shares a line with each): staying wins.
+    expect(pairsOf(doc(f("A", "B", "C"), f("A", "B")), doc(f("A", "B"), f("A", "C")))).toEqual([[0, 0], [1, 1]]);
+  });
+
+  it("follows a page that moved, by its unique lines, even around a rewritten one", () => {
+    expect(pairsOf(doc(f("a", "h"), f("z1", "z2")), doc(f("z1", "z2"), f("a", "h")))).toEqual([[0, 1], [1, 0]]);
+    expect(pairsOf(doc(f("p1", "p2"), f("m1", "m2"), f("q1", "q2")), doc(f("q1", "q2"), f("n1", "n2"), f("p1", "p2")))).toEqual([[0, 2], [1, 1], [2, 0]]);
+  });
+
+  it("matches a line repeated on every page inside its own block", () => {
+    const x = doc(f("A", "B", "C"), f("A", "B", "D"));
+    const y = doc(f("A", "B"), f("A", "B", "E"));
+    const d = diffBlocks(x.text, x.blocks, y.text, y.blocks);
+    const bOf = (block: number, line: string) => y.text.indexOf(`^FD${line}^FS`, y.blocks[block]?.start) - 4;
+    expect(d.mapOffset(x.text.indexOf("^FDB^FS") - 4)).toEqual({ offset: bOf(0, "B"), deleted: false });
+    expect(d.mapOffset(x.text.indexOf("^FDC^FS") - 4).deleted).toBe(true);
+    const secondA = x.text.indexOf("^FDA^FS", x.blocks[1]?.start) - 4;
+    expect(d.mapOffset(secondA)).toEqual({ offset: bOf(1, "A"), deleted: false });
+    expect(d.rangeMatched(secondA, secondA + 9)).toBe(true);
+  });
+
+  it("pairs by distinctive lines, not by the header every block shares", () => {
+    const x = doc(f("H", "A"), f("H", "B"));
+    const y = doc(f("H", "B"), f("H", "A"));
+    expect(pairsOf(x, y)).toEqual([[0, 1], [1, 0]]);
+  });
+
+  it("weighs a unique line over one shared by most pages", () => {
+    const x = doc(f("ANCHOR0", "COMMON"), f("ANCHOR1", "COMMON"), f("ANCHOR2", "COMMON"));
+    const y = doc(f("ANCHOR2", "COMMON"), f("ANCHOR0", "COMMONX", "H0"), f("ANCHOR1", "COMMON"));
+    expect(pairsOf(x, y)).toEqual([[0, 1], [1, 2], [2, 0]]);
+  });
+
+  it("rescues a page moved farther than the band by its unique lines", () => {
+    const pages = Array.from({ length: 12 }, (_, i) => f(`p${i}a`, `p${i}b`));
+    const moved = [...pages.slice(1), pages[0]!];
+    const pairs = pairsOf(doc(...pages), doc(...moved));
+    expect(pairs[0]).toEqual([0, 11]);
+    expect(pairs.slice(1)).toEqual(pages.slice(1).map((_, k) => [k + 1, k]));
+  });
+
+  it("ignores what trails the last ^XZ and follows equal text backwards", () => {
+    const x = doc(f("S"), f("S", "T"), f("S"));
+    const y = doc(f("S"), f("S"), f("S"));
+    expect(pairsOf(x, { text: y.text + NL + "^FXpad^FS", blocks: [...y.blocks.slice(0, 2), { start: y.blocks[2]!.start, end: y.text.length + 9 }] })).toEqual([[0, 0], [1, 1], [2, 2]]);
+    expect(pairsOf(doc(f("a", "b"), []), doc([], f("a", "b")))).toEqual([[0, 1], [1, 0]]);
+  });
+
+  it("skips an inserted page and drops a deleted one", () => {
+    expect(pairsOf(doc(f("a"), [], f("z")), doc(f("a"), f("n"), [], f("z")))).toEqual([[0, 0], [1, 2], [2, 3]]);
+    expect(pairsOf(doc(f("a"), [], f("z")), doc(f("a"), [], f("z"), f("t")))).toEqual([[0, 0], [1, 1], [2, 2]]);
+    const x = doc(f("a"), f("b"));
+    const y = doc(f("a"));
+    const d = diffBlocks(x.text, x.blocks, y.text + NL + NL, y.blocks);
+    expect(d.pairs.has(1)).toBe(false);
+    expect(d.mapOffset(x.blocks[1]!.start).deleted).toBe(true);
+    expect(d.rangeMatched(x.text.indexOf("^FDb^FS"), x.text.indexOf("^FDb^FS") + 9)).toBe(false);
+  });
+});

--- a/packages/core/src/lib/blockDiff.ts
+++ b/packages/core/src/lib/blockDiff.ts
@@ -1,0 +1,206 @@
+// Correspondence between two texts made of blocks: blocks pair first, lines only
+// within a pair, so a line repeated on every page still identifies itself inside its own.
+
+import { diffLines, indexAtOrBefore, mapOffset as mapLineOffset, rangeMatched as linesMatched, splitLines, type LineDiff, type MappedOffset } from "./lineDiff";
+import type { SourceSpan } from "./zplParser/types";
+
+const NL = "\n";
+
+export interface BlockDiff {
+  /** a block index -> b block index. */
+  pairs: ReadonlyMap<number, number>;
+  mapOffset(offset: number): MappedOffset;
+  rangeMatched(start: number, end: number): boolean;
+}
+
+/** A page keeps its place up to the document's growth plus a few reorder steps; farther moves are the rescue pass's. */
+const MOVE_BAND = 8;
+
+function blockOf(starts: readonly number[], blocks: readonly SourceSpan[], offset: number): number {
+  const i = indexAtOrBefore(starts, offset);
+  const block = blocks[i];
+  return block && offset < block.end ? i : -1;
+}
+
+/** A block's lines up to its closing ^XZ, trailing whitespace off: the parser folds
+ *  the separator after ^XZ into the block, the generator does not. */
+function linesOf(text: string, span: SourceSpan): string[] {
+  const lines = splitLines(text.slice(span.start, span.end)).lines.map((l) => l.trimEnd());
+  const close = lines.findLastIndex((l) => l.includes("^XZ"));
+  const last = lines[close];
+  if (last !== undefined) {
+    lines.length = close + 1;
+    lines[close] = last.slice(0, last.lastIndexOf("^XZ") + 3);
+  }
+  while (lines.at(-1) === "") lines.pop();
+  return lines;
+}
+
+/** A line's evidence for block identity: 1 when one block carries it, fading with
+ *  every further block, 0 when all do (the shared format head says nothing).
+ *  Counted once per block, spent once per line. */
+function lineWeights(blocks: readonly (readonly string[])[]): Map<string, number> {
+  const holders = new Map<string, number>();
+  for (const lines of blocks) for (const l of new Set(lines)) holders.set(l, (holders.get(l) ?? 0) + 1);
+  return new Map([...holders].map(([l, n]) => [l, n === blocks.length ? 0 : 1 / n]));
+}
+
+/** Weighted share of the lighter block's lines found in the other (multiset), so a page
+ *  that gained or lost fields still reads as itself; 0 when either weighs nothing. */
+function similarity(x: readonly string[], y: readonly string[], weight: ReadonlyMap<string, number>): number {
+  const count = new Map<string, number>();
+  let wx = 0;
+  for (const l of x) {
+    count.set(l, (count.get(l) ?? 0) + 1);
+    wx += weight.get(l) ?? 0;
+  }
+  let shared = 0;
+  let wy = 0;
+  for (const l of y) {
+    const w = weight.get(l) ?? 0;
+    wy += w;
+    const left = count.get(l) ?? 0;
+    if (left > 0) {
+      shared += w;
+      count.set(l, left - 1);
+    }
+  }
+  return wx === 0 || wy === 0 ? 0 : shared / Math.min(wx, wy);
+}
+
+/** Order-preserving alignment of maximal total similarity; the diagonal wins ties, so
+ *  an equal page stays in place. Only blocks within `band` positions of each other may pair. */
+function align(sim: (i: number, j: number) => number, n: number, m: number, band: number): Map<number, number> {
+  const total = new Float64Array((n + 1) * (m + 1));
+  const at = (i: number, j: number) => i * (m + 1) + j;
+  const pairable = (i: number, j: number) => (Math.abs(i - j) <= band ? sim(i - 1, j - 1) : 0);
+  // 0 = diagonal, 1 = up (a block skipped), 2 = left (b block skipped).
+  const choice = (i: number, j: number): 0 | 1 | 2 => {
+    const diag = (total[at(i - 1, j - 1)] ?? 0) + pairable(i, j);
+    const up = total[at(i - 1, j)] ?? 0;
+    const left = total[at(i, j - 1)] ?? 0;
+    if (up > diag && up >= left) return 1;
+    return left > diag ? 2 : 0;
+  };
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const move = choice(i, j);
+      total[at(i, j)] = move === 0 ? (total[at(i - 1, j - 1)] ?? 0) + pairable(i, j) : move === 1 ? (total[at(i - 1, j)] ?? 0) : (total[at(i, j - 1)] ?? 0);
+    }
+  }
+  const pairs = new Map<number, number>();
+  for (let i = n, j = m; i > 0 && j > 0; ) {
+    const move = choice(i, j);
+    if (move === 0) {
+      if (pairable(i, j) > 0) pairs.set(i - 1, j - 1);
+      i--;
+      j--;
+    } else if (move === 1) i--;
+    else j--;
+  }
+  return pairs;
+}
+
+/** Blocks align in order by weighted lines; a leftover follows its unique lines or equal
+ *  text to a free block (a moved page), and one with no evidence takes the gap its
+ *  neighbours leave. A reprint equalling another page's text can still displace it. */
+function pairBlocks(a: string, aBlocks: readonly SourceSpan[], aStarts: readonly number[], b: string, bBlocks: readonly SourceSpan[]): Map<number, number> {
+  const aLines = aBlocks.map((s) => linesOf(a, s));
+  const bLines = bBlocks.map((s) => linesOf(b, s));
+  const aText = aLines.map((l) => l.join(NL));
+  const bText = bLines.map((l) => l.join(NL));
+  const same = (i: number, j: number) => aText[i] === bText[j];
+  const weight = lineWeights([...aLines, ...bLines]);
+  const weightless = (lines: readonly string[]) => lines.every((l) => (weight.get(l) ?? 0) === 0);
+  const memo = new Map<number, number>();
+  // Blocks made of shared lines only (an empty page) are the same block when their text is.
+  const sim = (i: number, j: number): number => {
+    const key = i * bBlocks.length + j;
+    let s = memo.get(key);
+    if (s === undefined) {
+      const x = aLines[i] ?? [];
+      const y = bLines[j] ?? [];
+      s = weightless(x) && weightless(y) ? Number(same(i, j)) : similarity(x, y, weight);
+      memo.set(key, s);
+    }
+    return s;
+  };
+  const pairs = align(sim, aBlocks.length, bBlocks.length, Math.abs(aBlocks.length - bBlocks.length) + MOVE_BAND);
+  const taken = new Set(pairs.values());
+  const global = diffLines(a, b);
+  const bStarts = bBlocks.map((s) => s.start);
+  const linked: { i: number; j: number }[] = [];
+  for (const [la, lb] of global.aToB) {
+    const i = blockOf(aStarts, aBlocks, global.aStarts[la] ?? -1);
+    const j = blockOf(bStarts, bBlocks, global.bStarts[lb] ?? -1);
+    if (i >= 0 && j >= 0 && !pairs.has(i) && !taken.has(j)) linked.push({ i, j });
+  }
+  linked.sort((x, y) => sim(y.i, y.j) - sim(x.i, x.j) || x.i - y.i || x.j - y.j);
+  for (const { i, j } of linked) {
+    if (pairs.has(i) || taken.has(j)) continue;
+    pairs.set(i, j);
+    taken.add(j);
+  }
+  aBlocks.forEach((_, i) => {
+    if (pairs.has(i)) return;
+    const twin = bBlocks.findIndex((_, j) => !taken.has(j) && same(i, j));
+    if (twin >= 0) {
+      pairs.set(i, twin);
+      taken.add(twin);
+    }
+  });
+  aBlocks.forEach((_, i) => {
+    if (pairs.has(i)) return;
+    const partner = (k: number) => pairs.get(k);
+    let lo = -1;
+    let hi = bBlocks.length;
+    for (let k = i - 1; k >= 0 && lo < 0; k--) lo = partner(k) ?? -1;
+    for (let k = i + 1; k < aBlocks.length && hi === bBlocks.length; k++) hi = partner(k) ?? bBlocks.length;
+    // The rescue pass can cross pairs and leave no ordered gap; then any free block will do.
+    const inGap = (j: number) => lo >= hi || (lo < j && j < hi);
+    for (let j = 0; j < bBlocks.length; j++) {
+      if (taken.has(j) || !inGap(j)) continue;
+      pairs.set(i, j);
+      taken.add(j);
+      break;
+    }
+  });
+  return new Map([...pairs].sort((x, y) => x[0] - y[0]));
+}
+
+/** Blocks must ascend and not overlap on either side. */
+export function diffBlocks(a: string, aBlocks: readonly SourceSpan[], b: string, bBlocks: readonly SourceSpan[]): BlockDiff {
+  const aStarts = aBlocks.map((s) => s.start);
+  const pairs = pairBlocks(a, aBlocks, aStarts, b, bBlocks);
+  const local = new Map<number, { aBlock: SourceSpan; bBlock: SourceSpan; diff: LineDiff }>();
+  for (const [i, j] of pairs) {
+    const aBlock = aBlocks[i];
+    const bBlock = bBlocks[j];
+    if (aBlock && bBlock) local.set(i, { aBlock, bBlock, diff: diffLines(a.slice(aBlock.start, aBlock.end), b.slice(bBlock.start, bBlock.end)) });
+  }
+  const gone = (i: number): MappedOffset => {
+    let next = bBlocks.length;
+    for (let k = i + 1; k < aBlocks.length; k++) {
+      const j = pairs.get(k);
+      if (j !== undefined) {
+        next = j;
+        break;
+      }
+    }
+    return { offset: bBlocks[next]?.start ?? b.length, deleted: true };
+  };
+  return {
+    pairs,
+    mapOffset(offset) {
+      const i = blockOf(aStarts, aBlocks, offset);
+      const pair = local.get(i);
+      if (!pair) return gone(i);
+      const at = mapLineOffset(pair.diff, offset - pair.aBlock.start);
+      return { offset: at.offset + pair.bBlock.start, deleted: at.deleted };
+    },
+    rangeMatched(start, end) {
+      const pair = local.get(blockOf(aStarts, aBlocks, start));
+      return pair !== undefined && linesMatched(pair.diff, start - pair.aBlock.start, end - pair.aBlock.start);
+    },
+  };
+}

--- a/packages/core/src/lib/editorStateDiff.ts
+++ b/packages/core/src/lib/editorStateDiff.ts
@@ -1,14 +1,14 @@
-import { isGroup, type Page } from "../types/Group";
-import type { Variable } from "../types/Variable";
+import { isGroup, type LabelObject, type Page } from "../types/Group";
+import { matchVariablesByFn, type Variable } from "../types/Variable";
 
-/** What a full-document reparse cannot carry over: ZPL has no wire form for
- *  any of these, so an apply loses them. */
+/** Editor state a full-document reparse loses: ZPL has no wire form for any of it.
+ *  What sourceApplyCarry brings back is not lost, so it never counts. */
 export interface EditorStateDiff {
   groupsDissolved: number;
   namesLost: number;
   lockedLost: number;
   hiddenLost: number;
-  /** Objects the export cascade drops (self or an ancestor excluded). */
+  /** Excluded nodes gone after the apply, subtree included. */
   excludedLost: number;
   /** Variables whose ^FN slot vanished from the stream entirely. */
   variablesLost: string[];
@@ -44,6 +44,17 @@ export interface EditorSnapshot {
   variables: readonly Variable[];
 }
 
+/** The editor-only state a reparse cannot express, as one patch: unset fields are
+ *  omitted so it never clobbers the parse; carrying a field is what keeps `count` from scoring it. */
+export function pickEditorState(o: LabelObject): Partial<LabelObject> {
+  return {
+    ...(o.includeInExport === false ? { includeInExport: false } : {}),
+    ...(o.name !== undefined ? { name: o.name } : {}),
+    ...(o.locked ? { locked: true } : {}),
+    ...(o.visible === false ? { visible: false } : {}),
+  };
+}
+
 /** `mappingLost` comes from the caller's one remapBindingsByFn run, so diff
  *  and committed mapping cannot disagree. */
 export function diffEditorState(
@@ -75,16 +86,11 @@ export function diffEditorState(
   const after = count(next.pages);
   const lostCount = (b: number, a: number) => Math.max(0, b - a);
 
-  const nextByFn = new Map(next.variables.map((v) => [v.fnNumber, v]));
-  const variablesLost: string[] = [];
-  const variablesRenamed: { from: string; to: string; fnNumber: number }[] = [];
-  for (const v of prev.variables) {
-    const kept = nextByFn.get(v.fnNumber);
-    if (!kept) variablesLost.push(v.name);
-    else if (kept.name !== v.name) {
-      variablesRenamed.push({ from: v.name, to: kept.name, fnNumber: v.fnNumber });
-    }
-  }
+  const { kept, dropped } = matchVariablesByFn(prev.variables, next.variables);
+  const variablesLost = dropped.map((v) => v.name);
+  const variablesRenamed = kept
+    .filter((p) => p.from.name !== p.to.name)
+    .map((p) => ({ from: p.from.name, to: p.to.name, fnNumber: p.from.fnNumber }));
 
   return {
     groupsDissolved: lostCount(before.groups, after.groups),

--- a/packages/core/src/lib/lineDiff.test.ts
+++ b/packages/core/src/lib/lineDiff.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { diffLines, mapOffset, rangeMatched } from "./lineDiff";
+
+const NL = String.fromCharCode(10);
+const j = (...lines: string[]) => lines.join(NL);
+
+describe("diffLines", () => {
+  it("anchors unique lines and grows over equal neighbours", () => {
+    const a = j("^XA", "^FO1^FDa^FS", "^FO2^FDb^FS", "^XZ");
+    const b = j("^XA", "^FO1^FDa^FS", "^FO9^FDnew^FS", "^FO2^FDb^FS", "^XZ");
+    const d = diffLines(a, b);
+    expect([...d.aToB.entries()].sort()).toEqual([[0, 0], [1, 1], [2, 3], [3, 4]]);
+  });
+
+  it("maps a changed line to the same place inside its block and a deleted one as deleted", () => {
+    const a = j("^XA", "^FO1^FDa^FS", "^FO2^FDb^FS", "^XZ");
+    const changed = j("^XA", "^FO1^FDa^FS", "^FO2^FDB^FS", "^XZ");
+    expect(mapOffset(diffLines(a, changed), a.indexOf("^FO2"))).toEqual({ offset: changed.indexOf("^FO2"), deleted: false });
+    const deleted = j("^XA", "^FO1^FDa^FS", "^XZ");
+    expect(mapOffset(diffLines(a, deleted), a.indexOf("^FO2")).deleted).toBe(true);
+    // Three lines became one: the first takes its place, the rest are gone.
+    const shrunk = diffLines(j("^XA", "^FO1^FDa^FS", "^FO2^FDb^FS", "^FO3^FDc^FS"), j("^XA", "^FO9^FDz^FS"));
+    expect(mapOffset(shrunk, a.indexOf("^FO1")).deleted).toBe(false);
+    expect(mapOffset(shrunk, a.indexOf("^FO2")).deleted).toBe(true);
+  });
+
+  it("ignores a CR, treats the text end as its own line and survives an empty b", () => {
+    const a = j("^XA", "^FO1^FDa^FS", "^XZ");
+    const crlf = a.replace(/\n/g, "\r\n");
+    expect([...diffLines(crlf, a).aToB.entries()].sort()).toEqual([[0, 0], [1, 1], [2, 2]]);
+    const trailing = diffLines(a + NL, a + NL);
+    expect(trailing.aStarts).toHaveLength(4);
+    expect(mapOffset(trailing, a.length + 1)).toEqual({ offset: a.length + 1, deleted: false });
+    expect(mapOffset(diffLines(a, ""), 0)).toEqual({ offset: 0, deleted: false });
+    expect(mapOffset(diffLines(a, ""), a.indexOf("^FO1")).deleted).toBe(true);
+  });
+
+  it("tells a fully surviving span from a touched one", () => {
+    const a = j("^XA", "^FO1^FDa^FS", "^FO2^FDb^FS", "^XZ");
+    const b = j("^XA", "^FO1^FDa^FS", "^FO2^FDB^FS", "^XZ");
+    const d = diffLines(a, b);
+    expect(rangeMatched(d, a.indexOf("^FO1"), a.indexOf("^FO2"))).toBe(true);
+    expect(rangeMatched(d, a.indexOf("^FO2"), a.indexOf("^XZ"))).toBe(false);
+  });
+});

--- a/packages/core/src/lib/lineDiff.ts
+++ b/packages/core/src/lib/lineDiff.ts
@@ -1,0 +1,117 @@
+// Line-level correspondence between two texts: a line unique on both sides is the same
+// line wherever it went. Enough for ZPL, whose fields are lines that almost always differ.
+
+export interface LineDiff {
+  aStarts: number[];
+  bStarts: number[];
+  /** a line index -> b line index for matched (identical) lines. */
+  aToB: Map<number, number>;
+}
+
+export interface MappedOffset {
+  offset: number;
+  /** The a position fell into text b no longer has (a pure deletion). */
+  deleted: boolean;
+}
+
+/** Lines compare without their CR: an editor may hand back an LF-normalised buffer. */
+export function splitLines(text: string): { lines: string[]; starts: number[] } {
+  const lines: string[] = [];
+  const starts: number[] = [];
+  let at = 0;
+  while (at <= text.length) {
+    const nl = text.indexOf("\n", at);
+    const end = nl === -1 ? text.length : nl;
+    starts.push(at);
+    lines.push(text.slice(at, end).replace(/\r$/, ""));
+    if (nl === -1) break;
+    at = nl + 1;
+  }
+  return { lines, starts };
+}
+
+function uniqueLines(lines: readonly string[]): Map<string, number> {
+  const count = new Map<string, number>();
+  for (const l of lines) count.set(l, (count.get(l) ?? 0) + 1);
+  const out = new Map<string, number>();
+  lines.forEach((l, i) => {
+    if (count.get(l) === 1) out.set(l, i);
+  });
+  return out;
+}
+
+export function diffLines(a: string, b: string): LineDiff {
+  const A = splitLines(a);
+  const B = splitLines(b);
+  const ua = uniqueLines(A.lines);
+  const ub = uniqueLines(B.lines);
+  const pairs: { a: number; b: number }[] = [];
+  for (const [line, ia] of ua) {
+    const ib = ub.get(line);
+    if (ib !== undefined) pairs.push({ a: ia, b: ib });
+  }
+  pairs.sort((x, y) => x.a - y.a);
+  const aToB = new Map<number, number>();
+  const bToA = new Map<number, number>();
+  const link = (ia: number, ib: number): void => {
+    aToB.set(ia, ib);
+    bToA.set(ib, ia);
+  };
+  pairs.forEach(({ a: ia, b: ib }) => link(ia, ib));
+  for (const { a: ia, b: ib } of pairs) {
+    for (let d = 1; ; d++) {
+      const x = ia + d;
+      const y = ib + d;
+      if (aToB.has(x) || bToA.has(y) || A.lines[x] === undefined || A.lines[x] !== B.lines[y]) break;
+      link(x, y);
+    }
+    for (let d = 1; ; d++) {
+      const x = ia - d;
+      const y = ib - d;
+      if (x < 0 || y < 0 || aToB.has(x) || bToA.has(y) || A.lines[x] !== B.lines[y]) break;
+      link(x, y);
+    }
+  }
+  return { aStarts: A.starts, bStarts: B.starts, aToB };
+}
+
+/** Index of the last start at or before `offset` in an ascending list; 0 before the first. */
+export function indexAtOrBefore(starts: readonly number[], offset: number): number {
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if ((starts[mid] ?? 0) <= offset) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+/** Where an a offset lands in b: on its matched line at the same column, else at
+ *  the start of the same-ranked line inside the changed block around it; a rank the
+ *  block no longer has is deleted. */
+export function mapOffset(diff: LineDiff, offset: number): MappedOffset {
+  const la = indexAtOrBefore(diff.aStarts, offset);
+  const matched = diff.aToB.get(la);
+  if (matched !== undefined) {
+    const column = offset - (diff.aStarts[la] ?? 0);
+    return { offset: (diff.bStarts[matched] ?? 0) + column, deleted: false };
+  }
+  let pa = la - 1;
+  while (pa >= 0 && !diff.aToB.has(pa)) pa--;
+  let na = la + 1;
+  while (na < diff.aStarts.length && !diff.aToB.has(na)) na++;
+  const pb = pa >= 0 ? (diff.aToB.get(pa) ?? -1) : -1;
+  const nb = na < diff.aStarts.length ? (diff.aToB.get(na) ?? diff.bStarts.length) : diff.bStarts.length;
+  const rank = la - pa - 1;
+  if (rank >= nb - pb - 1) return { offset: diff.bStarts[nb] ?? 0, deleted: true };
+  return { offset: diff.bStarts[pb + 1 + rank] ?? 0, deleted: false };
+}
+
+/** True when every line of the a range [start, end) matched. */
+export function rangeMatched(diff: LineDiff, start: number, end: number): boolean {
+  const first = indexAtOrBefore(diff.aStarts, start);
+  const last = indexAtOrBefore(diff.aStarts, Math.max(start, end - 1));
+  for (let l = first; l <= last; l++) if (!diff.aToB.has(l)) return false;
+  return true;
+}

--- a/packages/core/src/lib/sourceApplyCarry.test.ts
+++ b/packages/core/src/lib/sourceApplyCarry.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect } from "vitest";
+import { prepareSourceApply, type SourceDocumentState } from "./zplSourceEdit";
+import { generateMultiPageZPL } from "./zplGenerator";
+import { importZplText } from "./zplImportService";
+import type { LabelConfig } from "../types/LabelConfig";
+import type { LabelObject, Page } from "../types/Group";
+import type { Variable } from "../types/Variable";
+
+const NL = String.fromCharCode(10);
+const label: LabelConfig = { widthMm: 70, heightMm: 40, dpmm: 8 };
+type Over = Partial<Omit<LabelObject, "props">> & { props?: unknown };
+const textProps = (content: string) => ({ content, fontHeight: 30, fontWidth: 0, rotation: "N" });
+const leaf = (id: string, over: Over = {}): LabelObject =>
+  ({ id, type: "text", x: 20, y: 90, rotation: 0, props: textProps(id), ...over }) as never;
+const hidden = (id: string, over: Over = {}): LabelObject => leaf(id, { includeInExport: false, ...over });
+const content = (o: LabelObject | undefined) => (o as { props?: { content?: string } } | undefined)?.props?.content;
+const group = (id: string, children: LabelObject[], over: Partial<LabelObject> = {}): LabelObject =>
+  ({ id, type: "group", x: 0, y: 0, rotation: 0, children, ...over }) as never;
+
+const current = (pages: Page[], variables: Variable[] = []): SourceDocumentState =>
+  ({ label, pages, variables, printerProfile: {}, columnMapping: null });
+
+/** Apply `edit(baseline)` as the buffer; the baseline is the export of `pages`. */
+const apply = (pages: Page[], edit: (baseline: string) => string = (b) => b, variables: Variable[] = []) => {
+  const baseline = generateMultiPageZPL(label, pages, variables);
+  const plan = prepareSourceApply({ text: edit(baseline), baseline, current: current(pages, variables) });
+  expect(plan.ok).toBe(true);
+  if (!plan.ok) throw new Error("refused");
+  return plan;
+};
+const ids = (page: Page | undefined) => (page?.objects ?? []).map((o) => o.id);
+const hiddenIds = (page: Page | undefined) => (page?.objects ?? []).filter((o) => o.includeInExport === false).map((o) => o.id);
+const line = (id: string) => `^FD${id}^FS`;
+/** The whole emitted line that prints `id`, including its line break. */
+const lineOf = (text: string, id: string): string => {
+  const at = text.indexOf(line(id));
+  const start = text.lastIndexOf(NL, at) + 1;
+  const end = text.indexOf(NL, at);
+  return text.slice(start, end === -1 ? text.length : end + 1);
+};
+
+describe("hidden objects across a source apply", () => {
+  it("stay in place on a value edit, with byte-identical re-export", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("h"), leaf("b")] }], (b) => b.replace("^FDb^FS", "^FDB^FS"));
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["h"]);
+    expect(ids(plan.next.pages[0]).indexOf("h")).toBe(1);
+    expect(plan.loss.excludedLost).toBe(0);
+  });
+
+  it("survive when every printing field of the page is edited", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("h")] }], (b) => b.replace(line("a"), line("A")));
+    expect(ids(plan.next.pages[0]).indexOf("h")).toBe(1);
+  });
+
+  it("keep their z-order when the field below them is deleted", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("h"), leaf("b")] }], (b) => b.replace(lineOf(b, "a"), ""));
+    expect(ids(plan.next.pages[0]).indexOf("h")).toBe(0);
+  });
+
+  it("stay right behind their predecessor when a field is inserted after it", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("h"), leaf("b")] }], (b) =>
+      b.replace(line("a"), `${line("a")}${NL}^FO20,10^A0N,30,30${line("new")}`));
+    const order = ids(plan.next.pages[0]);
+    expect(order.indexOf("h")).toBe(1);
+    expect(order).toHaveLength(4);
+  });
+
+  it("keep two adjacent hidden siblings in order", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("h1"), hidden("h2")] }]);
+    const order = ids(plan.next.pages[0]);
+    expect(order).toHaveLength(3);
+    expect(order.slice(1)).toEqual(["h1", "h2"]);
+  });
+
+  it("stay above identical neighbours", () => {
+    const dup = (id: string) => leaf(id, { props: textProps("dup") });
+    const plan = apply([{ objects: [dup("d1"), dup("d2"), hidden("h")] }]);
+    expect(ids(plan.next.pages[0]).indexOf("h")).toBe(2);
+  });
+
+  it("follow their page when two blocks are swapped", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("h")] }, { objects: [leaf("z1"), leaf("z2")] }];
+    const plan = apply(pages, () => generateMultiPageZPL(label, [pages[1]!, pages[0]!]));
+    expect(hiddenIds(plan.next.pages[0])).toEqual([]);
+    expect(hiddenIds(plan.next.pages[1])).toEqual(["h"]);
+    expect(plan.loss.excludedLost).toBe(0);
+  });
+
+  it("survive on an untouched page when another page is added or removed", () => {
+    const pages: Page[] = [{ objects: [leaf("a")] }, { objects: [leaf("b"), hidden("h")] }];
+    const added = apply(pages, () => generateMultiPageZPL(label, [pages[0]!, { objects: [leaf("n")] }, pages[1]!]));
+    expect(hiddenIds(added.next.pages[2])).toEqual(["h"]);
+    const removed = apply(pages, () => generateMultiPageZPL(label, [pages[1]!]));
+    expect(hiddenIds(removed.next.pages[0])).toEqual(["h"]);
+    expect(removed.loss.excludedLost).toBe(0);
+  });
+
+  it("drop with the page the edit removed, and say so, whatever trails the last ^XZ", () => {
+    const pages: Page[] = [{ objects: [leaf("a")] }, { objects: [leaf("b"), hidden("h")] }];
+    for (const tail of ["", NL, " ", `${NL}${NL}`]) {
+      const plan = apply(pages, () => generateMultiPageZPL(label, [pages[0]!]) + tail);
+      expect(plan.next.pages).toHaveLength(1);
+      expect(hiddenIds(plan.next.pages[0])).toEqual([]);
+      expect(plan.loss.excludedLost).toBe(1);
+    }
+  });
+
+  it("stay on a hidden-only page through a no-op, a page appended, a page prepended and a page removed elsewhere", () => {
+    const pages: Page[] = [{ objects: [leaf("a")] }, { objects: [hidden("h")] }, { objects: [leaf("z")] }];
+    expect(hiddenIds(apply(pages).next.pages[1])).toEqual(["h"]);
+    const appended = apply(pages, () => generateMultiPageZPL(label, [...pages, { objects: [leaf("tail")] }]));
+    expect(appended.next.pages.map(hiddenIds)).toEqual([[], ["h"], [], []]);
+    const prepended = apply(pages, () => generateMultiPageZPL(label, [{ objects: [leaf("head")] }, ...pages]));
+    expect(prepended.next.pages.map(hiddenIds)).toEqual([[], [], ["h"], []]);
+    const removed = apply(pages, () => generateMultiPageZPL(label, [pages[1]!, pages[2]!]));
+    expect(removed.next.pages.map(hiddenIds)).toEqual([["h"], []]);
+    expect(removed.loss.excludedLost).toBe(0);
+    const before = apply(pages, () => generateMultiPageZPL(label, [pages[0]!, { objects: [leaf("n")] }, pages[1]!, pages[2]!]));
+    expect(before.next.pages.map(hiddenIds)).toEqual([[], [], ["h"], []]);
+  });
+
+  it("stay on their page when only lines repeated on every page survive there", () => {
+    const pages: Page[] = [{ objects: [leaf("A"), leaf("B"), leaf("C"), hidden("H0")] }, { objects: [leaf("A"), leaf("B"), leaf("D"), hidden("H1")] }];
+    const plan = apply(pages, () => generateMultiPageZPL(label, [{ objects: [leaf("A"), leaf("B")] }, { objects: [leaf("A"), leaf("B"), leaf("E")] }]));
+    expect(plan.next.pages.map(hiddenIds)).toEqual([["H0"], ["H1"]]);
+    expect(plan.loss.excludedLost).toBe(0);
+  });
+
+  it("stay in place on equal pages when one of them is edited", () => {
+    const pages: Page[] = [{ objects: [leaf("p0a", { props: textProps("A") }), leaf("p0b", { props: textProps("B") }), hidden("H0")] }, { objects: [leaf("p1a", { props: textProps("A") }), leaf("p1b", { props: textProps("B") }), hidden("H1")] }];
+    const plan = apply(pages, (b) => b.replace("^FDB^FS", "^FDZ^FS"));
+    expect(plan.next.pages.map(hiddenIds)).toEqual([["H0"], ["H1"]]);
+    expect(plan.loss.excludedLost).toBe(0);
+  });
+
+  it("stay put when only shared lines print and bytes trail the last ^XZ", () => {
+    const pages: Page[] = [{ objects: [leaf("s1", { props: textProps("same") }), hidden("H0")] }, { objects: [leaf("s2", { props: textProps("same") }), leaf("t", { props: textProps("same2") }), hidden("H1")] }, { objects: [leaf("s3", { props: textProps("same") }), hidden("H2")] }];
+    for (const tail of [`${NL}${NL}`, " ", `${NL}^FXpad^FS`, " ^FXpad^FS", "~JA"]) {
+      const plan = apply(pages, (b) => b.replace(lineOf(b, "same2"), "") + tail);
+      expect(plan.next.pages.map(hiddenIds)).toEqual([["H0"], ["H1"], ["H2"]]);
+    }
+  });
+
+  it("follow a hidden-only page moved backwards", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), leaf("b")] }, { objects: [hidden("h")] }];
+    const plan = apply(pages, () => generateMultiPageZPL(label, [{ objects: [] }, { objects: [leaf("a"), leaf("b")] }]));
+    expect(plan.next.pages.map(hiddenIds)).toEqual([["h"], []]);
+  });
+
+  it("stay put when a reprint sits on the page their anchor moved to", () => {
+    const pages: Page[] = [
+      { objects: [leaf("a0", { props: textProps("ANCHOR0") }), leaf("c0", { props: textProps("COMMON") }), hidden("h0", { props: textProps("H0") })] },
+      { objects: [leaf("a1", { props: textProps("ANCHOR1") }), leaf("c1", { props: textProps("COMMON") })] },
+      { objects: [leaf("a2", { props: textProps("ANCHOR2") }), leaf("c2", { props: textProps("COMMON") })] },
+    ];
+    const plan = apply(pages, () => generateMultiPageZPL(label, [
+      { objects: [leaf("x", { props: textProps("ANCHOR2") }), leaf("y", { props: textProps("COMMON") })] },
+      { objects: [leaf("p", { props: textProps("ANCHOR0") }), leaf("q", { props: textProps("COMMONX") }), leaf("r", { props: textProps("H0") })] },
+      { objects: [leaf("s", { props: textProps("ANCHOR1") }), leaf("t", { props: textProps("COMMON") })] },
+    ]));
+    expect(plan.next.pages.map((p) => p.objects.map((o) => [content(o), o.includeInExport]))).toEqual([
+      [["ANCHOR2", undefined], ["COMMON", undefined]],
+      [["ANCHOR0", undefined], ["COMMONX", undefined], ["H0", false]],
+      [["ANCHOR1", undefined], ["COMMON", undefined]],
+    ]);
+  });
+
+  it("stay on a page that lost its only printing field, first or last", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("h")] }, { objects: [leaf("b"), hidden("k")] }];
+    for (const id of ["a", "b"]) {
+      const plan = apply(pages, (b) => b.replace(lineOf(b, id), ""));
+      expect(plan.next.pages.map(hiddenIds)).toEqual([["h"], ["k"]]);
+      expect(plan.loss.excludedLost).toBe(0);
+    }
+  });
+
+  it("anchor behind the previous field when their predecessor turned into a non-field line", () => {
+    const plan = apply([{ objects: [leaf("a"), leaf("b"), hidden("h")] }], (b) => b.replace(lineOf(b, "b").trimEnd(), "^LH0,0"));
+    expect(ids(plan.next.pages[0])).toHaveLength(2);
+    expect(ids(plan.next.pages[0]).indexOf("h")).toBe(1);
+  });
+
+  it("get their editor state back when an older buffer prints them again", () => {
+    const x = hidden("x", { name: "Watermark", locked: true, visible: false, comment: "keep" });
+    const plan = apply([{ objects: [leaf("a"), x] }], () => generateMultiPageZPL(label, [{ objects: [leaf("a"), leaf("x", { comment: "old" })] }]));
+    const objects = plan.next.pages[0]?.objects ?? [];
+    expect(objects).toHaveLength(2);
+    // Editor state from the model, the ^FX comment from the buffer: it is what the user pasted.
+    expect(objects.find((o) => o.includeInExport === false)).toMatchObject({ name: "Watermark", locked: true, visible: false, comment: "old" });
+    expect(plan.loss.excludedLost).toBe(0);
+  });
+
+  it("recognise a reprint before their successor and at the tail of a page", () => {
+    const lead = apply([{ objects: [hidden("h"), leaf("a")] }], () => generateMultiPageZPL(label, [{ objects: [leaf("h"), leaf("a")] }]));
+    expect(lead.next.pages[0]?.objects.map((o) => [content(o), o.includeInExport])).toEqual([["h", false], ["a", undefined]]);
+    const tail = apply([{ objects: [hidden("x"), hidden("y")] }], () => generateMultiPageZPL(label, [{ objects: [leaf("x"), leaf("y")] }]));
+    expect(tail.next.pages[0]?.objects.map((o) => [content(o), o.includeInExport])).toEqual([["x", false], ["y", false]]);
+  });
+
+  it("recognise a reprinted hidden field bound to a variable", () => {
+    const variables: Variable[] = [{ id: "v1", name: "LOT", fnNumber: 1, defaultValue: "L42" }];
+    const pages: Page[] = [{ objects: [leaf("t", { props: textProps("Lot «LOT»") }), hidden("h", { name: "H", props: textProps("Hid «LOT»") })] }];
+    const older = generateMultiPageZPL(label, [{ objects: [leaf("t", { props: textProps("Lot «LOT»") }), leaf("h", { props: textProps("Hid «LOT»") })] }], variables);
+    const plan = apply(pages, () => older, variables);
+    expect(plan.next.pages[0]?.objects).toHaveLength(2);
+    expect(plan.next.pages[0]?.objects[1]).toMatchObject({ name: "H", includeInExport: false });
+  });
+
+  it("recognise a reprint under a ^LH or ^LT the buffer added", () => {
+    for (const header of ["^LH10,0", "^LT10"]) {
+      const older = generateMultiPageZPL(label, [{ objects: [leaf("A"), leaf("X")] }]).replace("^PW560", `${header}${NL}^PW560`);
+      const plan = apply([{ objects: [leaf("A"), hidden("X")] }], () => older);
+      expect(plan.next.pages[0]?.objects.map((o) => [content(o), o.includeInExport])).toEqual([["A", undefined], ["X", false]]);
+    }
+  });
+
+  it("unfold a candidate with the ^LH in force where it was parsed, not the page's last", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("w", { x: 10, props: textProps("WM") }), leaf("b")] }];
+    const typed = (b: string) => b.replace(lineOf(b, "a"), `${lineOf(b, "a")}^FO20,90^A0N,30,0^FDWM^FS${NL}`).replace(lineOf(b, "b"), `${lineOf(b, "b")}^LH10,0${NL}`);
+    const plan = apply(pages, typed);
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages, plan.next.variables)).toContain("^FDWM^FS");
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["w"]);
+  });
+
+  it("unfold a candidate with the ^LH its opener saw, even when ^LH sits inside the field", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("w", { x: 20, props: textProps("WM") }), leaf("b")] }];
+    const plan = apply(pages, (b) => b.replace(lineOf(b, "b"), `^FO30,90^A0N,30,0^LH10,0^FDWM^FS${NL}${lineOf(b, "b")}`));
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages, plan.next.variables)).toContain("^FDWM^FS");
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["w"]);
+  });
+
+  it("recognise reprints with a new field typed between them", () => {
+    const older = generateMultiPageZPL(label, [{ objects: [leaf("a"), leaf("x"), leaf("y")] }]);
+    const text = older.replace(lineOf(older, "y"), `^FO20,10^A0N,30,30^FDnew^FS${NL}${lineOf(older, "y")}`);
+    const plan = apply([{ objects: [leaf("a"), hidden("x"), hidden("y")] }], () => text);
+    expect(plan.next.pages[0]?.objects.map((o) => [content(o), o.includeInExport])).toEqual([["a", undefined], ["x", false], ["y", false], ["new", undefined]]);
+  });
+
+  it("recognise a run reprinted in another order", () => {
+    const plan = apply([{ objects: [leaf("a"), hidden("x"), hidden("y")] }], () => generateMultiPageZPL(label, [{ objects: [leaf("a"), leaf("y"), leaf("x")] }]));
+    expect(plan.next.pages[0]?.objects.map((o) => [content(o), o.includeInExport])).toEqual([["a", undefined], ["x", false], ["y", false]]);
+  });
+
+  it("map two reprinted identical hidden siblings one to one", () => {
+    const dup = (id: string, over: Over = {}) => leaf(id, { props: textProps("dup"), ...over });
+    const plan = apply([{ objects: [leaf("a"), dup("d1", { includeInExport: false }), dup("d2", { includeInExport: false })] }],
+      () => generateMultiPageZPL(label, [{ objects: [leaf("a"), dup("d1"), dup("d2")] }]));
+    expect(hiddenIds(plan.next.pages[0])).toHaveLength(2);
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages, plan.next.variables)).not.toContain("^FDdup^FS");
+  });
+
+  it("rebuild a partly reprinted hidden group as a group, its lock and exclusion staying on the group", () => {
+    const g = group("g", [leaf("c1"), group("gg", [leaf("c2")])], { includeInExport: false, locked: true });
+    for (const edit of [(b: string) => b, () => generateMultiPageZPL(label, [{ objects: [leaf("a"), leaf("c1")] }])]) {
+      const plan = apply([{ objects: [leaf("a"), g] }], edit);
+      const back = (plan.next.pages[0]?.objects ?? []).filter((o) => o.includeInExport === false);
+      expect(back).toHaveLength(1);
+      expect(back[0]).toMatchObject({ id: "g", locked: true });
+      const children = (back[0] as { children: LabelObject[] }).children;
+      const nested = (children[1] as { children: LabelObject[] }).children;
+      for (const o of [...children, ...nested]) expect([o.locked, o.includeInExport]).toEqual([undefined, undefined]);
+    }
+  });
+
+  it("rename markers like the reparse and keep a variable only they reference", () => {
+    const variables: Variable[] = [{ id: "v1", name: "LOT", fnNumber: 1, defaultValue: "L42" }];
+    const bound = leaf("t", { props: textProps("Lot «LOT»") });
+    const hid = hidden("h", { props: { content: "Hid «LOT»", fontHeight: 30, fontWidth: 0, rotation: "N" } } as never);
+    const renamed = apply([{ objects: [bound, hid] }], (b) => b, variables);
+    const name = renamed.next.variables.find((v) => v.fnNumber === 1)?.name;
+    expect((renamed.next.pages[0]?.objects.find((o) => o.id === "h") as { props: { content: string } }).props.content).toBe(`Hid «${name}»`);
+    const only = apply([{ objects: [leaf("a"), hid] }], (b) => b, variables);
+    expect(only.next.variables.map((v) => v.name)).toEqual(["LOT"]);
+  });
+
+  it("replay foreign bytes verbatim around a carried object", () => {
+    const src = ["^XA", "^PW800", "^FXnote", "^FO50,50^A0N,30,30^FDHello^FS", "^XZ"].join(NL);
+    const imported = importZplText(src, label.dpmm);
+    const pages: Page[] = [{ ...imported.pages[0]!, objects: [...imported.pages[0]!.objects, hidden("h")] }];
+    const baseline = generateMultiPageZPL(label, pages);
+    expect(baseline).toBe(src);
+    const plan = prepareSourceApply({ text: src, baseline, current: current(pages) });
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["h"]);
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages, plan.next.variables)).toBe(src);
+  });
+
+  it("keep their z-order and their group when an older export reprints a member", () => {
+    const g = group("g", [leaf("c1"), leaf("c2")], { includeInExport: false, name: "Grp", locked: true });
+    const pages: Page[] = [{ objects: [leaf("a"), g] }];
+    const reprint = (id: string) => (b: string) => b.replace(line("a"), `${line("a")}${NL}${lineOf(generateMultiPageZPL(label, [{ objects: [leaf(id)] }]), id).trimEnd()}`);
+    for (const id of ["c1", "c2"]) {
+      const plan = apply(pages, reprint(id));
+      const objects = plan.next.pages[0]?.objects ?? [];
+      expect(objects).toHaveLength(2);
+      const back = objects[1]!;
+      expect(back).toMatchObject({ type: "group", name: "Grp", includeInExport: false });
+      expect((back as { children: LabelObject[] }).children.map(content)).toEqual(["c1", "c2"]);
+      expect(plan.loss.excludedLost).toBe(0);
+    }
+  });
+
+  it("leave a field the user typed alone, even when its bytes equal a hidden object's", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("w", { props: textProps("WM") }), leaf("b")] }];
+    const typed = lineOf(generateMultiPageZPL(label, [{ objects: [leaf("w", { props: textProps("WM") })] }]), "WM").trimEnd();
+    // Typed below b, away from the hidden object's slot: it prints, the hidden one is carried.
+    const plan = apply(pages, (b) => b.replace(line("b"), `${line("b")}${NL}${typed}`));
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages, plan.next.variables)).toContain("^FDWM^FS");
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["w"]);
+  });
+
+  it("do not carry without a usable baseline", () => {
+    const pages: Page[] = [{ objects: [leaf("a"), hidden("h")] }];
+    const plan = prepareSourceApply({ text: generateMultiPageZPL(label, pages), current: current(pages) });
+    expect(plan.ok && hiddenIds(plan.next.pages[0])).toEqual([]);
+  });
+});
+
+describe("unchanged printing objects across a source apply", () => {
+  it("keep name, lock and hiding when their lines survived the edit", () => {
+    const named = leaf("n", { name: "Title", locked: true, visible: false });
+    const plan = apply([{ objects: [named, leaf("b")] }], (b) => b.replace(line("b"), line("B")));
+    const kept = plan.next.pages[0]?.objects[0];
+    expect(kept).toMatchObject({ name: "Title", locked: true, visible: false, type: "text" });
+    expect(plan.loss.namesLost + plan.loss.lockedLost + plan.loss.hiddenLost).toBe(0);
+  });
+
+  it("lose them when their own line was edited, and say so", () => {
+    const named = leaf("n", { name: "Title" });
+    const plan = apply([{ objects: [named]}], (b) => b.replace(line("n"), line("N")));
+    expect(plan.loss.namesLost).toBe(1);
+  });
+
+  it("keep a rotated QR a QR through its sidecar, with its name, commented or not", () => {
+    for (const comment of [undefined, "scan me"]) {
+      const qr = { id: "q", type: "qrcode", x: 10, y: 10, rotation: 90, name: "Code", locked: true, comment,
+        props: { content: "https://example.test", magnification: 4, errorCorrection: "M", model: 2, rotation: "R" } } as never as LabelObject;
+      const plan = apply([{ objects: [qr, leaf("b")] }], (b) => b.replace(line("b"), line("B")));
+      expect(plan.next.pages[0]?.objects[0]).toMatchObject({ type: "qrcode", name: "Code", locked: true });
+    }
+  });
+
+  it("take markers, coordinates and comments from the buffer, never from the model", () => {
+    const variables: Variable[] = [{ id: "v1", name: "LOT", fnNumber: 1, defaultValue: "L42" }];
+    const bound = leaf("t", { name: "Field", props: textProps("Lot «LOT»") });
+    const noop = apply([{ objects: [bound, hidden("h")] }], (b) => b, variables);
+    const name = noop.next.variables.find((v) => v.fnNumber === 1)?.name;
+    expect(content(noop.next.pages[0]?.objects[0])).toBe(`Lot «${name}»`);
+    expect(noop.next.pages[0]?.objects[0]).toMatchObject({ name: "Field" });
+    expect(generateMultiPageZPL(noop.next.label, noop.next.pages.map((p) => ({ ...p, overlay: undefined })), noop.next.variables)).toContain("^FN1");
+
+    const home = apply([{ objects: [leaf("a", { name: "K" }), leaf("b"), hidden("h")] }], (b) => b.replace("^PW560", `^LH80,80${NL}^PW560`).replace(line("b"), line("B")));
+    const xs = (home.next.pages[0]?.objects ?? []).filter((o) => o.includeInExport !== false).map((o) => o.x);
+    expect(new Set(xs).size).toBe(1);
+
+    const commented = apply([{ objects: [leaf("n", { name: "Title" }), hidden("h")] }], (b) => b.replace(lineOf(b, "n"), `^FXhello^FS${NL}${lineOf(b, "n")}`));
+    expect(commented.next.pages[0]?.objects[0]).toMatchObject({ name: "Title", comment: "hello" });
+  });
+
+  it("keep identity across a ^CC, ^CT or ^CD remap of the whole buffer", () => {
+    const pages: Page[] = [{ objects: [leaf("a", { name: "Title", locked: true }), hidden("h")] }];
+    const remapFrom = (b: string, cmd: string, edit: (tail: string) => string) => {
+      const at = b.indexOf(NL) + 1;
+      return `${b.slice(0, at)}${cmd}${NL}${edit(b.slice(at))}`;
+    };
+    const remaps: ((b: string) => string)[] = [
+      (b) => remapFrom(b, "^CC!", (t) => t.replace(/\^/g, "!")),
+      (b) => remapFrom(b, "^CD;", (t) => t.split(NL).map((l) => (l.startsWith("^FO") ? l.replace(/,/g, ";") : l)).join(NL)),
+      (b) => remapFrom(b, "^CT|", (t) => t),
+    ];
+    for (const remap of remaps) {
+      const plan = apply(pages, remap);
+      expect(plan.next.pages[0]?.objects[0]).toMatchObject({ name: "Title", locked: true });
+      expect(hiddenIds(plan.next.pages[0])).toEqual(["h"]);
+      expect(plan.loss.namesLost + plan.loss.lockedLost).toBe(0);
+    }
+  });
+
+  it("keep identity when only the ^FX comment of a field changes", () => {
+    const plan = apply([{ objects: [leaf("n", { name: "Title", locked: true, comment: "old" }), hidden("h")] }], (b) => b.replace("^FXold", "^FXnew"));
+    expect(plan.next.pages[0]?.objects[0]).toMatchObject({ name: "Title", locked: true, comment: "new" });
+    expect(plan.loss.namesLost + plan.loss.lockedLost).toBe(0);
+  });
+
+  it("never let an inserted line borrow a commented field's identity", () => {
+    const pages: Page[] = [{ objects: [leaf("a", { name: "Aname", comment: "note" }), leaf("b")] }];
+    const plan = apply(pages, (b) => b.replace("^FXnote", `^FXnote${NL}^FO60,95^A0N,30,30^FDNEW^FS`));
+    const contents = (plan.next.pages[0]?.objects ?? []).map(content);
+    expect(contents).toEqual(["NEW", "a", "b"]);
+    expect(plan.next.pages[0]?.objects[1]).toMatchObject({ name: "Aname" });
+  });
+
+  it("carry a variable under a name the reparse left free", () => {
+    const variables: Variable[] = [{ id: "v1", name: "LOT", fnNumber: 1, defaultValue: "L42" }, { id: "v2", name: "field_1", fnNumber: 3, defaultValue: "x" }];
+    const bound = leaf("t", { props: textProps("Lot «LOT»") });
+    const hid = hidden("h", { props: textProps("Hid «field_1»") });
+    const plan = apply([{ objects: [bound, hid] }], (b) => b.replace("^LL320", "^LL400"), variables);
+    const names = plan.next.variables.map((v) => v.name);
+    expect(new Set(names).size).toBe(names.length);
+    const carriedName = plan.next.variables.find((v) => v.fnNumber === 3)?.name;
+    const keptName = plan.next.variables.find((v) => v.fnNumber === 1)?.name;
+    expect(content(plan.next.pages[0]?.objects.find((o) => o.id === "h"))).toBe(`Hid «${carriedName}»`);
+    expect(content(plan.next.pages[0]?.objects[0])).toBe(`Lot «${keptName}»`);
+    expect(generateMultiPageZPL(plan.next.label, plan.next.pages.map((p) => ({ ...p, overlay: undefined })), plan.next.variables)).toContain("^FN1^FDL42^FS");
+  });
+
+  it("carry through an LF-normalised buffer of a CRLF baseline", () => {
+    const pages: Page[] = [{ objects: [leaf("n", { name: "Title" }), hidden("h")] }];
+    const baseline = generateMultiPageZPL(label, pages).replace(/\n/g, "\r\n");
+    const crlfCurrent = current(pages);
+    // The baseline must be the regenerated text: model this with a CRLF overlay page.
+    const imported = importZplText(baseline, label.dpmm);
+    const crlfPages: Page[] = [{ ...imported.pages[0]!, objects: [...imported.pages[0]!.objects.map((o, i) => (i === 0 ? { ...o, name: "Title" } : o)), hidden("h")] }];
+    const base = generateMultiPageZPL(label, crlfPages);
+    expect(base).toBe(baseline);
+    const plan = prepareSourceApply({ text: base.replace(/\r\n/g, "\n"), baseline: base, current: { ...crlfCurrent, pages: crlfPages } });
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.next.pages[0]?.objects[0]).toMatchObject({ name: "Title" });
+    expect(hiddenIds(plan.next.pages[0])).toEqual(["h"]);
+  });
+});
+
+describe("the applied model prints what the buffer says", () => {
+  const rnd = (seed: number) => () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 2 ** 32;
+  const printed = (zpl: string) => [...zpl.matchAll(/\^F[DN]([^^]*)/g)].map((m) => m[1]).sort();
+
+  it("holds over random single-line edits (fuzz)", () => {
+    const rand = rnd(7);
+    let checked = 0;
+    for (let i = 0; i < 150; i++) {
+      const n = 2 + Math.floor(rand() * 4);
+      const variables: Variable[] = rand() < 0.5 ? [{ id: "v1", name: "LOT", fnNumber: 1, defaultValue: "L42" }, { id: "v2", name: "field_1", fnNumber: 3, defaultValue: "S" }] : [];
+      const objects: LabelObject[] = [];
+      for (let j = 0; j < n; j++) {
+        const id = `o${j}`;
+        const over: Over = {};
+        if (rand() < 0.4) over.name = `N${j}`;
+        if (rand() < 0.3) over.comment = `c${j}`;
+        if (rand() < 0.3) over.includeInExport = false;
+        if (variables.length > 0 && rand() < 0.5) over.props = textProps(`${id} «${rand() < 0.5 ? "LOT" : "field_1"}»`);
+        objects.push(leaf(id, { y: 20 + j * 30, ...over }));
+      }
+      const pages: Page[] = [{ objects }];
+      const baseline = generateMultiPageZPL(label, pages, variables);
+      const lines = baseline.split(NL);
+      const fieldIdx = lines.map((l, k) => (l.includes("^FD") ? k : -1)).filter((k) => k >= 0);
+      if (fieldIdx.length === 0) continue;
+      const pick = fieldIdx[Math.floor(rand() * fieldIdx.length)]!;
+      const op = Math.floor(rand() * 4);
+      const edited = [...lines];
+      if (op === 0) edited.splice(pick, 1);
+      else if (op === 1) edited.splice(pick, 0, lines[pick]!);
+      else if (op === 2) edited[pick] = lines[pick]!.replace(/\^FD([^^]*)\^FS/, "^FD$1x^FS");
+      else if (fieldIdx.length > 1) {
+        const other = fieldIdx[(fieldIdx.indexOf(pick) + 1) % fieldIdx.length]!;
+        [edited[pick], edited[other]] = [edited[other]!, edited[pick]!];
+      }
+      const text = edited.join(NL);
+      const plan = prepareSourceApply({ text, baseline, current: current(pages, variables) });
+      if (!plan.ok) continue;
+      checked++;
+      const applied = generateMultiPageZPL(plan.next.label, plan.next.pages.map((p) => ({ ...p, overlay: undefined })), plan.next.variables);
+      const reparsed = importZplText(text, label.dpmm);
+      const regenerated = generateMultiPageZPL(label, reparsed.pages.map((p) => ({ ...p, overlay: undefined })), reparsed.variables);
+      expect(printed(applied), `iteration ${i}, op ${op}`).toEqual(printed(regenerated));
+    }
+    expect(checked).toBeGreaterThan(100);
+  });
+});

--- a/packages/core/src/lib/sourceApplyCarry.ts
+++ b/packages/core/src/lib/sourceApplyCarry.ts
@@ -1,0 +1,280 @@
+import { exportableLeaves, isGroup, pageLabelConfig, walkExportOrder, walkObjects, type ExportStep, type LabelObject, type Page } from "../types/Group";
+import type { LabelConfig } from "../types/LabelConfig";
+import { matchVariablesByFn, uniqueVariableName, type Variable } from "../types/Variable";
+import type { PageSource } from "./zplParser/types";
+import type { OverlayFrame } from "./zplOverlay/overlay";
+import { generateMultiPageZplWithMap, shiftIntoFrame, type EmitSpan } from "./zplGenerator";
+import { rewriteTemplateMarkersMap } from "./templateObjects";
+import { extractTemplateRefs } from "./fnTemplate";
+import { getObjectStringContent } from "./variableBinding";
+import { pickEditorState } from "./editorStateDiff";
+import { indexAtOrBefore } from "./lineDiff";
+import { diffBlocks, type BlockDiff } from "./blockDiff";
+import { canonicalPrefixes } from "./zplCanonicalPrefixes";
+
+export interface CarryInput {
+  /** A subset, not SourceDocumentState: naming that type here would cycle through zplSourceEdit. */
+  current: { label: LabelConfig; pages: Page[]; variables: readonly Variable[] };
+  /** Must equal the export of `current`, else nothing carries. */
+  baseline: string | undefined;
+  text: string;
+  importedLabel: LabelConfig;
+  imported: Page[];
+  importedVariables: readonly Variable[];
+  /** Index-parallel to `imported`. */
+  pageSources: readonly PageSource[];
+}
+
+interface Located {
+  id: string;
+  page: Page;
+}
+
+interface Parsed extends Located {
+  start: number;
+  end: number;
+}
+
+/** A run's reach in a page: it enters at the anchored end and may find its reprints up to the other. */
+interface Slot {
+  page: Page;
+  from: number;
+  to: number;
+  anchor: "from" | "to";
+}
+
+interface Ctx {
+  current: CarryInput["current"];
+  importedLabel: LabelConfig;
+  importedVariables: readonly Variable[];
+  diff: BlockDiff;
+  baseText: string;
+  baseSpan: Map<string, EmitSpan>;
+  /** Ascending by start, `starts` alongside for the bisect. */
+  parsed: Parsed[];
+  starts: number[];
+  /** Parsed ^LH/^LT frame per linked object id. */
+  frames: Map<string, OverlayFrame>;
+  pages: Page[];
+  /** Parsed ids already standing for a model object. */
+  claimed: Set<string>;
+  /** Ids of carried subtrees already in a page. */
+  placed: Set<string>;
+}
+
+/** The field's own bytes identify it; every leading ^FX (comment, sidecar) is annotation. */
+const COMMENT_PREFIX_RE = /^(?:\^FX[^^~]*(?:\^FS)?\s*)+/;
+
+const fieldStart = (text: string, span: EmitSpan): number =>
+  span.start + (COMMENT_PREFIX_RE.exec(text.slice(span.start, span.end))?.[0].length ?? 0);
+
+const patched = <T extends LabelObject>(o: T, patch: Partial<LabelObject>): T => ({ ...o, ...patch }) as T;
+
+const indexOf = (p: Located): number => p.page.objects.findIndex((o) => o.id === p.id);
+
+const pairedPage = (ctx: Ctx, pageIndex: number): Page | undefined => {
+  const j = ctx.diff.pairs.get(pageIndex);
+  return j === undefined ? undefined : ctx.pages[j];
+};
+
+/** Neighbours come from `page` only: a mapped offset never crosses its block. */
+function neighbours(ctx: Ctx, page: Page, offset: number): { inside?: Parsed; before?: Parsed; after?: Parsed } {
+  const i = indexAtOrBefore(ctx.starts, offset);
+  const within = (p: Parsed | undefined) => (p && p.page === page ? p : undefined);
+  const p = ctx.parsed[i];
+  if (!p || p.start > offset) return { after: within(p) };
+  return offset < p.end ? { inside: within(p) } : { before: within(p), after: within(ctx.parsed[i + 1]) };
+}
+
+/** One object's comment-free bytes as the model emits them, the ^LH/^LT of `frame` unfolded. */
+function canonicalBytes(ctx: Ctx, page: Page, object: LabelObject, variables: readonly Variable[], frame?: OverlayFrame): string | undefined {
+  const [unframed] = shiftIntoFrame([object], frame, pageLabelConfig(ctx.importedLabel, page));
+  if (!unframed) return undefined;
+  const { text, spans } = generateMultiPageZplWithMap(ctx.importedLabel, [{ ...page, overlay: undefined, objects: [unframed] }], variables);
+  const span = spans[0];
+  return span === undefined ? undefined : text.slice(fieldStart(text, span), span.end);
+}
+
+/** A printing object whose field line survived keeps its editor state; the parse
+ *  stays authoritative for everything the buffer expresses. */
+function carryIdentity(ctx: Ctx): void {
+  ctx.current.pages.forEach((prev, pageIndex) => {
+    const page = pairedPage(ctx, pageIndex);
+    if (!page) return;
+    for (const leaf of exportableLeaves(prev.objects)) {
+      const span = ctx.baseSpan.get(leaf.id);
+      if (!span) continue;
+      const start = fieldStart(ctx.baseText, span);
+      if (!ctx.diff.rangeMatched(start, span.end)) continue;
+      const target = neighbours(ctx, page, ctx.diff.mapOffset(start).offset).inside;
+      if (!target || ctx.claimed.has(target.id)) continue;
+      const i = indexOf(target);
+      const parsed = page.objects[i];
+      if (!parsed) continue;
+      ctx.claimed.add(target.id);
+      page.objects[i] = patched(parsed, pickEditorState(leaf));
+    }
+  });
+}
+
+// A claimed or carried object belongs to someone else, so a run never reaches across it.
+const isBoundary = (ctx: Ctx, o: LabelObject | undefined): boolean => !!o && (ctx.claimed.has(o.id) || ctx.placed.has(o.id));
+
+function slotAt(ctx: Ctx, page: Page, index: number, anchor: Slot["anchor"]): Slot {
+  const objects = page.objects;
+  let from = index;
+  let to = index;
+  if (anchor === "from") while (to < objects.length && !isBoundary(ctx, objects[to])) to++;
+  else while (from > 0 && !isBoundary(ctx, objects[from - 1])) from--;
+  return { page, from, to, anchor };
+}
+
+/** Where a run of excluded subtrees goes: right after its predecessor's mapped field,
+ *  else before its successor's; a deleted neighbour passes the question on; without
+ *  any, the end of the page, which is then its whole reach. */
+function slotFor(ctx: Ctx, order: readonly ExportStep[], first: number, last: number, page: Page, placedIn: ReadonlyMap<string, Located>): Slot {
+  for (const s of order.slice(0, first).reverse()) {
+    if ("excluded" in s) {
+      const p = placedIn.get(s.excluded.id);
+      const i = p ? indexOf(p) : -1;
+      if (p && i >= 0) return slotAt(ctx, p.page, i + 1, "from");
+      continue;
+    }
+    const span = ctx.baseSpan.get(s.leaf.id);
+    if (!span) continue;
+    const at = ctx.diff.mapOffset(span.end - 1);
+    if (at.deleted) continue;
+    const n = neighbours(ctx, page, at.offset);
+    const p = n.inside ?? n.before;
+    const i = p ? indexOf(p) : -1;
+    if (p && i >= 0) return slotAt(ctx, page, i + 1, "from");
+  }
+  for (const s of order.slice(last)) {
+    if (!("leaf" in s)) continue;
+    const span = ctx.baseSpan.get(s.leaf.id);
+    if (!span) continue;
+    const at = ctx.diff.mapOffset(fieldStart(ctx.baseText, span));
+    if (at.deleted) continue;
+    const n = neighbours(ctx, page, at.offset);
+    const p = n.inside ?? n.after;
+    const i = p ? indexOf(p) : -1;
+    if (p && i >= 0) return slotAt(ctx, page, i, "to");
+  }
+  return slotAt(ctx, page, page.objects.length, "to");
+}
+
+/** Rebuilds a run of excluded subtrees at its slot. A leaf the buffer prints again
+ *  within the run's reach (an older export) is that leaf: the parsed copy joins its
+ *  subtree with its editor state; everything else comes back as a clone. */
+function placeExcluded(ctx: Ctx, roots: readonly LabelObject[], slot: Slot, renames: ReadonlyMap<string, string>): { placed: LabelObject[]; carried: LabelObject[] } {
+  const nodes = [...walkObjects(roots)];
+  const state = new Map(nodes.map((o) => [o.id, pickEditorState(o)] as const));
+  const page = slot.page;
+  const objects = page.objects;
+  // Each side resolves markers under its own variable names; the leaf must un-exclude or it emits nothing.
+  const leaves = nodes.filter((o) => !isGroup(o));
+  const bytesOf = new Map(leaves.map((l) => [l.id, canonicalBytes(ctx, page, patched(l, { includeInExport: undefined }), ctx.current.variables)] as const));
+  const twins = new Map<string, LabelObject>();
+  const taken: number[] = [];
+  for (let i = slot.from; i < slot.to; i++) {
+    const candidate = objects[i];
+    if (!candidate || isBoundary(ctx, candidate) || isGroup(candidate)) continue;
+    const bytes = canonicalBytes(ctx, page, candidate, ctx.importedVariables, ctx.frames.get(candidate.id));
+    const leaf = bytes === undefined ? undefined : leaves.find((l) => !twins.has(l.id) && bytesOf.get(l.id) === bytes);
+    if (!leaf) continue;
+    ctx.claimed.add(candidate.id);
+    twins.set(leaf.id, candidate);
+    taken.push(i);
+  }
+  const carried: LabelObject[] = [];
+  const rebuild = (node: LabelObject): LabelObject => {
+    const own = state.get(node.id) ?? {};
+    if (isGroup(node)) return { ...patched(structuredClone({ ...node, children: [] }), own), children: node.children.map(rebuild) };
+    const twin = twins.get(node.id);
+    if (twin) return patched(twin, own);
+    const clone = structuredClone(patched(node, own));
+    const [renamed = clone] = rewriteTemplateMarkersMap([clone], renames);
+    carried.push(renamed);
+    return renamed;
+  };
+  const placed = roots.map(rebuild);
+  for (const i of taken.reverse()) objects.splice(i, 1);
+  // Removals sat below the "to" anchor and above the "from" one, so only "to" shifts.
+  objects.splice(slot.anchor === "from" ? slot.from : slot.to - taken.length, 0, ...placed);
+  for (const p of placed) ctx.placed.add(p.id);
+  return { placed, carried };
+}
+
+/** Carries what a reparse cannot express from `current` into the parsed pages, keyed on
+ *  the block-then-line diff between the session baseline and the edited text. */
+export function carryAcrossApply(input: CarryInput): { pages: Page[]; variables: Variable[] } {
+  const { current, imported, importedVariables, importedLabel, text } = input;
+  const base = generateMultiPageZplWithMap(current.label, current.pages, current.variables);
+  if (!input.baseline || input.baseline !== base.text) return { pages: imported, variables: [...importedVariables] };
+
+  // A ^CC/^CT/^CD remap rewrites every line but no field; both texts diff in canonical prefixes.
+  const baseText = canonicalPrefixes(base.text);
+  const pages = imported.map((p) => ({ ...p, objects: [...p.objects] }));
+  const parsed: Parsed[] = [];
+  const frames = new Map<string, OverlayFrame>();
+  pages.forEach((page, i) => {
+    const source = input.pageSources[i];
+    for (const [id, span] of source?.objectSpans ?? []) parsed.push({ id, page, ...span });
+    for (const [id, frame] of source?.objectFrames ?? []) frames.set(id, frame);
+  });
+  parsed.sort((a, b) => a.start - b.start);
+  const ctx: Ctx = {
+    current,
+    importedLabel,
+    importedVariables,
+    diff: diffBlocks(baseText, base.blocks, canonicalPrefixes(text), input.pageSources.map((s) => s.span)),
+    baseText,
+    baseSpan: new Map(base.spans.map((s) => [s.objectId, s] as const)),
+    parsed,
+    starts: parsed.map((p) => p.start),
+    frames,
+    pages,
+    claimed: new Set<string>(),
+    placed: new Set<string>(),
+  };
+  carryIdentity(ctx);
+
+  // Names are settled before any clone exists, so the rewrite stays clone-scoped.
+  const { kept, dropped } = matchVariablesByFn(current.variables, importedVariables);
+  const renames = new Map(kept.filter((p) => p.from.name !== p.to.name).map((p) => [p.from.name, p.to.name] as const));
+  const reserved = [...importedVariables];
+  const candidates = dropped.map((v) => {
+    const name = uniqueVariableName(v.name, reserved);
+    if (name !== v.name) renames.set(v.name, name);
+    const candidate = name === v.name ? v : { ...v, name };
+    reserved.push(candidate);
+    return candidate;
+  });
+
+  const carried: LabelObject[] = [];
+  current.pages.forEach((prev, pageIndex) => {
+    const page = pairedPage(ctx, pageIndex);
+    if (!page) return;
+    const order = [...walkExportOrder(prev.objects)];
+    const excludedAt = (i: number): LabelObject | undefined => {
+      const s = order[i];
+      return s && "excluded" in s ? s.excluded : undefined;
+    };
+    const placedIn = new Map<string, Located>();
+    let k = 0;
+    while (k < order.length) {
+      const roots: LabelObject[] = [];
+      for (let r = excludedAt(k); r; r = excludedAt(k + roots.length)) roots.push(r);
+      if (roots.length > 0) {
+        const slot = slotFor(ctx, order, k, k + roots.length, page, placedIn);
+        const result = placeExcluded(ctx, roots, slot, renames);
+        carried.push(...result.carried);
+        roots.forEach((r, i) => placedIn.set(r.id, { id: result.placed[i]?.id ?? r.id, page: slot.page }));
+      }
+      k += Math.max(1, roots.length);
+    }
+  });
+
+  const refs = new Set(carried.flatMap((o) => extractTemplateRefs(getObjectStringContent(o) ?? "")));
+  return { pages, variables: [...importedVariables, ...candidates.filter((v) => refs.has(v.name))] };
+}

--- a/packages/core/src/lib/zplCanonicalPrefixes.test.ts
+++ b/packages/core/src/lib/zplCanonicalPrefixes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { canonicalPrefixes } from "./zplCanonicalPrefixes";
+
+const NL = String.fromCharCode(10);
+const j = (...lines: string[]) => lines.join(NL);
+
+describe("canonicalPrefixes", () => {
+  it("writes a remapped caret, tilde and delimiter back, keeping every offset", () => {
+    const zpl = j("^XA", "^CC!", "!CD;", "!FO20;90!A0N;30;0!FDa;b!FS", "!CT|", "|JA", "!XZ");
+    const out = canonicalPrefixes(zpl);
+    expect(out).toBe(j("^XA", "^CC!", "^CD;", "^FO20,90^A0N,30,0^FDa;b^FS", "^CT|", "~JA", "^XZ"));
+    expect(out.length).toBe(zpl.length);
+  });
+
+  it("keeps astral characters, a rejected remap, the tilde form and data delimiters intact", () => {
+    const emoji = j("^XA", "^FO1,2^FDa\u{1F600}b^FS", "^CC!", "!FO3,4!FDc!FS", "!XZ");
+    expect(canonicalPrefixes(emoji)).toBe(j("^XA", "^FO1,2^FDa\u{1F600}b^FS", "^CC!", "^FO3,4^FDc^FS", "^XZ"));
+    expect(canonicalPrefixes(emoji).length).toBe(emoji.length);
+    const rejected = j("^XA", "^CC,", "^FO1,2^FDa^FS", "^XZ");
+    expect(canonicalPrefixes(rejected)).toBe(rejected);
+    expect(canonicalPrefixes(j("^XA", "~CC!", "!FO1,2!FDa!FS", "!XZ"))).toBe(j("^XA", "~CC!", "^FO1,2^FDa^FS", "^XZ"));
+    expect(canonicalPrefixes(j("^XA", "^CD;", "^FO1;2^FDa;b^FS", "~DYR:X;B;PNG;3;;a;b", "^GFA;8;8;1;FF;0^FS", "^XZ"))).toBe(j("^XA", "^CD;", "^FO1,2^FDa;b^FS", "~DYR:X;B;PNG;3;;a;b", "^GFA;8;8;1;FF;0^FS", "^XZ"));
+  });
+
+  it("leaves a text without remaps alone and applies a remap only from where it lands", () => {
+    const plain = j("^XA", "^FO1,2^FDx,y^FS", "^XZ");
+    expect(canonicalPrefixes(plain)).toBe(plain);
+    const mid = j("^XA", "^FO1,2^FDa^FS", "^CC!", "!FO3,4!FDb!FS", "!XZ");
+    expect(canonicalPrefixes(mid)).toBe(j("^XA", "^FO1,2^FDa^FS", "^CC!", "^FO3,4^FDb^FS", "^XZ"));
+  });
+});

--- a/packages/core/src/lib/zplCanonicalPrefixes.ts
+++ b/packages/core/src/lib/zplCanonicalPrefixes.ts
@@ -1,0 +1,22 @@
+import { applyPrefixRemap, PAYLOAD_CMDS, tokenize, type TokenizerChars } from "./zplParser/helpers";
+
+/** Image and font payloads carry any byte, hex or binary, so their lines stay as typed. */
+const BYTE_PAYLOAD_CMDS = new Set(["GF", "DY"]);
+
+/** The same bytes with ^CC/^CT/^CD undone: every live prefix back to ^ or ~ and every
+ *  parameter delimiter to a comma, data left alone, so texts compare across a remap.
+ *  Length-preserving in UTF-16 units, the offsets every span is measured in. */
+export function canonicalPrefixes(zpl: string): string {
+  const st: TokenizerChars = { caretChar: "^", tildeChar: "~", delimiterChar: "," };
+  let out: string[] | undefined;
+  for (const t of tokenize(zpl, st)) {
+    if (out) {
+      out[t.start] = zpl[t.start] === st.caretChar ? "^" : "~";
+      if (st.delimiterChar !== "," && !PAYLOAD_CMDS.has(t.cmd) && !BYTE_PAYLOAD_CMDS.has(t.cmd)) {
+        for (let i = t.start + 3; i < t.end; i++) if (zpl[i] === st.delimiterChar) out[i] = ",";
+      }
+    }
+    if (applyPrefixRemap(st, t.cmd, t.rest[0])) out ??= zpl.split("");
+  }
+  return out ? out.join("") : zpl;
+}

--- a/packages/core/src/lib/zplGenerator.ts
+++ b/packages/core/src/lib/zplGenerator.ts
@@ -24,7 +24,8 @@ import type { ClockOffset, CustomFontMapping, JmDensity, LabelConfig, PageLabel 
 import type { ZplEmitContext } from '../types/ZplEmit';
 import type { Variable } from '../types/Variable';
 import { exportableLeaves, isGroup, pageLabelConfig, type LabelObject, type LeafObject, type Page } from '../types/Group';
-import { isOverlayConsistent, MIN_JM_SPAN, type FormatHead, type JmSpan } from './zplOverlay/overlay';
+import { isOverlayConsistent, MIN_JM_SPAN, type FormatHead, type JmSpan, type OverlayFrame } from './zplOverlay/overlay';
+import type { SourceSpan } from './zplParser/types';
 import { reconstructBlockHead } from './zplHeadScan';
 import { objectBoundsDots, qrPrintsAsGraphic, type ObjectBoundsCtx } from './objectBounds';
 import { formatFontDownloadFromPath } from './customFonts';
@@ -221,15 +222,17 @@ export interface EmitSpan {
   end: number;
 }
 
-/** The export text plus one span per emitted leaf, from the same emit walk (never a
- *  re-parse). Ascending, non-overlapping; hidden/excluded/dropped leaves have none. */
+/** The export text plus one span per emitted leaf and one block range per page, from
+ *  the same emit walk (never a re-parse). Spans are ascending and non-overlapping;
+ *  hidden/excluded/dropped leaves have none. */
 export function generateMultiPageZplWithMap(
   label: LabelConfig,
   pages: Page[],
   variables: readonly Variable[] = [],
-): { text: string; spans: EmitSpan[] } {
+): { text: string; spans: EmitSpan[]; blocks: SourceSpan[] } {
   let out = '';
   const spans: EmitSpan[] = [];
+  const blocks: SourceSpan[] = [];
   // ^JM persists on the wire, so a block only declares a density the preceding
   // blocks didn't set. `undefined` means nothing declared one yet, so a block
   // inheriting its ^JM from outside this export gets the declaration back.
@@ -272,6 +275,7 @@ export function generateMultiPageZplWithMap(
     if (out.length > 0 && !out.endsWith('\n')) out += '\n';
     const base = out.length;
     out += block;
+    blocks.push({ start: base, end: out.length });
     for (const s of emitted.spans) {
       // ^JM is legal before the first ^FS, so a recorded splice can sit INSIDE
       // a field span: such an edit grows the span; one before it shifts it.
@@ -293,7 +297,7 @@ export function generateMultiPageZplWithMap(
       });
     }
   });
-  return { text: out, spans };
+  return { text: out, spans, blocks };
 }
 
 
@@ -500,14 +504,9 @@ function emitPageBlock(
     return generateZplBlock(label, page.objects, variables);
   }
 
-  const fx = overlay.frame?.homeX ?? 0;
-  const fy = overlay.frame?.homeY ?? 0;
-  const ft = overlay.frame?.top ?? 0;
-  // Regenerated objects must be home-relative so they compose with the raw
-  // ^LH/^LT that still execute on replay (no double-shift). One shared emit
-  // context so a picked ^FE/^FC covers dirty and new fields alike.
-  const dirtyShifted = shiftObjectsByHome(dirtyLeaves, fx, fy, ft, label);
-  const newShifted = shiftObjectsByHome(newLeaves, fx, fy, ft, label);
+  // One shared emit context so a picked ^FE/^FC covers dirty and new fields alike.
+  const dirtyShifted = shiftIntoFrame(dirtyLeaves, overlay.frame, label);
+  const newShifted = shiftIntoFrame(newLeaves, overlay.frame, label);
   const { headerLines, emitCtx } = planTemplateHeader(
     [...dirtyShifted, ...newShifted],
     label,
@@ -703,6 +702,11 @@ export function generateBatchZpl(
 // (the plain check holds); rotated text ^FT uses a baseline anchor, where the
 // top-left check is only approximate (a pre-existing edge, untouched here).
 
+/** Home-relative to a parsed ^LH/^LT frame, not the label's own home/top (see OverlayFrame). */
+export function shiftIntoFrame(objects: LabelObject[], frame: OverlayFrame | undefined, label: PageLabel): LabelObject[] {
+  return frame ? shiftObjectsByHome(objects, frame.homeX, frame.homeY, frame.top, label) : objects;
+}
+
 /** Subtract label home/top from each object so emit matches the editor, the
  *  inverse of the parser folding ^LH/^LT into absolute coords. Leaves whose
  *  emitted origin goes negative are dropped (Zebra rejects negative ^FO/^FT and
@@ -767,15 +771,10 @@ export function planFieldEmission(
 
   const { headerLines, emitCtx } = planTemplateHeader(shifted, label, variables, bareFnSlots);
 
-  // Groups are structural; includeInExport=false cascades to the subtree.
-  // Byte-identical round-trip lives in the overlay path (emitOverlayPage); this
-  // model generator always regenerates.
-  const emitLeaf = (obj: LabelObject): EmittedBody[] => {
-    if (obj.includeInExport === false) return [];
-    if (isGroup(obj)) return obj.children.flatMap(emitLeaf);
-    return [{ objectId: obj.id, text: emitFieldBody(obj, emitCtx) }];
+  return {
+    headerLines,
+    bodies: exportableLeaves(shifted).map((o) => ({ objectId: o.id, text: emitFieldBody(o, emitCtx) })),
   };
-  return { headerLines, bodies: shifted.flatMap(emitLeaf) };
 }
 
 /** One leaf's emitted field bytes, id-attributed for the span map. */

--- a/packages/core/src/lib/zplHeadScan.ts
+++ b/packages/core/src/lib/zplHeadScan.ts
@@ -1,5 +1,5 @@
 import { jmDensityOf, type JmDensity } from "../types/LabelConfig";
-import { acceptsPrefixRemap, tokenize } from "./zplParser/helpers";
+import { applyPrefixRemap, tokenize } from "./zplParser/helpers";
 import { MIN_JM_SPAN, type FormatHead, type JmSpan } from "./zplOverlay/overlay";
 
 interface HeadToken {
@@ -24,15 +24,11 @@ export interface PrefixState {
   delimiterChar: string;
 }
 
-/** Tokenize from `fromOffset` with the live caret/delimiter per token, applying
- *  ^CC/^CT/^CD via the handlers' own acceptance so scans and the parser never
- *  diverge on remaps. `st` is mutated in place so a caller can thread it onward. */
+/** Tokenize from `fromOffset` with the live caret/delimiter per token; `st` is mutated
+ *  in place so a caller can thread it onward across blocks. */
 function* headTokens(zpl: string, fromOffset: number, st: PrefixState): Generator<HeadToken> {
   for (const t of tokenize(zpl.slice(fromOffset), st)) {
-    const arg = t.rest[0];
-    if (t.cmd === "CC") { if (acceptsPrefixRemap(arg, st.tildeChar, st.delimiterChar)) st.caretChar = arg; continue; }
-    if (t.cmd === "CT") { if (acceptsPrefixRemap(arg, st.caretChar, st.delimiterChar)) st.tildeChar = arg; continue; }
-    if (t.cmd === "CD") { if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delimiterChar = arg; continue; }
+    if (applyPrefixRemap(st, t.cmd, t.rest[0])) continue;
     const start = fromOffset + t.start;
     yield { cmd: t.cmd, rest: t.rest, start, isCaret: zpl[start] === st.caretChar, caret: st.caretChar, delim: st.delimiterChar };
   }

--- a/packages/core/src/lib/zplImportService.test.ts
+++ b/packages/core/src/lib/zplImportService.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { importZplText } from "./zplImportService";
+import { generateMultiPageZPL } from "./zplGenerator";
+
+describe("geometry sidecar on later blocks", () => {
+  it("is consumed on every block, so a multi-page export regenerates byte-stable", () => {
+    const label = { widthMm: 70, heightMm: 40, dpmm: 8 };
+    const leaf = (id: string) => ({ id, type: "text", x: 20, y: 35, rotation: 0, props: { content: id, fontHeight: 30, fontWidth: 0, rotation: "N" } }) as never;
+    const src = generateMultiPageZPL(label, [{ objects: [leaf("a")] }, { objects: [leaf("b")] }]);
+    const imported = importZplText(src, label.dpmm);
+    expect(imported.pages.map((p) => p.objects.map((o) => o.comment))).toEqual([[undefined], [undefined]]);
+    expect(generateMultiPageZPL(label, imported.pages.map((p) => ({ ...p, overlay: undefined })), imported.variables)).toBe(src);
+  });
+});
+

--- a/packages/core/src/lib/zplImportService.ts
+++ b/packages/core/src/lib/zplImportService.ts
@@ -1,3 +1,4 @@
+import type { PageSource } from "./zplParser/types";
 import { parseZPL, type ImportFinding, type ImportReport, type UnbalancedFormat } from "./zplParser";
 import { replayRiskFindings, dedupCommandsByKind } from "./importReport";
 import { dropPageOverlays } from "./pageOverlay";
@@ -22,6 +23,8 @@ export interface ZplImportResult {
    *  reconfigure the user's printer. */
   printerProfile: Partial<PrinterProfile>;
   pages: Page[];
+  /** Per page of `pages` (not the setup-routed list). */
+  pageSources: PageSource[];
   variables: Variable[];
   report: ImportReport;
   /** True when ^XA blocks diverge in ^PW/^LL or ^JM density, which the
@@ -39,6 +42,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
   const r = parseZPL(zpl, dpmm, { captureOverlay: true });
 
   const pages: Page[] = [];
+  const pageSources: PageSource[] = [];
   const findings: ImportFinding[] = [];
   // Variables are document-level; pages merge by source fnNumber only when
   // the ^FD defaults agree (^FN is scoped per ^XA format, so a shared slot
@@ -119,10 +123,9 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
     // so they aren't silently dropped (no overlay: the wrapper-less source has
     // nothing to replay byte-for-byte, and re-export adds the ^XA/^XZ wrapper).
     const jmDensity = page.labelConfig.jmDensity;
-    if (!page.bare) {
-      pages.push({ objects: page.objects, overlay: page.overlay, jmDensity });
-    } else if (page.objects.length > 0) {
-      pages.push({ objects: page.objects, jmDensity });
+    if (!page.bare || page.objects.length > 0) {
+      pages.push(page.bare ? { objects: page.objects, jmDensity } : { objects: page.objects, overlay: page.overlay, jmDensity });
+      pageSources.push({ span: page.span, objectSpans: page.objectSpans, objectFrames: page.objectFrames });
     }
     for (const f of page.findings) {
       // A bare page replays nothing, so its lossyEdit caveat is moot.
@@ -258,6 +261,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
     labelConfig,
     printerProfile,
     pages,
+    pageSources,
     variables,
     report,
     mixedPageGeometry: r.mixedPageGeometry || jmDiverges,

--- a/packages/core/src/lib/zplParser.ts
+++ b/packages/core/src/lib/zplParser.ts
@@ -21,7 +21,7 @@ import { createLabelConfigHandlers } from "./zplParser/handlers/labelConfig";
 import { createSetupScriptHandlers } from "./zplParser/handlers/setupScript";
 import { createUnitsHandler } from "./zplParser/handlers/units";
 import { createUnsupportedHandlers } from "./zplParser/handlers/unsupported";
-import { buildBlockOverlay, type BlockOverlay, type FormatHead, type JmSpan, type LinkedSpan } from "./zplOverlay/overlay";
+import { buildBlockOverlay, type BlockOverlay, type FormatHead, type OverlayFrame, type JmSpan, type LinkedSpan } from "./zplOverlay/overlay";
 import type {
   Handler,
   ImportFinding,
@@ -214,20 +214,18 @@ export function parseZPL(
   const resetComment: Handler = (_, rest) => {
     s.comment.pending = rest.trim() || undefined;
   };
-  // Our geometry sidecar, consumed (not shown as an object comment) only while
-  // no design object was seen, so a body ^FX can't rewrite the label settings.
-  // Deliberately document-wide, not page-0: a verbatim settings-only block
-  // precedes the regenerated design block (and its sidecar) on re-export.
-  // Holder object so the closure write survives TS flow narrowing.
-  const labelMeta: { value: LabelMeta | null } = { value: null };
+  // Our geometry sidecar heads every exported block, so every block consumes one;
+  // the settings are document-level, so the first wins and later ones are dropped,
+  // never shown as comments. A body ^FX cannot reach this: the block has no object yet.
+  const labelMeta: { value: LabelMeta | null } = { value: null }; // holder: the closure write survives TS narrowing
   // Multi-line ^FX before a field accumulate; XA/XZ reset at label boundaries.
   const appendComment: Handler = (_, rest) => {
     const next = rest.trim();
     if (!next) return;
-    if (!labelMeta.value && objects.length === 0) {
+    if (objects.length === pg.obj) {
       const meta = parseLabelMetaComment(next);
       if (meta) {
-        labelMeta.value = meta;
+        labelMeta.value ??= meta;
         return;
       }
     }
@@ -281,9 +279,11 @@ export function parseZPL(
 
   const overlaySpans: LinkedSpan[] = [];
   const linkedIds = new Set<string>();
+  const linkedFrames = new Map<string, OverlayFrame>();
   const linkObject = (start: number, end: number, objectId: string) => {
     overlaySpans.push({ start, end, link: { kind: "object", objectId } });
     linkedIds.add(objectId);
+    if (pg.ovFrame) linkedFrames.set(objectId, pg.ovFrame);
   };
 
   // Page bookkeeping: one page per ^XA block, closed at the NEXT ^XA (so the
@@ -319,6 +319,8 @@ export function parseZPL(
     // trips the all-linked gate and the block regenerates.
     ovStart: null as number | null,
     ovBase: 0,
+    // The ^LH/^LT the opener folded into the field's coordinates.
+    ovFrame: null as OverlayFrame | null,
     // Start of a contiguous ^FX run immediately before a field, so the
     // field's span owns its comment bytes.
     commentStart: null as number | null,
@@ -439,6 +441,7 @@ export function parseZPL(
       findings,
       labelSize: { widthMm: w, heightMm: h },
       labelConfig: { ...labelConfig },
+      span: { start: pg.start, end },
     };
     if (pageOverlay) page.overlay = pageOverlay;
     if (!s.sawXa) page.bare = true;
@@ -451,6 +454,11 @@ export function parseZPL(
       );
       if (spanEntries.length > 0) {
         page.objectSpans = new Map(spanEntries);
+        const frames = spanEntries.flatMap(([id]): [string, OverlayFrame][] => {
+          const frame = linkedFrames.get(id);
+          return frame ? [[id, frame]] : [];
+        });
+        if (frames.length > 0) page.objectFrames = new Map(frames);
       }
     }
     pages.push(page);
@@ -623,6 +631,7 @@ export function parseZPL(
         }
         if (cmd === "FO" || cmd === "FT") {
           pg.ovStart = pg.commentStart ?? start;
+          pg.ovFrame = s.label.lhX !== 0 || s.label.lhY !== 0 || s.label.ltY !== 0 ? { homeX: s.label.lhX, homeY: s.label.lhY, top: s.label.ltY } : null;
           pg.ovBase = objects.length;
           pg.commentStart = null;
           pg.spanHasBy = false;

--- a/packages/core/src/lib/zplParser/helpers.ts
+++ b/packages/core/src/lib/zplParser/helpers.ts
@@ -33,7 +33,7 @@ export function firstChar(rest: string): string {
 
 /** Accepts a ^CC/^CT/^CD remap char only if it's printable, non-DEL, and
  *  distinct from both other role chars (a collision would collapse a
- *  prefix/delimiter boundary). Shared with the ^JM head scan so both agree on effective remaps. */
+ *  prefix/delimiter boundary). */
 export function acceptsPrefixRemap(
   char: string | undefined,
   roleA: string,
@@ -48,6 +48,18 @@ export interface TokenizerChars {
   caretChar: string;
   tildeChar: string;
   delimiterChar: string;
+}
+
+/** Applies a ^CC/^CT/^CD to the live chars, so every scan remaps as the parser does; true for any of the three, accepted or not. */
+export function applyPrefixRemap(st: TokenizerChars, cmd: string, arg: string | undefined): boolean {
+  if (cmd === "CC") {
+    if (acceptsPrefixRemap(arg, st.tildeChar, st.delimiterChar)) st.caretChar = arg;
+  } else if (cmd === "CT") {
+    if (acceptsPrefixRemap(arg, st.caretChar, st.delimiterChar)) st.tildeChar = arg;
+  } else if (cmd === "CD") {
+    if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delimiterChar = arg;
+  } else return false;
+  return true;
 }
 
 /** Raw-binary payload commands: header slots before data, format/count slot
@@ -78,10 +90,7 @@ export function unsafeRawFieldSpans(text: string): UnsafeRawFieldSpan[] {
   const st: TokenizerChars = { caretChar: "^", tildeChar: "~", delimiterChar: "," };
   const spans: UnsafeRawFieldSpan[] = [];
   for (const t of tokenize(text, st)) {
-    const arg = t.rest[0];
-    if (t.cmd === "CC") { if (acceptsPrefixRemap(arg, st.tildeChar, st.delimiterChar)) st.caretChar = arg; continue; }
-    if (t.cmd === "CT") { if (acceptsPrefixRemap(arg, st.caretChar, st.delimiterChar)) st.tildeChar = arg; continue; }
-    if (t.cmd === "CD") { if (acceptsPrefixRemap(arg, st.caretChar, st.tildeChar)) st.delimiterChar = arg; continue; }
+    if (applyPrefixRemap(st, t.cmd, t.rest[0])) continue;
     if (t.cmd !== "GF" && t.cmd !== "DY") continue;
     const span = binaryPayloadEnd(text, t.cmd, t.start + 3, st.delimiterChar);
     if (!span) continue;
@@ -150,7 +159,7 @@ const NAME_CHAR_RE = /[0-9A-Za-z@]/;
 
 /** Commands whose rest is a free-text payload: a tilde inside it ends the
  *  field only when it opens a real immediate command (see zplImmediate.ts). */
-const PAYLOAD_CMDS = new Set(["FD", "FV", "FX"]);
+export const PAYLOAD_CMDS = new Set(["FD", "FV", "FX"]);
 
 const LETTER_RE = /[A-Za-z]/;
 

--- a/packages/core/src/lib/zplParser/types.ts
+++ b/packages/core/src/lib/zplParser/types.ts
@@ -2,7 +2,7 @@ import type { LabelConfig } from "../../types/LabelConfig";
 import type { LabelObject } from "../../types/Group";
 import type { Variable } from "../../types/Variable";
 import type { PrinterProfile } from "../../types/PrinterProfile";
-import type { BlockOverlay } from "../zplOverlay/overlay";
+import type { BlockOverlay, OverlayFrame } from "../zplOverlay/overlay";
 
 export type ImportFindingKind =
   | "partial"
@@ -15,7 +15,7 @@ export type ImportFindingKind =
   | "fnDefaultDropped"
   | "mixedPageGeometry";
 
-/** Absolute offsets into the parsed source string. Readonly: one span object
+/** Absolute offsets into a ZPL text, parsed or generated. Readonly: one span object
  *  may back several findings of the same token, so no consumer may rebase it. */
 export interface SourceSpan {
   readonly start: number;
@@ -84,11 +84,18 @@ export interface ParsedPage {
   /** Page 0 only: stream had no ^XA wrapper (bare field paste). Re-export
    *  regenerates the wrapper, so the overlay is suppressed by the caller. */
   bare?: boolean;
+  /** This page's bytes in the source (page 0 owns any preamble). */
+  span: SourceSpan;
   /** Absolute source span per cleanly linked object; unlinked objects absent.
    *  Requires `captureOverlay` (reuses the overlay's link pass) but survives
    *  pages whose overlay the all-linked gate refuses. */
   objectSpans?: ReadonlyMap<string, SourceSpan>;
+  /** The ^LH/^LT in force where a linked object was parsed, folded into its coordinates; absent when zero. */
+  objectFrames?: ReadonlyMap<string, OverlayFrame>;
 }
+
+/** The carry reads a page's positions only, never its parse. */
+export type PageSource = Pick<ParsedPage, "span" | "objectSpans" | "objectFrames">;
 
 /** First ^XA/^XZ imbalance. `at` is the command's offset in the source
  *  string; `cmd` its text (the remapped prefix under ^CC), so diagnostics

--- a/packages/core/src/lib/zplSourceEdit.ts
+++ b/packages/core/src/lib/zplSourceEdit.ts
@@ -4,6 +4,7 @@ import type { ImportReport, UnbalancedFormat } from "./zplParser";
 import type { LabelConfig } from "../types/LabelConfig";
 import type { PrinterProfile } from "../types/PrinterProfile";
 import type { Page } from "../types/Group";
+import { carryAcrossApply } from "./sourceApplyCarry";
 import type { ColumnMapping, Variable } from "../types/Variable";
 import { diffEditorState, type EditorStateDiff } from "./editorStateDiff";
 import { remapBindingsByFn } from "./variableBinding";
@@ -73,6 +74,7 @@ export interface SourceApplyOk {
   /** The complete post-apply document state, atomically committable. */
   next: SourceDocumentState;
   report: ImportReport;
+  /** Objects the buffer parsed to; carried-over excluded subtrees are not imports. */
   objectCount: number;
   loss: EditorStateDiff;
 }
@@ -148,10 +150,19 @@ export function prepareSourceApply(input: SourceApplyInput): SourceApplyPlan {
     );
   }
 
-  const remapped = remapBindingsByFn(current.variables, current.columnMapping, imported.variables);
+  const { pages, variables } = carryAcrossApply({
+    current,
+    baseline: input.baseline,
+    text: input.text,
+    importedLabel: label,
+    imported: imported.pages,
+    importedVariables: imported.variables,
+    pageSources: imported.pageSources,
+  });
+  const remapped = remapBindingsByFn(current.variables, current.columnMapping, variables);
   const loss = diffEditorState(
     { pages: current.pages, variables: current.variables },
-    { pages: imported.pages, variables: imported.variables },
+    { pages, variables },
     remapped.lost,
   );
 
@@ -162,8 +173,8 @@ export function prepareSourceApply(input: SourceApplyInput): SourceApplyPlan {
     ok: true,
     next: {
       label,
-      pages: imported.pages.length > 0 ? imported.pages : [{ objects: [] }],
-      variables: imported.variables,
+      pages: pages.length > 0 ? pages : [{ objects: [] }],
+      variables,
       printerProfile,
       columnMapping: remapped.mapping,
     },

--- a/packages/core/src/types/Group.ts
+++ b/packages/core/src/types/Group.ts
@@ -49,18 +49,22 @@ export function* walkObjects(objects: readonly LabelObject[]): Iterable<LabelObj
   }
 }
 
-/** Leaves that actually export: an `includeInExport=false` node hides its
- *  whole subtree. Also the preflight leaf set, so checks track what prints. */
+export type ExportStep = { leaf: LeafObject } | { excluded: LabelObject };
+
+/** Render-order walk of the export cascade: the leaves that print, and the
+ *  topmost `includeInExport=false` nodes, whose subtrees are not entered. */
+export function* walkExportOrder(objects: readonly LabelObject[]): Iterable<ExportStep> {
+  for (const o of objects) {
+    if (o.includeInExport === false) yield { excluded: o };
+    else if (isGroup(o)) yield* walkExportOrder(o.children);
+    else yield { leaf: o };
+  }
+}
+
+/** The leaves that print; also the preflight leaf set, so checks track what prints. */
 export function exportableLeaves(objects: readonly LabelObject[]): LeafObject[] {
   const out: LeafObject[] = [];
-  const walk = (list: readonly LabelObject[]): void => {
-    for (const o of list) {
-      if (o.includeInExport === false) continue;
-      if (isGroup(o)) walk(o.children);
-      else out.push(o);
-    }
-  };
-  walk(objects);
+  for (const step of walkExportOrder(objects)) if ("leaf" in step) out.push(step.leaf);
   return out;
 }
 

--- a/packages/core/src/types/Variable.ts
+++ b/packages/core/src/types/Variable.ts
@@ -90,6 +90,22 @@ export function validateVariablesUnique(variables: readonly Variable[]): boolean
   return true;
 }
 
+/** Pairs variables across a reparse by ^FN slot, the only identity the wire carries. */
+export function matchVariablesByFn(
+  prev: readonly Variable[],
+  next: readonly Variable[],
+): { kept: { from: Variable; to: Variable }[]; dropped: Variable[] } {
+  const nextByFn = new Map(next.map((v) => [v.fnNumber, v]));
+  const kept: { from: Variable; to: Variable }[] = [];
+  const dropped: Variable[] = [];
+  for (const from of prev) {
+    const to = nextByFn.get(from.fnNumber);
+    if (to) kept.push({ from, to });
+    else dropped.push(from);
+  }
+  return { kept, dropped };
+}
+
 /** Append `_2`, `_3`, ... until unique. */
 export function uniqueVariableName(
   base: string,


### PR DESCRIPTION
Hidden objects, names, locks and hiding survive a source apply: the session baseline and the edited buffer are line-diffed, unchanged fields keep their model identity, excluded subtrees follow their neighbours.