### PR TITLE
feat(zpl): sidecar envelope v2 (ZPLab: prefix, w/h keys), 0.4.x envel…

### DIFF
--- a/packages/core/src/lib/qrGraphic.ts
+++ b/packages/core/src/lib/qrGraphic.ts
@@ -6,7 +6,7 @@ import { isQrByHeight } from "./qrBy";
 import { isQrEcLevel, type QrEcLevel } from "./qrFd";
 
 // ^BQ cannot rotate (firmware no-op, ZD230-verified), so a rotated QR emits as a
-// ^GFA of the exact module matrix plus a ZPLLAB sidecar for lossless reimport.
+// ^GFA of the exact module matrix plus a ZPLab sidecar for lossless reimport.
 
 export interface QrGraphicInput {
   content: string;

--- a/packages/core/src/lib/zplImportService.ts
+++ b/packages/core/src/lib/zplImportService.ts
@@ -137,7 +137,7 @@ export function importZplText(zpl: string, dpmm: number): ZplImportResult {
   // Single-label design: block 0 wins where it speaks; other persistent
   // settings fall through to the first block that sets them (driver dumps
   // carry ^PW/^LL/^MM only in the job block). The ^PQ family is block-scoped
-  // and never falls through. Fonts stay document-wide; the ZPLLAB sidecar
+  // and never falls through. Fonts stay document-wide; the ZPLab sidecar
   // (dpmm, which plain ZPL can't carry) is a page-0 preamble overriding size.
   const labelConfig: Partial<LabelConfig> = { ...r.pages[0]?.labelConfig };
   const perFormat = new Set<string>(PER_FORMAT_ZPL_FIELDS);

--- a/packages/core/src/lib/zplLabelMeta.test.ts
+++ b/packages/core/src/lib/zplLabelMeta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatLabelMetaComment, formatSidecarComment, sidecarRanges, stripSidecarComments, zplForExport } from "./zplLabelMeta";
+import { formatLabelMetaComment, formatSidecarComment, parseLabelMetaComment, sidecarRanges, stripSidecarComments, zplForExport } from "./zplLabelMeta";
 
 describe("stripSidecarComments", () => {
   it("removes the label-meta line and its line break, leaving printer bytes intact", () => {
@@ -57,5 +57,25 @@ describe("sidecarRanges", () => {
     }
     expect(kept + text.slice(at)).toBe(stripSidecarComments(text));
     expect(ranges).toHaveLength(2);
+  });
+});
+
+describe("sidecar envelope v2", () => {
+  it("writes the ZPLab prefix with mm keys and reads the 0.4.x spelling as well", () => {
+    const meta = { dpmm: 8, widthMm: 100, heightMm: 60 };
+    const line = formatLabelMetaComment(meta);
+    expect(line).toBe('^FXZPLab:{"dpmm":8,"w":100,"h":60}^FS');
+    expect(parseLabelMetaComment(line.slice(3, -3))).toEqual(meta);
+    expect(parseLabelMetaComment('ZPLLAB:{"dpmm":8,"wMm":100,"hMm":60}')).toEqual(meta);
+    expect(parseLabelMetaComment('ZPLLAB:{"dpmm":8,"w":100,"h":60}')).toEqual(meta);
+    expect(parseLabelMetaComment('ZPLab:{"dpmm":8,"wMm":100,"hMm":60}')).toEqual(meta);
+    expect(parseLabelMetaComment('ZPLab:{"dpmm":8,"w":"x","h":60}')).toBeNull();
+    expect(parseLabelMetaComment('{"dpmm":8,"w":100,"h":60}')).toBeNull();
+  });
+
+  it("strips and ranges both envelopes", () => {
+    const text = ["^XA", '^FXZPLab:{"dpmm":8,"w":70,"h":40}^FS', '^FXZPLLAB:{"qr":{"content":"A"}}^FS^FO1,1^GFA,1,1,1,00^FS', "^XZ"].join("\n");
+    expect(stripSidecarComments(text)).toBe(["^XA", "^FO1,1^GFA,1,1,1,00^FS", "^XZ"].join("\n"));
+    expect(sidecarRanges(text)).toHaveLength(2);
   });
 });

--- a/packages/core/src/lib/zplLabelMeta.ts
+++ b/packages/core/src/lib/zplLabelMeta.ts
@@ -7,7 +7,10 @@ import { isDpmm } from "../types/LabelConfig";
 import type { SourceSpan } from "./zplParser/types";
 
 /** Namespace so a foreign ^FX comment can't be mistaken for our metadata. */
-export const LABEL_META_PREFIX = "ZPLLAB:";
+const SIDECAR_PREFIX = "ZPLab:";
+/** The 0.4.x envelope, read forever. */
+const LEGACY_SIDECAR_PREFIX = "ZPLLAB:";
+const SIDECAR_PREFIXES = [SIDECAR_PREFIX, LEGACY_SIDECAR_PREFIX];
 
 const MM_MIN = 1;
 const MM_MAX = 5000;
@@ -27,14 +30,14 @@ export function labelMetaOf(label: LabelMeta): LabelMeta {
   return Object.fromEntries(LABEL_META_KEYS.map((k) => [k, label[k]])) as LabelMeta;
 }
 
-/** Shared ZPLLAB envelope (label meta, QR props). Body must be free of ^/~
+/** Shared sidecar envelope (label meta, QR props). Body must be free of ^/~
  *  or the ^FX comment terminates mid-payload. */
 export function formatSidecarComment(body: string): string {
-  return `^FX${LABEL_META_PREFIX}${body}^FS`;
+  return `^FX${SIDECAR_PREFIX}${body}^FS`;
 }
 
-/** Exactly the envelope the emitter writes; a foreign comment without the colon survives. */
-const SIDECAR_LINE_RE = /\^[Ff][Xx]ZPLLAB:[^^~]*\^[Ff][Ss](?:\r?\n)?/g;
+/** Every envelope we ever wrote; a foreign comment without the colon survives. */
+const SIDECAR_LINE_RE = new RegExp(`\\^[Ff][Xx](?:${SIDECAR_PREFIXES.join("|")})[^^~]*\\^[Ff][Ss](?:\\r?\\n)?`, "g");
 
 /** The byte ranges the export strips: each sidecar plus any line break right after it. */
 export function sidecarRanges(zpl: string): SourceSpan[] {
@@ -55,15 +58,14 @@ export function zplForExport(zpl: string, keepMetadata = false): string {
 /** Sidecar payload, or null for a foreign comment. */
 export function sidecarBody(commentBody: string): string | null {
   const trimmed = commentBody.trim();
-  return trimmed.startsWith(LABEL_META_PREFIX) ? trimmed.slice(LABEL_META_PREFIX.length) : null;
+  const prefix = SIDECAR_PREFIXES.find((p) => trimmed.startsWith(p));
+  return prefix === undefined ? null : trimmed.slice(prefix.length);
 }
 
 /** The leading sidecar line. Numbers only, no `^`/`~`, so it is a valid ^FX
  *  comment terminated by ^FS (verified against the ZPL spec and Labelary). */
 export function formatLabelMetaComment(meta: LabelMeta): string {
-  return formatSidecarComment(
-    JSON.stringify({ dpmm: meta.dpmm, wMm: meta.widthMm, hMm: meta.heightMm }),
-  );
+  return formatSidecarComment(JSON.stringify({ dpmm: meta.dpmm, w: meta.widthMm, h: meta.heightMm }));
 }
 
 /** Parse a ^FX comment body (text after `^FX`) into validated label meta, or
@@ -79,10 +81,12 @@ export function parseLabelMetaComment(commentBody: string): LabelMeta | null {
     return null;
   }
   if (!parsed || typeof parsed !== "object") return null;
-  const { dpmm, wMm, hMm } = parsed as Record<string, unknown>;
+  const { dpmm, w, h, wMm, hMm } = parsed as Record<string, unknown>;
   // Emit assumes dpmm ∈ DPMM_VALUES (the only densities the UI produces); keep
   // emit and this guard on the same source of truth.
   if (typeof dpmm !== "number" || !isDpmm(dpmm)) return null;
-  if (!isPlausibleLabelMm(wMm) || !isPlausibleLabelMm(hMm)) return null;
-  return { dpmm, widthMm: wMm, heightMm: hMm };
+  const widthMm = w ?? wMm;
+  const heightMm = h ?? hMm;
+  if (!isPlausibleLabelMm(widthMm) || !isPlausibleLabelMm(heightMm)) return null;
+  return { dpmm, widthMm, heightMm };
 }

--- a/packages/core/src/lib/zplSourceEdit.test.ts
+++ b/packages/core/src/lib/zplSourceEdit.test.ts
@@ -73,7 +73,7 @@ describe("the edit gate", () => {
   });
 });
 
-describe("foreign text without the ZPLLAB sidecar", () => {
+describe("foreign text without the ZPLab sidecar", () => {
   it("inherits the open label's dpmm; a sidecar wins over it", () => {
     const foreign = "^XA^FO10,10^A0N,30,30^FDX^FS^XZ";
     const at12 = prepareSourceApply({
@@ -148,7 +148,7 @@ describe("deleting a command from the buffer clears its field", () => {
     const baseline = generateMultiPageZPL(label, pages, []);
     const without = baseline
       .split("\n")
-      .filter((l) => !l.includes("ZPLLAB") && !/^\^PW|^\^LL/.test(l))
+      .filter((l) => !l.includes("^FXZPLab:") && !/^\^PW|^\^LL/.test(l))
       .join("\n");
     const plan = prepareSourceApply({ text: without, baseline, current: current() });
     expect(plan.ok).toBe(true);

--- a/packages/core/src/lib/zplSourceEdit.ts
+++ b/packages/core/src/lib/zplSourceEdit.ts
@@ -103,7 +103,7 @@ export function prepareSourceApply(input: SourceApplyInput): SourceApplyPlan {
   const gate = sourceEditGate(input.text);
   if (!gate.ok) return gate;
 
-  // Same dpmm path as the import modal: a ZPLLAB ^FX sidecar in the text wins,
+  // Same dpmm path as the import modal: a ZPLab ^FX sidecar in the text wins,
   // foreign text inherits the open label's density.
   const imported = importZplText(input.text, current.label.dpmm);
   // The parser is the only ^CC-aware lexer, so the balance verdict is its: an

--- a/packages/mcp-server/src/boundaryWritePaths.test.ts
+++ b/packages/mcp-server/src/boundaryWritePaths.test.ts
@@ -280,11 +280,11 @@ describe("export_zpl metadata", () => {
 
   it("returns plain printer bytes by default", () => {
     const zpl = ok(exportZpl(design)).zpl;
-    expect(zpl).not.toContain("ZPLLAB");
+    expect(zpl).not.toContain("ZPLab:");
     expect(zpl).toContain("^FDhi^FS");
   });
 
-  it("keeps the ZPLLAB metadata when asked for a re-importable export", () => {
-    expect(ok(exportZpl(design, { metadata: true })).zpl).toContain("^FXZPLLAB:");
+  it("keeps the ZPLab metadata when asked for a re-importable export", () => {
+    expect(ok(exportZpl(design, { metadata: true })).zpl).toContain("^FXZPLab:");
   });
 });

--- a/src/components/Output/ZPLOutput.sourceEdit.test.tsx
+++ b/src/components/Output/ZPLOutput.sourceEdit.test.tsx
@@ -503,9 +503,9 @@ describe("the header copy button and the sidecar setting", () => {
   it("copies plain ZPL by default while the editor text keeps its sidecars", () => {
     useLabelStore.setState({ keepExportMetadata: false });
     render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
-    expect(editor().value).toContain("^FXZPLLAB:");
+    expect(editor().value).toContain("^FXZPLab:");
     fireEvent.click(screen.getByRole("button", { name: t().output.copy }));
-    expect(copiedTexts.at(-1)).not.toContain("ZPLLAB");
+    expect(copiedTexts.at(-1)).not.toContain("ZPLab:");
     expect(copiedTexts.at(-1)).toContain("^FDhello^FS");
   });
 
@@ -513,6 +513,6 @@ describe("the header copy button and the sidecar setting", () => {
     useLabelStore.setState({ keepExportMetadata: true });
     render(<ZPLOutput onResizeMouseDown={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: t().output.copy }));
-    expect(copiedTexts.at(-1)).toContain("^FXZPLLAB:");
+    expect(copiedTexts.at(-1)).toContain("^FXZPLab:");
   });
 });

--- a/src/components/Output/ZplCodeMirror.test.tsx
+++ b/src/components/Output/ZplCodeMirror.test.tsx
@@ -359,7 +359,8 @@ describe("ZplCodeMirror payload folding", () => {
 });
 
 describe("ZplCodeMirror sidecar lines", () => {
-  const sidecar = '^FXZPLLAB:{"dpmm":8,"wMm":70,"hMm":40}^FS';
+  // One envelope of each generation: the pane must hide what any release wrote.
+  const sidecar = '^FXZPLab:{"dpmm":8,"w":70,"h":40}^FS';
   const qr = '^FXZPLLAB:{"qr":{"content":"A","mag":4}}^FS^FO10,10^GFA,1,1,1,00^FS';
   const value = ["^XA", sidecar, "^PW560", qr, "^FO10,10^A0N,30,30^FDHi^FS", "^XZ"].join("\n");
   const mount = (doc = value, hide = true, onChange: (v: string) => void = vi.fn()) => {
@@ -375,7 +376,7 @@ describe("ZplCodeMirror sidecar lines", () => {
     const changes: string[] = [];
     const { container, view } = mount(value, true, (v) => changes.push(v));
     expect(view.state.doc.toString()).toBe(value);
-    expect(container.textContent).not.toContain("ZPLLAB");
+    expect(container.textContent).not.toMatch(/ZPL(ab|LAB):/);
     expect(container.querySelectorAll(".cm-line").length).toBe(5);
     const copy = view.state.facet(EditorView.clipboardOutputFilter);
     expect(copy.reduce((t, f) => f(t, view.state), value)).toBe(stripSidecarComments(value));
@@ -407,7 +408,7 @@ describe("ZplCodeMirror sidecar lines", () => {
       if (inside(at)) continue;
       const { container, view } = mount();
       view.dispatch({ changes: { from: at, insert: "x" }, userEvent: "input.type" });
-      expect(container.textContent, `insert at ${at}`).not.toContain("ZPLLAB");
+      expect(container.textContent, `insert at ${at}`).not.toMatch(/ZPL(ab|LAB):/);
       cleanup();
     }
     const { container, view } = mount();
@@ -423,9 +424,9 @@ describe("ZplCodeMirror sidecar lines", () => {
 
   it("shows them when metadata is kept and after the setting flips back", () => {
     const { container, rerender } = mount();
-    expect(container.textContent).not.toContain("ZPLLAB");
+    expect(container.textContent).not.toMatch(/ZPL(ab|LAB):/);
     rerender(<ZplCodeMirror value={value} onChange={vi.fn()} ariaLabel="zpl" placeholderText="ph" hideSidecars={false} />);
-    expect(container.textContent).toContain("ZPLLAB");
+    expect(container.textContent).toMatch(/ZPL(ab|LAB):/);
     expect(container.querySelectorAll(".cm-line").length).toBe(6);
   });
 

--- a/src/hooks/useZplImportExport.test.tsx
+++ b/src/hooks/useZplImportExport.test.tsx
@@ -37,13 +37,13 @@ describe("direct-print ZPL and the sidecar setting", () => {
   it("hands the printer plain ZPL by default", () => {
     const { result } = renderHook(() => useZplImportExport());
     const zpl = result.current.currentZpl();
-    expect(zpl).not.toContain("ZPLLAB");
+    expect(zpl).not.toContain("ZPLab:");
     expect(zpl).toContain("^GFA");
   });
 
   it("keeps the metadata once the user opted in", () => {
     useLabelStore.setState({ keepExportMetadata: true });
     const { result } = renderHook(() => useZplImportExport());
-    expect(result.current.currentZpl()).toContain("^FXZPLLAB:");
+    expect(result.current.currentZpl()).toContain("^FXZPLab:");
   });
 });

--- a/src/hooks/useZplOutputView.test.tsx
+++ b/src/hooks/useZplOutputView.test.tsx
@@ -95,6 +95,6 @@ describe("useZplOutputView and the export sidecar setting", () => {
   it("keeps the sidecars in the source pane even when exports drop them", () => {
     seed([{ objects: [text("a", "Alpha")] }], { keepExportMetadata: false });
     const { result } = renderHook(() => useZplOutputView(true));
-    expect(result.current.zpl).toContain("^FXZPLLAB:");
+    expect(result.current.zpl).toContain("^FXZPLab:");
   });
 });

--- a/src/lib/exportZpl.test.ts
+++ b/src/lib/exportZpl.test.ts
@@ -21,9 +21,9 @@ beforeEach(() => useLabelStore.setState({ keepExportMetadata: false }));
 describe("finishZplExport", () => {
   it("strips the label-meta and QR sidecars by default, keeping the printed fields", () => {
     const full = generateMultiPageZPL(label, pages);
-    expect(full).toContain("^FXZPLLAB:");
+    expect(full).toContain("^FXZPLab:");
     const out = finishZplExport(full);
-    expect(out).not.toContain("ZPLLAB");
+    expect(out).not.toContain("ZPLab:");
     expect(out).toContain("^GFA");
     expect(out).toContain("^PW560");
   });

--- a/src/lib/printPreview.test.ts
+++ b/src/lib/printPreview.test.ts
@@ -52,7 +52,7 @@ describe("buildPreviewZpl blank-field samples", () => {
 describe("buildPreviewZpl metadata", () => {
   it("never carries ZPLab metadata: a preview is rendered, not re-imported", () => {
     const zpl = buildPreviewZpl(label, blankBarcode(), [], null);
-    expect(zpl).not.toContain("ZPLLAB");
+    expect(zpl).not.toContain("ZPLab:");
     expect(zpl).toContain("^PW800");
   });
 });

--- a/src/lib/zplForSelection.test.ts
+++ b/src/lib/zplForSelection.test.ts
@@ -31,7 +31,7 @@ describe("zplForSelection", () => {
     expect(zpl).not.toContain("^XA");
     expect(zpl).not.toContain("^XZ");
     expect(zpl).not.toContain("^PW");
-    expect(zpl).not.toContain("ZPLLAB");
+    expect(zpl).not.toContain("ZPLab:");
     expect(zpl.startsWith("^FO10,10")).toBe(true);
   });
 

--- a/src/lib/zplGenerator.test.ts
+++ b/src/lib/zplGenerator.test.ts
@@ -945,7 +945,7 @@ describe('generateZPL — ^TB text block', () => {
     const zpl = generateZPL(BASE_LABEL, [single, template], vars);
     expect(zpl).toMatchInlineSnapshot(`
       "^XA
-      ^FXZPLLAB:{"dpmm":8,"wMm":100,"hMm":50}^FS
+      ^FXZPLab:{"dpmm":8,"w":100,"h":50}^FS
       ^PW800
       ^LL400
       ^CI28

--- a/src/lib/zplLabelMeta.test.ts
+++ b/src/lib/zplLabelMeta.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect } from "vitest";
-import {
-  formatLabelMetaComment,
-  parseLabelMetaComment,
-  LABEL_META_PREFIX,
-} from "@zplab/core/lib/zplLabelMeta";
+import { formatLabelMetaComment, parseLabelMetaComment } from "@zplab/core/lib/zplLabelMeta";
 
 describe("zplLabelMeta", () => {
   it("round-trips dpmm/width/height through format → parse", () => {
     const meta = { dpmm: 12, widthMm: 57, heightMm: 32 };
     const line = formatLabelMetaComment(meta);
-    expect(line).toBe(`^FX${LABEL_META_PREFIX}{"dpmm":12,"wMm":57,"hMm":32}^FS`);
+    expect(line).toBe(`^FXZPLab:{"dpmm":12,"w":57,"h":32}^FS`);
     // parse consumes the comment BODY (text after ^FX), before the ^FS.
     expect(parseLabelMetaComment(line.slice(3, line.length - 3))).toEqual(meta);
   });
@@ -25,30 +21,30 @@ describe("zplLabelMeta", () => {
   });
 
   it("returns null for malformed JSON after the prefix", () => {
-    expect(parseLabelMetaComment(`${LABEL_META_PREFIX}{not json`)).toBeNull();
+    expect(parseLabelMetaComment(`ZPLab:{not json`)).toBeNull();
   });
 
   it("rejects an out-of-set dpmm", () => {
     expect(
-      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":10,"wMm":100,"hMm":60}`),
+      parseLabelMetaComment(`ZPLab:{"dpmm":10,"wMm":100,"hMm":60}`),
     ).toBeNull();
   });
 
   it("rejects out-of-range or non-numeric mm", () => {
     expect(
-      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":0,"hMm":60}`),
+      parseLabelMetaComment(`ZPLab:{"dpmm":8,"wMm":0,"hMm":60}`),
     ).toBeNull();
     expect(
-      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":100,"hMm":99999}`),
+      parseLabelMetaComment(`ZPLab:{"dpmm":8,"wMm":100,"hMm":99999}`),
     ).toBeNull();
     expect(
-      parseLabelMetaComment(`${LABEL_META_PREFIX}{"dpmm":8,"wMm":"x","hMm":60}`),
+      parseLabelMetaComment(`ZPLab:{"dpmm":8,"wMm":"x","hMm":60}`),
     ).toBeNull();
   });
 
   it("tolerates surrounding whitespace on the body", () => {
     expect(
-      parseLabelMetaComment(`  ${LABEL_META_PREFIX}{"dpmm":8,"wMm":100,"hMm":60}  `),
+      parseLabelMetaComment(`  ZPLab:{"dpmm":8,"wMm":100,"hMm":60}  `),
     ).toEqual({ dpmm: 8, widthMm: 100, heightMm: 60 });
   });
 });

--- a/src/registry/registry.test.ts
+++ b/src/registry/registry.test.ts
@@ -324,7 +324,7 @@ describe('barcode rotation in ZPL output', () => {
   it('qrcode rotated emits sidecar + ^GFA instead of ^BQ', () => {
     const def = defined(getEntry('qrcode'));
     const zpl = def.toZPL(makeObj('qrcode', { content: 'X', magnification: 4, errorCorrection: 'Q', model: 2, rotation: 'R' }));
-    expect(zpl).toContain('^FXZPLLAB:');
+    expect(zpl).toContain('^FXZPLab:');
     expect(zpl).toContain('^GFA,');
     expect(zpl).not.toContain('^BQ');
   });

--- a/src/test/zplRoundtrip.test.ts
+++ b/src/test/zplRoundtrip.test.ts
@@ -725,7 +725,7 @@ describe('round-trip — label geometry sidecar', () => {
   it('recovers dpmm + exact mm even when re-parsed at a different dpmm', () => {
     const label: LabelConfig = { widthMm: 57, heightMm: 32, dpmm: 12 };
     const zpl = generateZPL(label, []);
-    expect(zpl).toContain('^FXZPLLAB:');
+    expect(zpl).toContain('^FXZPLab:');
     // Re-parse at the wrong external dpmm: ^PW/^LL alone would give 85.5×48mm
     // at 8dpmm, but the sidecar restores the authored geometry exactly.
     const parsed = parseSingle(zpl, 8);


### PR DESCRIPTION
…ope still read